### PR TITLE
Add keyboard shortcuts for playback control

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2,7 +2,26 @@
   import Sidebar from './Sidebar.svelte';
   import Content from './Content.svelte';
   import NowPlayingBar from './NowPlayingBar.svelte';
+  import ShortcutHelp from './ShortcutHelp.svelte';
+  import { handleKeydown } from './lib/shortcuts';
+
+  let showHelp = $state(false);
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === '?' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      showHelp = !showHelp;
+      return;
+    }
+    if (e.key === 'Escape' && showHelp) {
+      showHelp = false;
+      return;
+    }
+    handleKeydown(e);
+  }
 </script>
+
+<svelte:window onkeydown={onKeydown} />
 
 <div class="shell">
   <div class="top">
@@ -13,3 +32,7 @@
   </div>
   <NowPlayingBar />
 </div>
+
+{#if showHelp}
+  <ShortcutHelp onclose={() => showHelp = false} />
+{/if}

--- a/frontend/src/ShortcutHelp.svelte
+++ b/frontend/src/ShortcutHelp.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { shortcuts, formatKey } from './lib/shortcuts';
+
+  let { onclose }: { onclose: () => void } = $props();
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onclick={onclose} role="presentation">
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div class="panel" onclick={(e) => e.stopPropagation()} role="dialog" aria-label="Keyboard shortcuts" tabindex="-1">
+    <div class="header">
+      <h2>Keyboard Shortcuts</h2>
+      <button class="close-btn" onclick={onclose} aria-label="Close">x</button>
+    </div>
+    <table>
+      <tbody>
+        {#each shortcuts as shortcut}
+          <tr>
+            <td class="key"><kbd>{formatKey(shortcut)}</kbd></td>
+            <td class="desc">{shortcut.description}</td>
+          </tr>
+        {/each}
+        <tr>
+          <td class="key"><kbd>Ctrl + ?</kbd></td>
+          <td class="desc">Show this help</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+
+  .panel {
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    min-width: 320px;
+    max-width: 420px;
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .close-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 1rem;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+  }
+
+  .close-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  tr {
+    border-bottom: 1px solid var(--border);
+  }
+
+  tr:last-child {
+    border-bottom: none;
+  }
+
+  td {
+    padding: 0.5rem 0;
+  }
+
+  .key {
+    width: 120px;
+  }
+
+  kbd {
+    background: var(--bg-hover);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 2px 6px;
+    font-family: inherit;
+    font-size: 0.8rem;
+    color: var(--text-primary);
+  }
+
+  .desc {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+  }
+</style>

--- a/frontend/src/lib/shortcuts.ts
+++ b/frontend/src/lib/shortcuts.ts
@@ -1,0 +1,120 @@
+import { PlayerService } from "../../bindings/github.com/willfish/forte";
+
+export interface Shortcut {
+  key: string;
+  ctrl?: boolean;
+  description: string;
+  action: () => void | Promise<void>;
+}
+
+const VOLUME_STEP = 5;
+const SEEK_STEP = 5;
+
+export const shortcuts: Shortcut[] = [
+  {
+    key: " ",
+    description: "Play / Pause",
+    action: async () => {
+      const state = await PlayerService.State();
+      if (state === "playing") await PlayerService.Pause();
+      else if (state === "paused") await PlayerService.Resume();
+    },
+  },
+  {
+    key: "ArrowLeft",
+    description: "Seek backward 5s",
+    action: async () => {
+      const pos = await PlayerService.Position();
+      await PlayerService.Seek(Math.max(0, pos - SEEK_STEP));
+    },
+  },
+  {
+    key: "ArrowRight",
+    description: "Seek forward 5s",
+    action: async () => {
+      const pos = await PlayerService.Position();
+      const dur = await PlayerService.Duration();
+      await PlayerService.Seek(Math.min(dur, pos + SEEK_STEP));
+    },
+  },
+  {
+    key: "ArrowLeft",
+    ctrl: true,
+    description: "Previous track",
+    action: () => PlayerService.Previous(),
+  },
+  {
+    key: "ArrowRight",
+    ctrl: true,
+    description: "Next track",
+    action: () => PlayerService.Next(),
+  },
+  {
+    key: "ArrowUp",
+    ctrl: true,
+    description: "Volume up",
+    action: async () => {
+      const vol = await PlayerService.Volume();
+      await PlayerService.SetVolume(Math.min(100, vol + VOLUME_STEP));
+    },
+  },
+  {
+    key: "ArrowDown",
+    ctrl: true,
+    description: "Volume down",
+    action: async () => {
+      const vol = await PlayerService.Volume();
+      await PlayerService.SetVolume(Math.max(0, vol - VOLUME_STEP));
+    },
+  },
+];
+
+function isInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+}
+
+export function handleKeydown(e: KeyboardEvent): boolean {
+  if (isInputFocused()) return false;
+
+  const match = shortcuts.find(
+    (s) => s.key === e.key && !!s.ctrl === (e.ctrlKey || e.metaKey)
+  );
+  if (!match) return false;
+
+  e.preventDefault();
+  match.action();
+  return true;
+}
+
+export function formatKey(shortcut: Shortcut): string {
+  const parts: string[] = [];
+  if (shortcut.ctrl) parts.push("Ctrl");
+
+  switch (shortcut.key) {
+    case " ":
+      parts.push("Space");
+      break;
+    case "ArrowLeft":
+      parts.push("\u2190");
+      break;
+    case "ArrowRight":
+      parts.push("\u2192");
+      break;
+    case "ArrowUp":
+      parts.push("\u2191");
+      break;
+    case "ArrowDown":
+      parts.push("\u2193");
+      break;
+    case "?":
+      parts.push("?");
+      break;
+    default:
+      parts.push(shortcut.key);
+  }
+
+  return parts.join(" + ");
+}


### PR DESCRIPTION
### What?

- [x] Add global keyboard shortcut handler in App.svelte via `svelte:window`
- [x] Create shortcut definitions in `lib/shortcuts.ts` with key matching logic
- [x] Build help overlay component (Ctrl+?) showing all available shortcuts
- [x] Guard shortcuts from firing when input elements are focused

### Shortcuts

| Key | Action |
|-----|--------|
| Space | Play / Pause |
| Left / Right | Seek backward / forward 5s |
| Ctrl+Left / Right | Previous / next track |
| Ctrl+Up / Down | Volume up / down (5%) |
| Ctrl+? | Toggle shortcut help overlay |
| Escape | Close help overlay |

### Why?

Power users expect keyboard control for a music player. This implements the core transport shortcuts from story #26. Search-related shortcuts (Ctrl+F, Escape to clear search) are deferred until a search bar exists.

Closes #26