### PR TITLE
Add ReplayGain support with track/album/off modes

### DIFF
--- a/internal/player/engine.go
+++ b/internal/player/engine.go
@@ -56,6 +56,7 @@ func NewEngine() (*Engine, error) {
 		{"vo", "null"},
 		{"terminal", "no"},
 		{"gapless-audio", "yes"},
+		{"replaygain", "track"},
 	} {
 		if err := m.SetOptionString(opt[0], opt[1]); err != nil {
 			m.TerminateDestroy()
@@ -212,6 +213,21 @@ func (e *Engine) State() PlaybackState {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return e.state
+}
+
+// SetReplayGain sets the ReplayGain mode: "track", "album", or "no" (off).
+func (e *Engine) SetReplayGain(mode string) error {
+	switch mode {
+	case "track", "album", "no":
+		return e.handle.SetPropertyString("replaygain", mode)
+	default:
+		return fmt.Errorf("invalid replaygain mode: %q (expected track, album, or no)", mode)
+	}
+}
+
+// ReplayGain returns the current ReplayGain mode.
+func (e *Engine) ReplayGain() string {
+	return e.handle.GetPropertyString("replaygain")
 }
 
 // Close shuts down the mpv instance.

--- a/internal/player/engine_test.go
+++ b/internal/player/engine_test.go
@@ -159,6 +159,35 @@ func TestGaplessOptionSet(t *testing.T) {
 	}
 }
 
+func TestReplayGainDefault(t *testing.T) {
+	e := newTestEngine(t)
+
+	if v := e.ReplayGain(); v != "track" {
+		t.Fatalf("expected default replaygain=track, got %q", v)
+	}
+}
+
+func TestSetReplayGain(t *testing.T) {
+	e := newTestEngine(t)
+
+	for _, mode := range []string{"album", "no", "track"} {
+		if err := e.SetReplayGain(mode); err != nil {
+			t.Fatalf("SetReplayGain(%q) error: %v", mode, err)
+		}
+		if v := e.ReplayGain(); v != mode {
+			t.Fatalf("expected replaygain=%q, got %q", mode, v)
+		}
+	}
+}
+
+func TestSetReplayGainInvalid(t *testing.T) {
+	e := newTestEngine(t)
+
+	if err := e.SetReplayGain("bogus"); err == nil {
+		t.Fatal("expected error for invalid replaygain mode")
+	}
+}
+
 func TestPlaybackStateString(t *testing.T) {
 	tests := []struct {
 		state PlaybackState

--- a/playerservice.go
+++ b/playerservice.go
@@ -122,6 +122,22 @@ func (p *PlayerService) State() string {
 	return p.engine.State().String()
 }
 
+// SetReplayGain sets the ReplayGain mode: "track", "album", or "no" (off).
+func (p *PlayerService) SetReplayGain(mode string) error {
+	if p.engine == nil {
+		return fmt.Errorf("player not initialised")
+	}
+	return p.engine.SetReplayGain(mode)
+}
+
+// ReplayGain returns the current ReplayGain mode.
+func (p *PlayerService) ReplayGain() string {
+	if p.engine == nil {
+		return ""
+	}
+	return p.engine.ReplayGain()
+}
+
 // Version returns the mpv library version string.
 func (p *PlayerService) Version() string {
 	if p.engine == nil {


### PR DESCRIPTION
## Summary

- Set `replaygain=track` by default on mpv init for consistent volume across tracks
- Add `SetReplayGain(mode)` to switch between `track`, `album`, and `no` (off) at runtime
- Add `ReplayGain()` to query the current mode
- Invalid modes are rejected with an error

## Test plan

- [x] `TestReplayGainDefault` - confirms default is `track`
- [x] `TestSetReplayGain` - cycles through all valid modes
- [x] `TestSetReplayGainInvalid` - rejects bogus input
- [x] 15 total tests pass, 0 lint issues
- [ ] CI passes all 5 jobs

Closes #15