### PR TITLE
Add audio tag reader using go-taglib WASM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25
 require (
 	github.com/gen2brain/go-mpv v0.2.3
 	github.com/wailsapp/wails/v3 v3.0.0-alpha.74
+	go.senan.xyz/taglib v0.11.1
 	modernc.org/sqlite v1.46.1
 )
 
@@ -44,6 +45,7 @@ require (
 	github.com/samber/lo v1.52.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
+	github.com/tetratelabs/wazero v1.10.1 // indirect
 	github.com/wailsapp/go-webview2 v1.0.23 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/crypto v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,12 +117,16 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tetratelabs/wazero v1.10.1 h1:2DugeJf6VVk58KTPszlNfeeN8AhhpwcZqkJj2wwFuH8=
+github.com/tetratelabs/wazero v1.10.1/go.mod h1:DRm5twOQ5Gr1AoEdSi0CLjDQF1J9ZAuyqFIjl1KKfQU=
 github.com/wailsapp/go-webview2 v1.0.23 h1:jmv8qhz1lHibCc79bMM/a/FqOnnzOGEisLav+a0b9P0=
 github.com/wailsapp/go-webview2 v1.0.23/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/wails/v3 v3.0.0-alpha.74 h1:wRm1EiDQtxDisXk46NtpiBH90STwfKp36NrTDwOEdxw=
 github.com/wailsapp/wails/v3 v3.0.0-alpha.74/go.mod h1:4saK4A4K9970X+X7RkMwP2lyGbLogcUz54wVeq4C/V8=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
+go.senan.xyz/taglib v0.11.1 h1:S3mO5e3HRRG0Ehw1jLUodYbAJK8TtqdOoNgqkC0D3uU=
+go.senan.xyz/taglib v0.11.1/go.mod h1:qyTl978MnGeZ/ny4d/t0ErLXxysA+39X4+SNSCk56Zs=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=

--- a/internal/metadata/reader.go
+++ b/internal/metadata/reader.go
@@ -1,0 +1,142 @@
+// Package metadata reads audio file tags and properties.
+package metadata
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.senan.xyz/taglib"
+)
+
+// TrackMeta holds metadata extracted from an audio file.
+type TrackMeta struct {
+	Title       string
+	Artist      string
+	AlbumArtist string
+	Album       string
+	TrackNumber int
+	DiscNumber  int
+	Year        int
+	Genre       string
+	Duration    time.Duration
+	Bitrate     int
+	SampleRate  int
+	Channels    int
+	HasArtwork  bool
+}
+
+// ReadTags reads metadata from the audio file at path.
+// Falls back to filename parsing when tags are missing.
+func ReadTags(path string) (TrackMeta, error) {
+	tags, err := taglib.ReadTags(path)
+	if err != nil {
+		return TrackMeta{}, err
+	}
+
+	props, err := taglib.ReadProperties(path)
+	if err != nil {
+		return TrackMeta{}, err
+	}
+
+	meta := TrackMeta{
+		Title:       first(tags[taglib.Title]),
+		Artist:      first(tags[taglib.Artist]),
+		AlbumArtist: first(tags[taglib.AlbumArtist]),
+		Album:       first(tags[taglib.Album]),
+		TrackNumber: parseNum(first(tags[taglib.TrackNumber])),
+		DiscNumber:  parseNum(first(tags[taglib.DiscNumber])),
+		Year:        parseNum(first(tags[taglib.Date])),
+		Genre:       first(tags[taglib.Genre]),
+		Duration:    props.Length,
+		Bitrate:     int(props.Bitrate),
+		SampleRate:  int(props.SampleRate),
+		Channels:    int(props.Channels),
+		HasArtwork:  len(props.Images) > 0,
+	}
+
+	// Fall back to filename if title is missing.
+	if meta.Title == "" {
+		meta.Title, meta.TrackNumber = parseFilename(path)
+	}
+	// Fall back to parent directory name if album is missing.
+	if meta.Album == "" {
+		meta.Album = parentDirName(path)
+	}
+
+	return meta, nil
+}
+
+// ReadArtwork returns the embedded front cover image bytes and MIME type.
+// Returns empty values if no artwork is embedded.
+func ReadArtwork(path string) ([]byte, string, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, "", fmt.Errorf("artwork: %w", err)
+	}
+
+	props, err := taglib.ReadProperties(path)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if len(props.Images) == 0 {
+		return nil, "", nil
+	}
+
+	data, err := taglib.ReadImage(path)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return data, props.Images[0].MIMEType, nil
+}
+
+// first returns the first element of a string slice, or "" if empty.
+func first(ss []string) string {
+	if len(ss) > 0 {
+		return ss[0]
+	}
+	return ""
+}
+
+// parseNum parses a string to int, handling "3/12" track number formats.
+func parseNum(s string) int {
+	if s == "" {
+		return 0
+	}
+	// Handle "3/12" format (track 3 of 12).
+	if i := strings.IndexByte(s, '/'); i >= 0 {
+		s = s[:i]
+	}
+	n, _ := strconv.Atoi(strings.TrimSpace(s))
+	return n
+}
+
+// parseFilename extracts a title and optional track number from a filename.
+// Patterns: "01 - Track Name.flac", "01 Track Name.flac", "Track Name.flac"
+func parseFilename(path string) (title string, trackNum int) {
+	name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	if name == "" {
+		return "", 0
+	}
+
+	// Try "NN - Title" or "NN. Title" patterns.
+	for _, sep := range []string{" - ", ". ", " "} {
+		if i := strings.Index(name, sep); i > 0 {
+			prefix := name[:i]
+			if n, err := strconv.Atoi(prefix); err == nil {
+				return strings.TrimSpace(name[i+len(sep):]), n
+			}
+		}
+	}
+
+	return name, 0
+}
+
+// parentDirName returns the name of the parent directory.
+func parentDirName(path string) string {
+	return filepath.Base(filepath.Dir(path))
+}

--- a/internal/metadata/reader_test.go
+++ b/internal/metadata/reader_test.go
@@ -1,0 +1,88 @@
+package metadata
+
+import (
+	"testing"
+)
+
+func TestParseFilename(t *testing.T) {
+	tests := []struct {
+		path      string
+		wantTitle string
+		wantTrack int
+	}{
+		{"/music/01 - Track Name.flac", "Track Name", 1},
+		{"/music/12 - Song Title.mp3", "Song Title", 12},
+		{"/music/01. First Song.flac", "First Song", 1},
+		{"/music/03 Third Track.ogg", "Third Track", 3},
+		{"/music/Song Without Number.flac", "Song Without Number", 0},
+		{"/music/01 - Track - With Dash.flac", "Track - With Dash", 1},
+		{"/music/.flac", "", 0},
+	}
+	for _, tt := range tests {
+		title, track := parseFilename(tt.path)
+		if title != tt.wantTitle || track != tt.wantTrack {
+			t.Errorf("parseFilename(%q) = (%q, %d), want (%q, %d)", tt.path, title, track, tt.wantTitle, tt.wantTrack)
+		}
+	}
+}
+
+func TestParseNum(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"", 0},
+		{"1", 1},
+		{"12", 12},
+		{"3/12", 3},
+		{"01/10", 1},
+		{"abc", 0},
+	}
+	for _, tt := range tests {
+		if got := parseNum(tt.input); got != tt.want {
+			t.Errorf("parseNum(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestFirst(t *testing.T) {
+	if got := first(nil); got != "" {
+		t.Errorf("first(nil) = %q, want empty", got)
+	}
+	if got := first([]string{}); got != "" {
+		t.Errorf("first([]) = %q, want empty", got)
+	}
+	if got := first([]string{"a", "b"}); got != "a" {
+		t.Errorf("first([a,b]) = %q, want a", got)
+	}
+}
+
+func TestParentDirName(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/music/Artist/Album/01.flac", "Album"},
+		{"/music/track.mp3", "music"},
+		{"track.mp3", "."},
+	}
+	for _, tt := range tests {
+		if got := parentDirName(tt.path); got != tt.want {
+			t.Errorf("parentDirName(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestReadTagsNonExistentFile(t *testing.T) {
+	_, err := ReadTags("/nonexistent/file.flac")
+	if err == nil {
+		t.Error("expected error for non-existent file")
+	}
+}
+
+func TestReadArtworkNonExistentFile(t *testing.T) {
+	_, _, err := ReadArtwork("/nonexistent/file.flac")
+	if err == nil {
+		t.Error("expected error for non-existent file")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/metadata` package for reading audio file tags via `go.senan.xyz/taglib` (TagLib compiled to WASM, no cgo)
- Extracts title, artist, album artist, album, track/disc number, year, genre, duration, bitrate, channels, sample rate
- Reads embedded artwork (front cover) with MIME type detection
- Filename fallback parser for files with missing tags ("01 - Track Name.flac", "01. Title.flac")
- Parent directory fallback for missing album name

## Test plan
- [x] 6 tests: filename parser (7 patterns), number parser (incl. "3/12" format), first() helper, parent dir name, error handling for non-existent files