### PR TITLE
Enable gapless playback with playlist support

### DIFF
--- a/internal/player/engine.go
+++ b/internal/player/engine.go
@@ -55,6 +55,7 @@ func NewEngine() (*Engine, error) {
 		{"audio-display", "no"},
 		{"vo", "null"},
 		{"terminal", "no"},
+		{"gapless-audio", "yes"},
 	} {
 		if err := m.SetOptionString(opt[0], opt[1]); err != nil {
 			m.TerminateDestroy()
@@ -78,15 +79,49 @@ func NewEngine() (*Engine, error) {
 }
 
 // Play loads and plays the audio file at the given path.
+// This replaces the current playlist.
 func (e *Engine) Play(path string) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	if err := e.handle.Command([]string{"loadfile", path}); err != nil {
+	if err := e.handle.Command([]string{"loadfile", path, "replace"}); err != nil {
 		return fmt.Errorf("mpv loadfile: %w", err)
 	}
 
 	e.state = StatePlaying
+	return nil
+}
+
+// Enqueue appends a track to the playlist for gapless playback.
+func (e *Engine) Enqueue(path string) error {
+	if err := e.handle.Command([]string{"loadfile", path, "append"}); err != nil {
+		return fmt.Errorf("mpv enqueue: %w", err)
+	}
+	return nil
+}
+
+// PlayAll replaces the playlist and plays the given tracks in order.
+func (e *Engine) PlayAll(paths []string) error {
+	if len(paths) == 0 {
+		return nil
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Load the first track (replaces playlist).
+	if err := e.handle.Command([]string{"loadfile", paths[0], "replace"}); err != nil {
+		return fmt.Errorf("mpv loadfile: %w", err)
+	}
+	e.state = StatePlaying
+
+	// Append the rest for gapless transitions.
+	for _, p := range paths[1:] {
+		if err := e.handle.Command([]string{"loadfile", p, "append"}); err != nil {
+			return fmt.Errorf("mpv enqueue: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -205,11 +240,23 @@ func (e *Engine) eventLoop() {
 
 		switch event.EventID {
 		case mpv.EventEnd:
-			e.mu.Lock()
-			e.state = StateStopped
-			e.mu.Unlock()
-			slog.Debug("playback ended")
+			ef := event.EndFile()
+			if ef.Reason == mpv.EndFileEOF || ef.Reason == mpv.EndFileStop || ef.Reason == mpv.EndFileError {
+				// Check if mpv has more playlist entries queued.
+				pos, _ := e.handle.GetProperty("playlist-pos", mpv.FormatInt64)
+				if pos == nil || pos.(int64) < 0 {
+					e.mu.Lock()
+					e.state = StateStopped
+					e.mu.Unlock()
+					slog.Debug("playlist finished")
+				} else {
+					slog.Debug("track ended, next track queued")
+				}
+			}
 		case mpv.EventFileLoaded:
+			e.mu.Lock()
+			e.state = StatePlaying
+			e.mu.Unlock()
 			slog.Debug("file loaded")
 		case mpv.EventShutdown:
 			return

--- a/internal/player/engine_test.go
+++ b/internal/player/engine_test.go
@@ -116,6 +116,49 @@ func TestSeekWhileStopped(t *testing.T) {
 	e.Seek(30.0)
 }
 
+func TestEnqueue(t *testing.T) {
+	e := newTestEngine(t)
+
+	// Enqueue without playing first should succeed (appends to empty playlist).
+	if err := e.Enqueue("/nonexistent/a.flac"); err != nil {
+		t.Fatalf("Enqueue() error: %v", err)
+	}
+}
+
+func TestPlayAll(t *testing.T) {
+	e := newTestEngine(t)
+
+	paths := []string{"/nonexistent/a.flac", "/nonexistent/b.flac", "/nonexistent/c.flac"}
+	if err := e.PlayAll(paths); err != nil {
+		t.Fatalf("PlayAll() error: %v", err)
+	}
+
+	if s := e.State(); s != StatePlaying {
+		t.Fatalf("expected StatePlaying after PlayAll(), got %s", s)
+	}
+}
+
+func TestPlayAllEmpty(t *testing.T) {
+	e := newTestEngine(t)
+
+	if err := e.PlayAll(nil); err != nil {
+		t.Fatalf("PlayAll(nil) error: %v", err)
+	}
+
+	if s := e.State(); s != StateStopped {
+		t.Fatalf("expected StateStopped after PlayAll(nil), got %s", s)
+	}
+}
+
+func TestGaplessOptionSet(t *testing.T) {
+	e := newTestEngine(t)
+
+	v := e.handle.GetPropertyString("gapless-audio")
+	if v != "yes" {
+		t.Fatalf("expected gapless-audio=yes, got %q", v)
+	}
+}
+
 func TestPlaybackStateString(t *testing.T) {
 	tests := []struct {
 		state PlaybackState

--- a/playerservice.go
+++ b/playerservice.go
@@ -39,6 +39,22 @@ func (p *PlayerService) Play(path string) error {
 	return p.engine.Play(path)
 }
 
+// Enqueue appends a track to the playlist for gapless playback.
+func (p *PlayerService) Enqueue(path string) error {
+	if p.engine == nil {
+		return fmt.Errorf("player not initialised")
+	}
+	return p.engine.Enqueue(path)
+}
+
+// PlayAll replaces the playlist and plays the given tracks in order.
+func (p *PlayerService) PlayAll(paths []string) error {
+	if p.engine == nil {
+		return fmt.Errorf("player not initialised")
+	}
+	return p.engine.PlayAll(paths)
+}
+
 // Pause pauses the current playback.
 func (p *PlayerService) Pause() {
 	if p.engine != nil {


### PR DESCRIPTION
## Summary

- Set `gapless-audio=yes` on mpv init for seamless transitions between consecutive tracks
- Add `Enqueue` method to append tracks to mpv's internal playlist
- Add `PlayAll` method to replace the playlist and play a list of tracks
- Refine event loop: only mark stopped when the entire playlist finishes (check `playlist-pos`), not between tracks
- Set state to `StatePlaying` on `EventFileLoaded` so state stays correct during playlist transitions

## Test plan

- [x] `go test -tags nocgo -v ./internal/player/...` - 12 tests pass
- [x] `TestGaplessOptionSet` confirms `gapless-audio=yes` is set
- [x] `TestEnqueue`, `TestPlayAll`, `TestPlayAllEmpty` cover playlist operations
- [x] `golangci-lint run --build-tags nocgo` - 0 issues
- [ ] CI passes all 5 jobs

Closes #14