### PR TITLE
Add transport controls with NowPlaying UI

### DIFF
--- a/frontend/bindings/github.com/willfish/forte/playerservice.ts
+++ b/frontend/bindings/github.com/willfish/forte/playerservice.ts
@@ -11,6 +11,20 @@
 import { Call as $Call, CancellablePromise as $CancellablePromise, Create as $Create } from "@wailsio/runtime";
 
 /**
+ * Duration returns the duration of the current track in seconds.
+ */
+export function Duration(): $CancellablePromise<number> {
+    return $Call.ByID(1985222848);
+}
+
+/**
+ * Pause pauses the current playback.
+ */
+export function Pause(): $CancellablePromise<void> {
+    return $Call.ByID(191671602);
+}
+
+/**
  * Play starts playback of the audio file at the given path.
  */
 export function Play(path: string): $CancellablePromise<void> {
@@ -18,10 +32,38 @@ export function Play(path: string): $CancellablePromise<void> {
 }
 
 /**
- * Playing reports whether audio is currently playing.
+ * Position returns the current playback position in seconds.
  */
-export function Playing(): $CancellablePromise<boolean> {
-    return $Call.ByID(2882669630);
+export function Position(): $CancellablePromise<number> {
+    return $Call.ByID(3379668963);
+}
+
+/**
+ * Resume resumes paused playback.
+ */
+export function Resume(): $CancellablePromise<void> {
+    return $Call.ByID(4192344979);
+}
+
+/**
+ * Seek seeks to the given position in seconds.
+ */
+export function Seek(seconds: number): $CancellablePromise<void> {
+    return $Call.ByID(1479346536, seconds);
+}
+
+/**
+ * SetVolume sets the volume (0-100).
+ */
+export function SetVolume(percent: number): $CancellablePromise<void> {
+    return $Call.ByID(671101282, percent);
+}
+
+/**
+ * State returns the current playback state as a string.
+ */
+export function State(): $CancellablePromise<string> {
+    return $Call.ByID(2570357237);
 }
 
 /**
@@ -36,4 +78,11 @@ export function Stop(): $CancellablePromise<void> {
  */
 export function Version(): $CancellablePromise<string> {
     return $Call.ByID(1040332204);
+}
+
+/**
+ * Volume returns the current volume (0-100).
+ */
+export function Volume(): $CancellablePromise<number> {
+    return $Call.ByID(2798880050);
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,30 +1,30 @@
 <script lang="ts">
-  import {GreetService} from "../bindings/github.com/willfish/forte";
+  import NowPlaying from './NowPlaying.svelte';
+  import { PlayerService } from "../bindings/github.com/willfish/forte";
 
-  let name = $state('');
-  let result = $state('Enter your name to test the Go bridge');
+  let filePath = $state('');
 
-  async function greet() {
-    const greeting = await GreetService.Greet(name || 'anonymous');
-    result = greeting;
+  async function loadFile() {
+    if (!filePath.trim()) return;
+    await PlayerService.Play(filePath.trim());
   }
 </script>
 
 <main>
   <h1>Forte</h1>
   <p class="subtitle">A modern music player</p>
-  <div class="bridge-test">
-    <p class="result">{result}</p>
-    <div class="input-row">
-      <input
-        type="text"
-        bind:value={name}
-        placeholder="Your name"
-        onkeydown={(e) => e.key === 'Enter' && greet()}
-      />
-      <button onclick={greet}>Greet</button>
-    </div>
+
+  <div class="file-input">
+    <input
+      type="text"
+      bind:value={filePath}
+      placeholder="Path to audio file"
+      onkeydown={(e) => e.key === 'Enter' && loadFile()}
+    />
+    <button onclick={loadFile}>Load</button>
   </div>
+
+  <NowPlaying />
 </main>
 
 <style>
@@ -42,6 +42,8 @@
   main {
     text-align: center;
     padding: 2rem;
+    width: 100%;
+    max-width: 600px;
   }
 
   h1 {
@@ -56,22 +58,10 @@
     margin: 0.5rem 0 2rem;
   }
 
-  .bridge-test {
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: 12px;
-    padding: 2rem;
-    max-width: 400px;
-    margin: 0 auto;
-  }
-
-  .result {
-    margin: 0 0 1.5rem;
-    min-height: 1.5em;
-  }
-
-  .input-row {
+  .file-input {
     display: flex;
     gap: 0.5rem;
+    margin-bottom: 1.5rem;
   }
 
   input {

--- a/frontend/src/NowPlaying.svelte
+++ b/frontend/src/NowPlaying.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import { PlayerService } from "../bindings/github.com/willfish/forte";
+
+  let playbackState = $state('stopped');
+  let position = $state(0);
+  let duration = $state(0);
+  let volume = $state(100);
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  function startPolling() {
+    if (pollTimer) return;
+    pollTimer = setInterval(async () => {
+      playbackState = await PlayerService.State();
+      position = await PlayerService.Position();
+      duration = await PlayerService.Duration();
+      volume = await PlayerService.Volume();
+    }, 250);
+  }
+
+  function stopPolling() {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  $effect(() => {
+    startPolling();
+    return () => stopPolling();
+  });
+
+  function formatTime(seconds: number): string {
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  }
+
+  async function togglePlayPause() {
+    if (playbackState === 'playing') {
+      await PlayerService.Pause();
+    } else if (playbackState === 'paused') {
+      await PlayerService.Resume();
+    }
+  }
+
+  async function stop() {
+    await PlayerService.Stop();
+  }
+
+  async function handleSeek(e: Event) {
+    const target = e.target as HTMLInputElement;
+    await PlayerService.Seek(parseFloat(target.value));
+  }
+
+  async function handleVolume(e: Event) {
+    const target = e.target as HTMLInputElement;
+    await PlayerService.SetVolume(parseInt(target.value));
+  }
+</script>
+
+<div class="now-playing">
+  <div class="transport">
+    <button onclick={togglePlayPause} disabled={playbackState === 'stopped'}>
+      {playbackState === 'playing' ? 'Pause' : 'Play'}
+    </button>
+    <button onclick={stop} disabled={playbackState === 'stopped'}>Stop</button>
+  </div>
+
+  <div class="seek">
+    <span class="time">{formatTime(position)}</span>
+    <input
+      type="range"
+      min="0"
+      max={duration || 1}
+      value={position}
+      step="0.5"
+      oninput={handleSeek}
+      disabled={playbackState === 'stopped'}
+    />
+    <span class="time">{formatTime(duration)}</span>
+  </div>
+
+  <div class="volume">
+    <span class="label">Vol</span>
+    <input
+      type="range"
+      min="0"
+      max="100"
+      value={volume}
+      oninput={handleVolume}
+    />
+    <span class="value">{volume}%</span>
+  </div>
+</div>
+
+<style>
+  .now-playing {
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 12px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 500px;
+    margin: 0 auto;
+  }
+
+  .transport {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+  }
+
+  .seek, .volume {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .seek input, .volume input {
+    flex: 1;
+    accent-color: #3366aa;
+  }
+
+  .time, .label, .value {
+    font-size: 0.85rem;
+    color: #8899aa;
+    min-width: 3em;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .time:last-child, .value {
+    text-align: right;
+  }
+
+  button {
+    padding: 0.5rem 1.25rem;
+    border-radius: 8px;
+    border: none;
+    background: #3366aa;
+    color: #fff;
+    font-size: 0.9rem;
+    cursor: pointer;
+  }
+
+  button:hover:not(:disabled) {
+    background: #4477bb;
+  }
+
+  button:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+</style>

--- a/internal/player/engine.go
+++ b/internal/player/engine.go
@@ -10,6 +10,26 @@ import (
 	mpv "github.com/gen2brain/go-mpv"
 )
 
+// PlaybackState represents the current state of the player.
+type PlaybackState int
+
+const (
+	StateStopped PlaybackState = iota
+	StatePlaying
+	StatePaused
+)
+
+func (s PlaybackState) String() string {
+	switch s {
+	case StatePlaying:
+		return "playing"
+	case StatePaused:
+		return "paused"
+	default:
+		return "stopped"
+	}
+}
+
 // ErrMpvNotFound is returned when libmpv cannot be loaded.
 var ErrMpvNotFound = errors.New(
 	"mpv not found: install mpv (e.g. 'sudo apt install libmpv-dev' or 'nix-shell -p mpv')",
@@ -17,10 +37,10 @@ var ErrMpvNotFound = errors.New(
 
 // Engine wraps an mpv instance for audio playback.
 type Engine struct {
-	mu      sync.Mutex
-	handle  *mpv.Mpv
-	playing bool
-	stop    chan struct{}
+	mu     sync.Mutex
+	handle *mpv.Mpv
+	state  PlaybackState
+	stop   chan struct{}
 }
 
 // NewEngine initialises mpv for audio-only playback.
@@ -31,19 +51,15 @@ func NewEngine() (*Engine, error) {
 		return nil, ErrMpvNotFound
 	}
 
-	if err := m.SetOptionString("audio-display", "no"); err != nil {
-		m.TerminateDestroy()
-		return nil, fmt.Errorf("mpv set audio-display: %w", err)
-	}
-
-	if err := m.SetOptionString("vo", "null"); err != nil {
-		m.TerminateDestroy()
-		return nil, fmt.Errorf("mpv set vo: %w", err)
-	}
-
-	if err := m.SetOptionString("terminal", "no"); err != nil {
-		m.TerminateDestroy()
-		return nil, fmt.Errorf("mpv set terminal: %w", err)
+	for _, opt := range [][2]string{
+		{"audio-display", "no"},
+		{"vo", "null"},
+		{"terminal", "no"},
+	} {
+		if err := m.SetOptionString(opt[0], opt[1]); err != nil {
+			m.TerminateDestroy()
+			return nil, fmt.Errorf("mpv set %s: %w", opt[0], err)
+		}
 	}
 
 	if err := m.Initialize(); err != nil {
@@ -70,8 +86,32 @@ func (e *Engine) Play(path string) error {
 		return fmt.Errorf("mpv loadfile: %w", err)
 	}
 
-	e.playing = true
+	e.state = StatePlaying
 	return nil
+}
+
+// Pause pauses the current playback.
+func (e *Engine) Pause() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.state != StatePlaying {
+		return
+	}
+	_ = e.handle.SetProperty("pause", mpv.FormatFlag, true)
+	e.state = StatePaused
+}
+
+// Resume resumes paused playback.
+func (e *Engine) Resume() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.state != StatePaused {
+		return
+	}
+	_ = e.handle.SetProperty("pause", mpv.FormatFlag, false)
+	e.state = StatePlaying
 }
 
 // Stop stops the current playback.
@@ -80,14 +120,63 @@ func (e *Engine) Stop() {
 	defer e.mu.Unlock()
 
 	_ = e.handle.Command([]string{"stop"})
-	e.playing = false
+	e.state = StateStopped
 }
 
-// Playing reports whether audio is currently playing.
-func (e *Engine) Playing() bool {
+// Seek seeks to the given position in seconds.
+func (e *Engine) Seek(seconds float64) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	return e.playing
+
+	if e.state == StateStopped {
+		return
+	}
+	_ = e.handle.CommandString(fmt.Sprintf("seek %f absolute", seconds))
+}
+
+// SetVolume sets the volume (0-100).
+func (e *Engine) SetVolume(percent int) {
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	_ = e.handle.SetProperty("volume", mpv.FormatDouble, float64(percent))
+}
+
+// Volume returns the current volume (0-100).
+func (e *Engine) Volume() int {
+	v, err := e.handle.GetProperty("volume", mpv.FormatDouble)
+	if err != nil {
+		return 0
+	}
+	return int(v.(float64))
+}
+
+// Position returns the current playback position in seconds.
+func (e *Engine) Position() float64 {
+	v, err := e.handle.GetProperty("time-pos", mpv.FormatDouble)
+	if err != nil {
+		return 0
+	}
+	return v.(float64)
+}
+
+// Duration returns the duration of the current track in seconds.
+func (e *Engine) Duration() float64 {
+	v, err := e.handle.GetProperty("duration", mpv.FormatDouble)
+	if err != nil {
+		return 0
+	}
+	return v.(float64)
+}
+
+// State returns the current playback state.
+func (e *Engine) State() PlaybackState {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.state
 }
 
 // Close shuts down the mpv instance.
@@ -117,7 +206,7 @@ func (e *Engine) eventLoop() {
 		switch event.EventID {
 		case mpv.EventEnd:
 			e.mu.Lock()
-			e.playing = false
+			e.state = StateStopped
 			e.mu.Unlock()
 			slog.Debug("playback ended")
 		case mpv.EventFileLoaded:

--- a/internal/player/engine_test.go
+++ b/internal/player/engine_test.go
@@ -4,12 +4,18 @@ import (
 	"testing"
 )
 
-func TestNewEngine(t *testing.T) {
+func newTestEngine(t *testing.T) *Engine {
+	t.Helper()
 	e, err := NewEngine()
 	if err != nil {
 		t.Fatalf("NewEngine() error: %v", err)
 	}
-	defer e.Close()
+	t.Cleanup(func() { e.Close() })
+	return e
+}
+
+func TestNewEngine(t *testing.T) {
+	e := newTestEngine(t)
 
 	v := e.Version()
 	if v == "" {
@@ -18,16 +24,110 @@ func TestNewEngine(t *testing.T) {
 	t.Logf("mpv version: %s", v)
 }
 
-func TestPlayNonExistentFile(t *testing.T) {
-	e, err := NewEngine()
-	if err != nil {
-		t.Fatalf("NewEngine() error: %v", err)
+func TestInitialState(t *testing.T) {
+	e := newTestEngine(t)
+
+	if s := e.State(); s != StateStopped {
+		t.Fatalf("expected StateStopped, got %s", s)
 	}
-	defer e.Close()
+}
+
+func TestPlayNonExistentFile(t *testing.T) {
+	e := newTestEngine(t)
 
 	// loadfile queues the file asynchronously, so the command itself succeeds
 	// even for non-existent files. mpv will emit an end-file event with an error.
 	if err := e.Play("/nonexistent/file.flac"); err != nil {
 		t.Fatalf("Play() error: %v", err)
+	}
+
+	if s := e.State(); s != StatePlaying {
+		t.Fatalf("expected StatePlaying after Play(), got %s", s)
+	}
+}
+
+func TestPauseResume(t *testing.T) {
+	e := newTestEngine(t)
+
+	// Pause in stopped state should be a no-op.
+	e.Pause()
+	if s := e.State(); s != StateStopped {
+		t.Fatalf("expected StateStopped after Pause() in stopped state, got %s", s)
+	}
+
+	// Play, then pause.
+	if err := e.Play("/nonexistent/file.flac"); err != nil {
+		t.Fatalf("Play() error: %v", err)
+	}
+	e.Pause()
+	if s := e.State(); s != StatePaused {
+		t.Fatalf("expected StatePaused, got %s", s)
+	}
+
+	// Resume.
+	e.Resume()
+	if s := e.State(); s != StatePlaying {
+		t.Fatalf("expected StatePlaying after Resume(), got %s", s)
+	}
+
+	// Resume when already playing should be a no-op.
+	e.Resume()
+	if s := e.State(); s != StatePlaying {
+		t.Fatalf("expected StatePlaying after redundant Resume(), got %s", s)
+	}
+}
+
+func TestStopResetsState(t *testing.T) {
+	e := newTestEngine(t)
+
+	if err := e.Play("/nonexistent/file.flac"); err != nil {
+		t.Fatalf("Play() error: %v", err)
+	}
+	e.Stop()
+	if s := e.State(); s != StateStopped {
+		t.Fatalf("expected StateStopped after Stop(), got %s", s)
+	}
+}
+
+func TestVolume(t *testing.T) {
+	e := newTestEngine(t)
+
+	e.SetVolume(50)
+	if v := e.Volume(); v != 50 {
+		t.Fatalf("expected volume 50, got %d", v)
+	}
+
+	// Clamp to bounds.
+	e.SetVolume(-10)
+	if v := e.Volume(); v != 0 {
+		t.Fatalf("expected volume 0 after setting -10, got %d", v)
+	}
+
+	e.SetVolume(200)
+	if v := e.Volume(); v != 100 {
+		t.Fatalf("expected volume 100 after setting 200, got %d", v)
+	}
+}
+
+func TestSeekWhileStopped(t *testing.T) {
+	e := newTestEngine(t)
+
+	// Seek in stopped state should be a no-op (no panic).
+	e.Seek(30.0)
+}
+
+func TestPlaybackStateString(t *testing.T) {
+	tests := []struct {
+		state PlaybackState
+		want  string
+	}{
+		{StateStopped, "stopped"},
+		{StatePlaying, "playing"},
+		{StatePaused, "paused"},
+	}
+	for _, tt := range tests {
+		if got := tt.state.String(); got != tt.want {
+			t.Errorf("PlaybackState(%d).String() = %q, want %q", tt.state, got, tt.want)
+		}
 	}
 }

--- a/playerservice.go
+++ b/playerservice.go
@@ -39,6 +39,20 @@ func (p *PlayerService) Play(path string) error {
 	return p.engine.Play(path)
 }
 
+// Pause pauses the current playback.
+func (p *PlayerService) Pause() {
+	if p.engine != nil {
+		p.engine.Pause()
+	}
+}
+
+// Resume resumes paused playback.
+func (p *PlayerService) Resume() {
+	if p.engine != nil {
+		p.engine.Resume()
+	}
+}
+
 // Stop halts the current playback.
 func (p *PlayerService) Stop() {
 	if p.engine != nil {
@@ -46,12 +60,50 @@ func (p *PlayerService) Stop() {
 	}
 }
 
-// Playing reports whether audio is currently playing.
-func (p *PlayerService) Playing() bool {
-	if p.engine == nil {
-		return false
+// Seek seeks to the given position in seconds.
+func (p *PlayerService) Seek(seconds float64) {
+	if p.engine != nil {
+		p.engine.Seek(seconds)
 	}
-	return p.engine.Playing()
+}
+
+// SetVolume sets the volume (0-100).
+func (p *PlayerService) SetVolume(percent int) {
+	if p.engine != nil {
+		p.engine.SetVolume(percent)
+	}
+}
+
+// Volume returns the current volume (0-100).
+func (p *PlayerService) Volume() int {
+	if p.engine == nil {
+		return 0
+	}
+	return p.engine.Volume()
+}
+
+// Position returns the current playback position in seconds.
+func (p *PlayerService) Position() float64 {
+	if p.engine == nil {
+		return 0
+	}
+	return p.engine.Position()
+}
+
+// Duration returns the duration of the current track in seconds.
+func (p *PlayerService) Duration() float64 {
+	if p.engine == nil {
+		return 0
+	}
+	return p.engine.Duration()
+}
+
+// State returns the current playback state as a string.
+func (p *PlayerService) State() string {
+	if p.engine == nil {
+		return "stopped"
+	}
+	return p.engine.State().String()
 }
 
 // Version returns the mpv library version string.


### PR DESCRIPTION
## Summary

- Extends player engine with `Pause`, `Resume`, `Seek`, `SetVolume`, `Volume`, `Position`, `Duration`, `State`
- Replaces boolean `playing` field with `PlaybackState` enum (Stopped, Playing, Paused)
- Adds `NowPlaying.svelte` component: play/pause toggle, stop, seek bar, volume slider
- Replaces greet demo UI with file path input and transport controls
- 8 unit tests covering state transitions, volume clamping, seek-while-stopped, and the state string representation

## Test plan

- [x] `go test -tags nocgo -v ./internal/player/...` - 8 tests pass
- [x] `golangci-lint run --build-tags nocgo` - 0 issues
- [x] `npm run check` - 0 errors
- [x] `task build` - builds cleanly
- [ ] CI passes all 5 jobs

Closes #13