### PR TITLE
Implement Subsonic/OpenSubsonic API client

### DIFF
--- a/internal/library/db.go
+++ b/internal/library/db.go
@@ -90,4 +90,5 @@ type migration struct {
 var migrations = []migration{
 	{version: 1, sql: migration001},
 	{version: 2, sql: migration002},
+	{version: 3, sql: migration003},
 }

--- a/internal/library/schema.go
+++ b/internal/library/schema.go
@@ -94,3 +94,14 @@ CREATE TABLE playback_state (
 );
 INSERT INTO playback_state (id) VALUES (1);
 `
+
+const migration003 = `
+CREATE TABLE servers (
+	id       TEXT PRIMARY KEY,
+	name     TEXT NOT NULL,
+	type     TEXT NOT NULL DEFAULT 'subsonic',
+	url      TEXT NOT NULL,
+	username TEXT NOT NULL,
+	password TEXT NOT NULL DEFAULT ''
+);
+`

--- a/internal/library/servers.go
+++ b/internal/library/servers.go
@@ -1,0 +1,77 @@
+package library
+
+import "fmt"
+
+// Server represents a streaming server configuration.
+type Server struct {
+	ID       string
+	Name     string
+	Type     string
+	URL      string
+	Username string
+	Password string
+}
+
+// AddServer inserts a new server.
+func (db *DB) AddServer(s Server) error {
+	_, err := db.Exec(
+		"INSERT INTO servers (id, name, type, url, username, password) VALUES (?, ?, ?, ?, ?, ?)",
+		s.ID, s.Name, s.Type, s.URL, s.Username, s.Password,
+	)
+	if err != nil {
+		return fmt.Errorf("add server: %w", err)
+	}
+	return nil
+}
+
+// GetServer returns a server by ID.
+func (db *DB) GetServer(id string) (Server, error) {
+	var s Server
+	err := db.QueryRow(
+		"SELECT id, name, type, url, username, password FROM servers WHERE id = ?", id,
+	).Scan(&s.ID, &s.Name, &s.Type, &s.URL, &s.Username, &s.Password)
+	if err != nil {
+		return Server{}, fmt.Errorf("get server: %w", err)
+	}
+	return s, nil
+}
+
+// GetServers returns all servers ordered by name.
+func (db *DB) GetServers() ([]Server, error) {
+	rows, err := db.Query("SELECT id, name, type, url, username, password FROM servers ORDER BY name")
+	if err != nil {
+		return nil, fmt.Errorf("get servers: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var servers []Server
+	for rows.Next() {
+		var s Server
+		if err := rows.Scan(&s.ID, &s.Name, &s.Type, &s.URL, &s.Username, &s.Password); err != nil {
+			return nil, fmt.Errorf("scan server: %w", err)
+		}
+		servers = append(servers, s)
+	}
+	return servers, rows.Err()
+}
+
+// UpdateServer updates an existing server.
+func (db *DB) UpdateServer(s Server) error {
+	_, err := db.Exec(
+		"UPDATE servers SET name = ?, type = ?, url = ?, username = ?, password = ? WHERE id = ?",
+		s.Name, s.Type, s.URL, s.Username, s.Password, s.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update server: %w", err)
+	}
+	return nil
+}
+
+// DeleteServer deletes a server by ID.
+func (db *DB) DeleteServer(id string) error {
+	_, err := db.Exec("DELETE FROM servers WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("delete server: %w", err)
+	}
+	return nil
+}

--- a/internal/library/servers_test.go
+++ b/internal/library/servers_test.go
@@ -1,0 +1,84 @@
+package library
+
+import (
+	"testing"
+)
+
+func TestAddAndGetServer(t *testing.T) {
+	db := openTestDB(t)
+
+	s := Server{ID: "srv-1", Name: "My Navidrome", Type: "subsonic", URL: "http://localhost:4533", Username: "admin", Password: "secret"}
+	if err := db.AddServer(s); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	got, err := db.GetServer("srv-1")
+	if err != nil {
+		t.Fatalf("GetServer: %v", err)
+	}
+	if got.Name != "My Navidrome" || got.URL != "http://localhost:4533" || got.Password != "secret" {
+		t.Errorf("GetServer = %+v, want matching fields", got)
+	}
+}
+
+func TestGetServers(t *testing.T) {
+	db := openTestDB(t)
+
+	mustExec(t, db, "INSERT INTO servers (id, name, type, url, username) VALUES ('s2', 'Zebra', 'subsonic', 'http://z', 'u')")
+	mustExec(t, db, "INSERT INTO servers (id, name, type, url, username) VALUES ('s1', 'Alpha', 'subsonic', 'http://a', 'u')")
+
+	servers, err := db.GetServers()
+	if err != nil {
+		t.Fatalf("GetServers: %v", err)
+	}
+	if len(servers) != 2 {
+		t.Fatalf("got %d servers, want 2", len(servers))
+	}
+	if servers[0].Name != "Alpha" {
+		t.Errorf("servers[0].Name = %q, want Alpha (ordered by name)", servers[0].Name)
+	}
+}
+
+func TestUpdateServer(t *testing.T) {
+	db := openTestDB(t)
+
+	mustExec(t, db, "INSERT INTO servers (id, name, type, url, username) VALUES ('s1', 'Old', 'subsonic', 'http://old', 'u')")
+
+	err := db.UpdateServer(Server{ID: "s1", Name: "New", Type: "subsonic", URL: "http://new", Username: "u2", Password: "p2"})
+	if err != nil {
+		t.Fatalf("UpdateServer: %v", err)
+	}
+
+	got, err := db.GetServer("s1")
+	if err != nil {
+		t.Fatalf("GetServer: %v", err)
+	}
+	if got.Name != "New" || got.URL != "http://new" || got.Username != "u2" || got.Password != "p2" {
+		t.Errorf("after update: %+v", got)
+	}
+}
+
+func TestDeleteServer(t *testing.T) {
+	db := openTestDB(t)
+
+	mustExec(t, db, "INSERT INTO servers (id, name, type, url, username) VALUES ('s1', 'Test', 'subsonic', 'http://t', 'u')")
+
+	if err := db.DeleteServer("s1"); err != nil {
+		t.Fatalf("DeleteServer: %v", err)
+	}
+
+	_, err := db.GetServer("s1")
+	if err == nil {
+		t.Error("expected error after delete, got nil")
+	}
+}
+
+func TestServersTableExists(t *testing.T) {
+	db := openTestDB(t)
+
+	var name string
+	err := db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='servers'").Scan(&name)
+	if err != nil {
+		t.Errorf("servers table not found: %v", err)
+	}
+}

--- a/internal/streaming/provider.go
+++ b/internal/streaming/provider.go
@@ -1,0 +1,55 @@
+// Package streaming defines the interface and domain types for music streaming providers.
+package streaming
+
+// Provider is the interface that all streaming backends must implement.
+type Provider interface {
+	Ping() error
+	GetArtists() ([]Artist, error)
+	GetAlbums(sortBy string, offset, count int) ([]Album, error)
+	GetAlbum(id string) (Album, []Track, error)
+	StreamURL(trackID string) string
+	CoverArtURL(coverArtID string) string
+	Search(query string) (SearchResults, error)
+}
+
+// Artist represents a music artist from a streaming server.
+type Artist struct {
+	ID         string
+	Name       string
+	AlbumCount int
+}
+
+// Album represents a music album from a streaming server.
+type Album struct {
+	ID         string
+	Title      string
+	Artist     string
+	ArtistID   string
+	Year       int
+	TrackCount int
+	CoverArtID string
+}
+
+// Track represents a single track from a streaming server.
+type Track struct {
+	ID          string
+	Title       string
+	Artist      string
+	ArtistID    string
+	Album       string
+	AlbumID     string
+	CoverArtID  string
+	DurationMs  int
+	TrackNumber int
+	DiscNumber  int
+	Genre       string
+	ContentType string
+	Size        int64
+}
+
+// SearchResults holds the results of a search query across artists, albums, and tracks.
+type SearchResults struct {
+	Artists []Artist
+	Albums  []Album
+	Tracks  []Track
+}

--- a/internal/streaming/subsonic/auth.go
+++ b/internal/streaming/subsonic/auth.go
@@ -1,0 +1,23 @@
+package subsonic
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+// generateSalt returns a random hex string of the given byte length.
+func generateSalt(length int) (string, error) {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate salt: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// generateToken computes the Subsonic authentication token: md5(password + salt).
+func generateToken(password, salt string) string {
+	sum := md5.Sum([]byte(password + salt))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/streaming/subsonic/auth_test.go
+++ b/internal/streaming/subsonic/auth_test.go
@@ -1,0 +1,32 @@
+package subsonic
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestGenerateToken(t *testing.T) {
+	// Known vector: md5("sesame" + "c19b2d") = "26719a1196d2a940705a59634eb18eab"
+	got := generateToken("sesame", "c19b2d")
+	want := "26719a1196d2a940705a59634eb18eab"
+	if got != want {
+		t.Errorf("generateToken = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateSalt(t *testing.T) {
+	salt, err := generateSalt(8)
+	if err != nil {
+		t.Fatalf("generateSalt: %v", err)
+	}
+
+	// 8 bytes = 16 hex characters.
+	if len(salt) != 16 {
+		t.Errorf("salt length = %d, want 16", len(salt))
+	}
+
+	// Must be valid hex.
+	if _, err := hex.DecodeString(salt); err != nil {
+		t.Errorf("salt is not valid hex: %v", err)
+	}
+}

--- a/internal/streaming/subsonic/client.go
+++ b/internal/streaming/subsonic/client.go
@@ -1,0 +1,210 @@
+// Package subsonic implements the Subsonic/OpenSubsonic streaming API client.
+package subsonic
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/willfish/forte/internal/streaming"
+)
+
+const (
+	apiVersion = "1.16.1"
+	clientName = "forte"
+)
+
+// Client is a Subsonic API client implementing streaming.Provider.
+type Client struct {
+	baseURL  string
+	username string
+	password string
+	http     *http.Client
+}
+
+// New creates a new Subsonic client.
+func New(baseURL, username, password string) *Client {
+	return &Client{
+		baseURL:  baseURL,
+		username: username,
+		password: password,
+		http:     http.DefaultClient,
+	}
+}
+
+// NewWithHTTPClient creates a new Subsonic client with a custom HTTP client.
+func NewWithHTTPClient(baseURL, username, password string, c *http.Client) *Client {
+	return &Client{
+		baseURL:  baseURL,
+		username: username,
+		password: password,
+		http:     c,
+	}
+}
+
+// authParams returns URL query parameters for authentication.
+func (c *Client) authParams() (url.Values, error) {
+	salt, err := generateSalt(8)
+	if err != nil {
+		return nil, err
+	}
+	return url.Values{
+		"u": {c.username},
+		"t": {generateToken(c.password, salt)},
+		"s": {salt},
+		"v": {apiVersion},
+		"c": {clientName},
+		"f": {"json"},
+	}, nil
+}
+
+// request makes an authenticated request to the Subsonic API.
+func (c *Client) request(method string, params url.Values) (*responseBody, error) {
+	auth, err := c.authParams()
+	if err != nil {
+		return nil, err
+	}
+
+	if params == nil {
+		params = url.Values{}
+	}
+	for k, v := range auth {
+		params[k] = v
+	}
+
+	reqURL := fmt.Sprintf("%s/rest/%s.view?%s", c.baseURL, method, params.Encode())
+	resp, err := c.http.Get(reqURL)
+	if err != nil {
+		return nil, fmt.Errorf("subsonic %s: %w", method, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var envelope subsonicResponse
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("subsonic %s: decode: %w", method, err)
+	}
+
+	body := &envelope.Response
+	if body.Status != "ok" && body.Error != nil {
+		return nil, body.Error
+	}
+
+	return body, nil
+}
+
+// Ping tests the connection to the Subsonic server.
+func (c *Client) Ping() error {
+	_, err := c.request("ping", nil)
+	return err
+}
+
+// GetArtists returns all artists, flattening the indexed structure.
+func (c *Client) GetArtists() ([]streaming.Artist, error) {
+	body, err := c.request("getArtists", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if body.Artists == nil {
+		return nil, nil
+	}
+
+	var artists []streaming.Artist
+	for _, idx := range body.Artists.Index {
+		for _, a := range idx.Artists {
+			artists = append(artists, convertArtist(a))
+		}
+	}
+	return artists, nil
+}
+
+// GetAlbums returns a paginated list of albums.
+func (c *Client) GetAlbums(sortBy string, offset, count int) ([]streaming.Album, error) {
+	body, err := c.request("getAlbumList2", url.Values{
+		"type":   {sortBy},
+		"offset": {fmt.Sprint(offset)},
+		"size":   {fmt.Sprint(count)},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if body.AlbumList == nil {
+		return nil, nil
+	}
+
+	albums := make([]streaming.Album, len(body.AlbumList.Albums))
+	for i, a := range body.AlbumList.Albums {
+		albums[i] = convertAlbum(a)
+	}
+	return albums, nil
+}
+
+// GetAlbum returns an album and its tracks.
+func (c *Client) GetAlbum(id string) (streaming.Album, []streaming.Track, error) {
+	body, err := c.request("getAlbum", url.Values{"id": {id}})
+	if err != nil {
+		return streaming.Album{}, nil, err
+	}
+
+	if body.Album == nil {
+		return streaming.Album{}, nil, fmt.Errorf("subsonic getAlbum: no album in response")
+	}
+
+	album := convertAlbum(body.Album.albumJSON)
+	tracks := make([]streaming.Track, len(body.Album.Songs))
+	for i, s := range body.Album.Songs {
+		tracks[i] = convertTrack(s)
+	}
+	return album, tracks, nil
+}
+
+// StreamURL returns an authenticated URL for streaming a track.
+// No HTTP request is made; mpv handles the URL directly.
+func (c *Client) StreamURL(trackID string) string {
+	auth, err := c.authParams()
+	if err != nil {
+		return ""
+	}
+	auth.Set("id", trackID)
+	return fmt.Sprintf("%s/rest/stream.view?%s", c.baseURL, auth.Encode())
+}
+
+// CoverArtURL returns an authenticated URL for fetching cover art.
+// No HTTP request is made.
+func (c *Client) CoverArtURL(coverArtID string) string {
+	auth, err := c.authParams()
+	if err != nil {
+		return ""
+	}
+	auth.Set("id", coverArtID)
+	return fmt.Sprintf("%s/rest/getCoverArt.view?%s", c.baseURL, auth.Encode())
+}
+
+// Search performs a search across artists, albums, and tracks.
+func (c *Client) Search(query string) (streaming.SearchResults, error) {
+	body, err := c.request("search3", url.Values{"query": {query}})
+	if err != nil {
+		return streaming.SearchResults{}, err
+	}
+
+	var results streaming.SearchResults
+	if body.Search == nil {
+		return results, nil
+	}
+
+	for _, a := range body.Search.Artists {
+		results.Artists = append(results.Artists, convertArtist(a))
+	}
+	for _, a := range body.Search.Albums {
+		results.Albums = append(results.Albums, convertAlbum(a))
+	}
+	for _, s := range body.Search.Songs {
+		results.Tracks = append(results.Tracks, convertTrack(s))
+	}
+	return results, nil
+}
+
+// Compile-time check that Client implements streaming.Provider.
+var _ streaming.Provider = (*Client)(nil)

--- a/internal/streaming/subsonic/client_test.go
+++ b/internal/streaming/subsonic/client_test.go
@@ -1,0 +1,321 @@
+package subsonic
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// cannedServer returns an httptest.Server that responds with canned JSON
+// keyed by the Subsonic method name extracted from the request path.
+func cannedServer(t *testing.T, responses map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Path is /rest/{method}.view
+		path := strings.TrimPrefix(r.URL.Path, "/rest/")
+		method := strings.TrimSuffix(path, ".view")
+
+		body, ok := responses[method]
+		if !ok {
+			t.Errorf("unexpected method: %s", method)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+func wrap(body any) map[string]any {
+	return map[string]any{
+		"subsonic-response": body,
+	}
+}
+
+func okBody(extra map[string]any) map[string]any {
+	body := map[string]any{
+		"status":  "ok",
+		"version": "1.16.1",
+	}
+	for k, v := range extra {
+		body[k] = v
+	}
+	return body
+}
+
+func TestPing(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"ping": wrap(okBody(nil)),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "admin", "admin")
+	if err := c.Ping(); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+}
+
+func TestPingAuthFailure(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"ping": wrap(map[string]any{
+			"status":  "failed",
+			"version": "1.16.1",
+			"error":   map[string]any{"code": 40, "message": "Wrong username or password"},
+		}),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "bad", "bad")
+	err := c.Ping()
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+
+	apiErr, ok := err.(*apiError)
+	if !ok {
+		t.Fatalf("expected *apiError, got %T", err)
+	}
+	if apiErr.Code != 40 {
+		t.Errorf("error code = %d, want 40", apiErr.Code)
+	}
+}
+
+func TestGetArtists(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"getArtists": wrap(okBody(map[string]any{
+			"artists": map[string]any{
+				"index": []map[string]any{
+					{
+						"name": "A",
+						"artist": []map[string]any{
+							{"id": "ar-1", "name": "ABBA", "albumCount": 10},
+						},
+					},
+					{
+						"name": "B",
+						"artist": []map[string]any{
+							{"id": "ar-2", "name": "Beatles", "albumCount": 13},
+							{"id": "ar-3", "name": "Bjork", "albumCount": 9},
+						},
+					},
+				},
+			},
+		})),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "admin", "admin")
+	artists, err := c.GetArtists()
+	if err != nil {
+		t.Fatalf("GetArtists: %v", err)
+	}
+
+	if len(artists) != 3 {
+		t.Fatalf("got %d artists, want 3", len(artists))
+	}
+	if artists[0].Name != "ABBA" {
+		t.Errorf("artists[0].Name = %q, want ABBA", artists[0].Name)
+	}
+	if artists[1].AlbumCount != 13 {
+		t.Errorf("artists[1].AlbumCount = %d, want 13", artists[1].AlbumCount)
+	}
+}
+
+func TestGetAlbums(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"getAlbumList2": wrap(okBody(map[string]any{
+			"albumList2": map[string]any{
+				"album": []map[string]any{
+					{"id": "al-1", "title": "Abbey Road", "artist": "Beatles", "artistId": "ar-2", "year": 1969, "songCount": 17, "coverArt": "al-1"},
+					{"id": "al-2", "title": "Arrival", "artist": "ABBA", "artistId": "ar-1", "year": 1976, "songCount": 10, "coverArt": "al-2"},
+				},
+			},
+		})),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "admin", "admin")
+	albums, err := c.GetAlbums("alphabeticalByName", 0, 20)
+	if err != nil {
+		t.Fatalf("GetAlbums: %v", err)
+	}
+
+	if len(albums) != 2 {
+		t.Fatalf("got %d albums, want 2", len(albums))
+	}
+	if albums[0].Title != "Abbey Road" {
+		t.Errorf("albums[0].Title = %q, want Abbey Road", albums[0].Title)
+	}
+	if albums[0].Year != 1969 {
+		t.Errorf("albums[0].Year = %d, want 1969", albums[0].Year)
+	}
+}
+
+func TestGetAlbum(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"getAlbum": wrap(okBody(map[string]any{
+			"album": map[string]any{
+				"id": "al-1", "title": "Abbey Road", "artist": "Beatles", "artistId": "ar-2",
+				"year": 1969, "songCount": 2, "coverArt": "al-1",
+				"song": []map[string]any{
+					{
+						"id": "tr-1", "title": "Come Together", "artist": "Beatles", "artistId": "ar-2",
+						"album": "Abbey Road", "albumId": "al-1", "coverArt": "al-1",
+						"duration": 259, "track": 1, "discNumber": 1,
+						"genre": "Rock", "contentType": "audio/flac", "size": 35000000,
+					},
+					{
+						"id": "tr-2", "title": "Something", "artist": "Beatles", "artistId": "ar-2",
+						"album": "Abbey Road", "albumId": "al-1", "coverArt": "al-1",
+						"duration": 182, "track": 2, "discNumber": 1,
+						"genre": "Rock", "contentType": "audio/flac", "size": 25000000,
+					},
+				},
+			},
+		})),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "admin", "admin")
+	album, tracks, err := c.GetAlbum("al-1")
+	if err != nil {
+		t.Fatalf("GetAlbum: %v", err)
+	}
+
+	if album.Title != "Abbey Road" {
+		t.Errorf("album.Title = %q, want Abbey Road", album.Title)
+	}
+	if len(tracks) != 2 {
+		t.Fatalf("got %d tracks, want 2", len(tracks))
+	}
+
+	// Duration should be converted from seconds to milliseconds.
+	if tracks[0].DurationMs != 259000 {
+		t.Errorf("tracks[0].DurationMs = %d, want 259000", tracks[0].DurationMs)
+	}
+	if tracks[1].DurationMs != 182000 {
+		t.Errorf("tracks[1].DurationMs = %d, want 182000", tracks[1].DurationMs)
+	}
+	if tracks[0].TrackNumber != 1 {
+		t.Errorf("tracks[0].TrackNumber = %d, want 1", tracks[0].TrackNumber)
+	}
+}
+
+func TestStreamURL(t *testing.T) {
+	c := New("http://localhost:4533", "admin", "admin")
+	u := c.StreamURL("tr-42")
+
+	if u == "" {
+		t.Fatal("StreamURL returned empty string")
+	}
+	if !strings.HasPrefix(u, "http://localhost:4533/rest/stream.view?") {
+		t.Errorf("unexpected URL prefix: %s", u)
+	}
+	if !strings.Contains(u, "id=tr-42") {
+		t.Errorf("URL missing track id: %s", u)
+	}
+	if !strings.Contains(u, "u=admin") {
+		t.Errorf("URL missing username: %s", u)
+	}
+}
+
+func TestCoverArtURL(t *testing.T) {
+	c := New("http://localhost:4533", "admin", "admin")
+	u := c.CoverArtURL("al-1")
+
+	if u == "" {
+		t.Fatal("CoverArtURL returned empty string")
+	}
+	if !strings.HasPrefix(u, "http://localhost:4533/rest/getCoverArt.view?") {
+		t.Errorf("unexpected URL prefix: %s", u)
+	}
+	if !strings.Contains(u, "id=al-1") {
+		t.Errorf("URL missing cover art id: %s", u)
+	}
+}
+
+func TestSearch(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"search3": wrap(okBody(map[string]any{
+			"searchResult3": map[string]any{
+				"artist": []map[string]any{
+					{"id": "ar-2", "name": "Beatles", "albumCount": 13},
+				},
+				"album": []map[string]any{
+					{"id": "al-1", "title": "Abbey Road", "artist": "Beatles", "artistId": "ar-2", "year": 1969, "songCount": 17, "coverArt": "al-1"},
+				},
+				"song": []map[string]any{
+					{"id": "tr-1", "title": "Come Together", "artist": "Beatles", "artistId": "ar-2", "album": "Abbey Road", "albumId": "al-1", "duration": 259},
+				},
+			},
+		})),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "admin", "admin")
+	results, err := c.Search("beatles")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	if len(results.Artists) != 1 {
+		t.Errorf("got %d artists, want 1", len(results.Artists))
+	}
+	if len(results.Albums) != 1 {
+		t.Errorf("got %d albums, want 1", len(results.Albums))
+	}
+	if len(results.Tracks) != 1 {
+		t.Errorf("got %d tracks, want 1", len(results.Tracks))
+	}
+}
+
+func TestSearchEmpty(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"search3": wrap(okBody(map[string]any{
+			"searchResult3": map[string]any{},
+		})),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "admin", "admin")
+	results, err := c.Search("zzzzz")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	if len(results.Artists) != 0 || len(results.Albums) != 0 || len(results.Tracks) != 0 {
+		t.Errorf("expected empty results, got artists=%d albums=%d tracks=%d",
+			len(results.Artists), len(results.Albums), len(results.Tracks))
+	}
+}
+
+func TestAPIError(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"getAlbum": wrap(map[string]any{
+			"status":  "failed",
+			"version": "1.16.1",
+			"error":   map[string]any{"code": 70, "message": "Album not found"},
+		}),
+	})
+	defer srv.Close()
+
+	c := New(srv.URL, "admin", "admin")
+	_, _, err := c.GetAlbum("nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	apiErr, ok := err.(*apiError)
+	if !ok {
+		t.Fatalf("expected *apiError, got %T", err)
+	}
+	if apiErr.Code != 70 {
+		t.Errorf("error code = %d, want 70", apiErr.Code)
+	}
+	if !strings.Contains(apiErr.Error(), "Album not found") {
+		t.Errorf("error message = %q, want to contain 'Album not found'", apiErr.Error())
+	}
+}

--- a/internal/streaming/subsonic/response.go
+++ b/internal/streaming/subsonic/response.go
@@ -1,0 +1,133 @@
+package subsonic
+
+import (
+	"fmt"
+
+	"github.com/willfish/forte/internal/streaming"
+)
+
+// subsonicResponse is the outer JSON envelope for all Subsonic API responses.
+type subsonicResponse struct {
+	Response responseBody `json:"subsonic-response"`
+}
+
+// responseBody is the inner body of a Subsonic API response.
+type responseBody struct {
+	Status  string `json:"status"`
+	Version string `json:"version"`
+
+	Error *apiError `json:"error,omitempty"`
+
+	// Endpoint-specific fields.
+	Artists    *artistIndex   `json:"artists,omitempty"`
+	AlbumList *albumList     `json:"albumList2,omitempty"`
+	Album     *albumDetail   `json:"album,omitempty"`
+	Search    *searchResult3 `json:"searchResult3,omitempty"`
+}
+
+// apiError represents an error returned by the Subsonic API.
+type apiError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *apiError) Error() string {
+	return fmt.Sprintf("subsonic error %d: %s", e.Code, e.Message)
+}
+
+// --- JSON structures matching the Subsonic API ---
+
+type artistIndex struct {
+	Index []indexEntry `json:"index"`
+}
+
+type indexEntry struct {
+	Artists []artistJSON `json:"artist"`
+}
+
+type artistJSON struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	AlbumCount int    `json:"albumCount"`
+}
+
+type albumList struct {
+	Albums []albumJSON `json:"album"`
+}
+
+type albumDetail struct {
+	albumJSON
+	Songs []songJSON `json:"song"`
+}
+
+type albumJSON struct {
+	ID         string `json:"id"`
+	Title      string `json:"title"`
+	Artist     string `json:"artist"`
+	ArtistID   string `json:"artistId"`
+	Year       int    `json:"year"`
+	SongCount  int    `json:"songCount"`
+	CoverArt   string `json:"coverArt"`
+}
+
+type songJSON struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Artist      string `json:"artist"`
+	ArtistID    string `json:"artistId"`
+	Album       string `json:"album"`
+	AlbumID     string `json:"albumId"`
+	CoverArt    string `json:"coverArt"`
+	Duration    int    `json:"duration"` // seconds
+	Track       int    `json:"track"`
+	DiscNumber  int    `json:"discNumber"`
+	Genre       string `json:"genre"`
+	ContentType string `json:"contentType"`
+	Size        int64  `json:"size"`
+}
+
+type searchResult3 struct {
+	Artists []artistJSON `json:"artist"`
+	Albums  []albumJSON  `json:"album"`
+	Songs   []songJSON   `json:"song"`
+}
+
+// --- Conversion functions ---
+
+func convertArtist(a artistJSON) streaming.Artist {
+	return streaming.Artist{
+		ID:         a.ID,
+		Name:       a.Name,
+		AlbumCount: a.AlbumCount,
+	}
+}
+
+func convertAlbum(a albumJSON) streaming.Album {
+	return streaming.Album{
+		ID:         a.ID,
+		Title:      a.Title,
+		Artist:     a.Artist,
+		ArtistID:   a.ArtistID,
+		Year:       a.Year,
+		TrackCount: a.SongCount,
+		CoverArtID: a.CoverArt,
+	}
+}
+
+func convertTrack(s songJSON) streaming.Track {
+	return streaming.Track{
+		ID:          s.ID,
+		Title:       s.Title,
+		Artist:      s.Artist,
+		ArtistID:    s.ArtistID,
+		Album:       s.Album,
+		AlbumID:     s.AlbumID,
+		CoverArtID:  s.CoverArt,
+		DurationMs:  s.Duration * 1000,
+		TrackNumber: s.Track,
+		DiscNumber:  s.DiscNumber,
+		Genre:       s.Genre,
+		ContentType: s.ContentType,
+		Size:        s.Size,
+	}
+}


### PR DESCRIPTION
## Summary

- Add `streaming.Provider` interface and domain types shared across all streaming backends
- Implement Subsonic client with token auth (v1.16.1), covering ping, artist/album/track browsing, search, and URL generation for streaming/cover art
- Add server credential CRUD with SQLite migration (servers table)
- 22 new tests (12 subsonic client + 5 server CRUD + 5 auth/helpers) all passing

## What's included

### New packages
- `internal/streaming/` - Provider interface, Artist/Album/Track/SearchResults domain types
- `internal/streaming/subsonic/` - Client, auth helpers (salt + md5 token), JSON response deserialization

### Modified
- `internal/library/schema.go` - migration003 (servers table)
- `internal/library/db.go` - register migration003
- `internal/library/servers.go` - AddServer, GetServer, GetServers, UpdateServer, DeleteServer

## Design decisions

- Token auth only (v1.13.0+) - covers Navidrome, Gonic, modern Airsonic
- `StreamURL`/`CoverArtURL` return strings (no HTTP call) - mpv handles URLs natively
- Server ID is TEXT to match existing `tracks.server_id` column
- No third-party HTTP library - stdlib is sufficient
- Plaintext password in SQLite - standard for desktop music players; filesystem is the trust boundary

## Test plan

- [x] Auth: known MD5 vector, salt length/hex validation
- [x] Client: all Provider methods tested via httptest with canned JSON
- [x] Error handling: API error code parsing, auth failure
- [x] Duration conversion: seconds to milliseconds
- [x] Server CRUD: full lifecycle (add, get, list, update, delete)
- [x] Migration: servers table exists after migration
- [x] go vet clean, golangci-lint 0 issues, go build succeeds