### PR TITLE
Implement Jellyfin API client

### DIFF
--- a/internal/streaming/jellyfin/client.go
+++ b/internal/streaming/jellyfin/client.go
@@ -1,0 +1,289 @@
+// Package jellyfin implements the Jellyfin streaming API client.
+package jellyfin
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/willfish/forte/internal/streaming"
+)
+
+// Client is a Jellyfin API client implementing streaming.Provider.
+type Client struct {
+	baseURL  string
+	username string
+	password string
+	http     *http.Client
+
+	token   string
+	userID  string
+	once    sync.Once
+	authErr error
+}
+
+// New creates a new Jellyfin client.
+func New(baseURL, username, password string) *Client {
+	return &Client{
+		baseURL:  baseURL,
+		username: username,
+		password: password,
+		http:     http.DefaultClient,
+	}
+}
+
+// NewWithHTTPClient creates a new Jellyfin client with a custom HTTP client.
+func NewWithHTTPClient(baseURL, username, password string, c *http.Client) *Client {
+	return &Client{
+		baseURL:  baseURL,
+		username: username,
+		password: password,
+		http:     c,
+	}
+}
+
+// deviceID returns a deterministic device identifier based on the server URL and username.
+func (c *Client) deviceID() string {
+	h := sha256.Sum256([]byte(c.baseURL + c.username))
+	return fmt.Sprintf("%x", h[:8])
+}
+
+// authHeader returns the MediaBrowser Authorization header value.
+// If authenticated, the token is included.
+func (c *Client) authHeader() string {
+	h := fmt.Sprintf(`MediaBrowser Client="forte", Device="Desktop", DeviceId="%s", Version="1.0.0"`, c.deviceID())
+	if c.token != "" {
+		h += fmt.Sprintf(`, Token="%s"`, c.token)
+	}
+	return h
+}
+
+// authenticate performs a one-time login to the Jellyfin server.
+func (c *Client) authenticate() {
+	c.once.Do(func() {
+		body := fmt.Sprintf(`{"Username":%q,"Pw":%q}`, c.username, c.password)
+		req, err := http.NewRequest("POST", c.baseURL+"/Users/AuthenticateByName", strings.NewReader(body))
+		if err != nil {
+			c.authErr = fmt.Errorf("jellyfin auth: %w", err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", c.authHeader())
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			c.authErr = fmt.Errorf("jellyfin auth: %w", err)
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			c.authErr = fmt.Errorf("jellyfin auth: status %d", resp.StatusCode)
+			return
+		}
+
+		var authResp authResponse
+		if err := json.NewDecoder(resp.Body).Decode(&authResp); err != nil {
+			c.authErr = fmt.Errorf("jellyfin auth: decode: %w", err)
+			return
+		}
+
+		c.token = authResp.AccessToken
+		c.userID = authResp.User.ID
+	})
+}
+
+// request makes an authenticated GET request to the Jellyfin API.
+func (c *Client) request(path string, params url.Values, target any) error {
+	c.authenticate()
+	if c.authErr != nil {
+		return c.authErr
+	}
+
+	reqURL := c.baseURL + path
+	if len(params) > 0 {
+		reqURL += "?" + params.Encode()
+	}
+
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("jellyfin %s: %w", path, err)
+	}
+	req.Header.Set("Authorization", c.authHeader())
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("jellyfin %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("jellyfin %s: status %d", path, resp.StatusCode)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		return fmt.Errorf("jellyfin %s: decode: %w", path, err)
+	}
+
+	return nil
+}
+
+// userPath returns a path under the authenticated user's namespace.
+func (c *Client) userPath(suffix string) string {
+	return fmt.Sprintf("/Users/%s%s", c.userID, suffix)
+}
+
+// Ping tests the connection to the Jellyfin server.
+// Does not require authentication.
+func (c *Client) Ping() error {
+	resp, err := c.http.Get(c.baseURL + "/System/Ping")
+	if err != nil {
+		return fmt.Errorf("jellyfin ping: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("jellyfin ping: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// GetArtists returns all album artists.
+func (c *Client) GetArtists() ([]streaming.Artist, error) {
+	c.authenticate()
+	if c.authErr != nil {
+		return nil, c.authErr
+	}
+
+	var result itemsResponse
+	if err := c.request("/Artists/AlbumArtists", url.Values{"userId": {c.userID}}, &result); err != nil {
+		return nil, err
+	}
+
+	artists := make([]streaming.Artist, len(result.Items))
+	for i, item := range result.Items {
+		artists[i] = convertArtist(item)
+	}
+	return artists, nil
+}
+
+// GetAlbums returns a paginated list of albums.
+func (c *Client) GetAlbums(sortBy string, offset, count int) ([]streaming.Album, error) {
+	c.authenticate()
+	if c.authErr != nil {
+		return nil, c.authErr
+	}
+
+	var result itemsResponse
+	if err := c.request(c.userPath("/Items"), url.Values{
+		"IncludeItemTypes": {"MusicAlbum"},
+		"Recursive":        {"true"},
+		"SortBy":           {mapSortBy(sortBy)},
+		"StartIndex":       {fmt.Sprint(offset)},
+		"Limit":            {fmt.Sprint(count)},
+	}, &result); err != nil {
+		return nil, err
+	}
+
+	albums := make([]streaming.Album, len(result.Items))
+	for i, item := range result.Items {
+		albums[i] = convertAlbum(item)
+	}
+	return albums, nil
+}
+
+// GetAlbum returns an album and its tracks.
+func (c *Client) GetAlbum(id string) (streaming.Album, []streaming.Track, error) {
+	c.authenticate()
+	if c.authErr != nil {
+		return streaming.Album{}, nil, c.authErr
+	}
+
+	var albumItem itemJSON
+	if err := c.request(c.userPath("/Items/"+id), nil, &albumItem); err != nil {
+		return streaming.Album{}, nil, err
+	}
+
+	var tracksResult itemsResponse
+	if err := c.request(c.userPath("/Items"), url.Values{
+		"ParentId": {id},
+		"SortBy":   {"ParentIndexNumber,IndexNumber"},
+	}, &tracksResult); err != nil {
+		return streaming.Album{}, nil, err
+	}
+
+	album := convertAlbum(albumItem)
+	tracks := make([]streaming.Track, len(tracksResult.Items))
+	for i, item := range tracksResult.Items {
+		tracks[i] = convertTrack(item)
+	}
+	return album, tracks, nil
+}
+
+// StreamURL returns a URL for streaming a track.
+// No HTTP request is made; mpv handles the URL directly.
+func (c *Client) StreamURL(trackID string) string {
+	return fmt.Sprintf("%s/Audio/%s/stream?static=true&api_key=%s", c.baseURL, trackID, c.token)
+}
+
+// CoverArtURL returns a URL for fetching cover art.
+// No HTTP request is made; Jellyfin serves images without auth.
+func (c *Client) CoverArtURL(coverArtID string) string {
+	return fmt.Sprintf("%s/Items/%s/Images/Primary?maxWidth=300", c.baseURL, coverArtID)
+}
+
+// Search performs a search across artists, albums, and tracks.
+func (c *Client) Search(query string) (streaming.SearchResults, error) {
+	c.authenticate()
+	if c.authErr != nil {
+		return streaming.SearchResults{}, c.authErr
+	}
+
+	var result itemsResponse
+	if err := c.request(c.userPath("/Items"), url.Values{
+		"SearchTerm":       {query},
+		"IncludeItemTypes": {"MusicArtist,MusicAlbum,Audio"},
+		"Recursive":        {"true"},
+		"Limit":            {"20"},
+	}, &result); err != nil {
+		return streaming.SearchResults{}, err
+	}
+
+	var results streaming.SearchResults
+	for _, item := range result.Items {
+		switch item.Type {
+		case "MusicArtist":
+			results.Artists = append(results.Artists, convertArtist(item))
+		case "MusicAlbum":
+			results.Albums = append(results.Albums, convertAlbum(item))
+		case "Audio":
+			results.Tracks = append(results.Tracks, convertTrack(item))
+		}
+	}
+	return results, nil
+}
+
+// mapSortBy converts provider-agnostic sort names to Jellyfin SortBy values.
+func mapSortBy(sortBy string) string {
+	switch sortBy {
+	case "alphabeticalByName":
+		return "SortName"
+	case "newest":
+		return "DateCreated"
+	case "recent":
+		return "DatePlayed"
+	case "frequent":
+		return "PlayCount"
+	case "random":
+		return "Random"
+	default:
+		return "SortName"
+	}
+}
+
+// Compile-time check that Client implements streaming.Provider.
+var _ streaming.Provider = (*Client)(nil)

--- a/internal/streaming/jellyfin/client_test.go
+++ b/internal/streaming/jellyfin/client_test.go
@@ -1,0 +1,368 @@
+package jellyfin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+const testUserID = "user-abc-123"
+const testToken = "fake-token-xyz"
+
+// cannedServer returns an httptest.Server with route matching on method + path.
+// Auth is pre-registered so all subsequent paths use the known userID.
+func cannedServer(t *testing.T, routes map[string]any) *httptest.Server {
+	t.Helper()
+
+	// Always register auth endpoint.
+	if _, ok := routes["POST /Users/AuthenticateByName"]; !ok {
+		routes["POST /Users/AuthenticateByName"] = authResponse{
+			AccessToken: testToken,
+			User:        authUser{ID: testUserID},
+		}
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+
+		body, ok := routes[key]
+		if !ok {
+			t.Errorf("unexpected request: %s", key)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+func newClient(srv *httptest.Server) *Client {
+	return NewWithHTTPClient(srv.URL, "admin", "admin", srv.Client())
+}
+
+func TestPing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/System/Ping" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "", "", srv.Client())
+	if err := c.Ping(); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+}
+
+func TestPingFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "", "", srv.Client())
+	if err := c.Ping(); err == nil {
+		t.Fatal("expected error from Ping")
+	}
+}
+
+func TestGetArtists(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"GET /Artists/AlbumArtists": itemsResponse{
+			Items: []itemJSON{
+				{ID: "ar-1", Name: "ABBA", ChildCount: 10},
+				{ID: "ar-2", Name: "Beatles", ChildCount: 13},
+			},
+			TotalRecordCount: 2,
+		},
+	})
+	defer srv.Close()
+
+	c := newClient(srv)
+	artists, err := c.GetArtists()
+	if err != nil {
+		t.Fatalf("GetArtists: %v", err)
+	}
+
+	if len(artists) != 2 {
+		t.Fatalf("got %d artists, want 2", len(artists))
+	}
+	if artists[0].Name != "ABBA" {
+		t.Errorf("artists[0].Name = %q, want ABBA", artists[0].Name)
+	}
+	if artists[0].AlbumCount != 10 {
+		t.Errorf("artists[0].AlbumCount = %d, want 10", artists[0].AlbumCount)
+	}
+	if artists[1].AlbumCount != 13 {
+		t.Errorf("artists[1].AlbumCount = %d, want 13", artists[1].AlbumCount)
+	}
+}
+
+func TestGetAlbums(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"GET /Users/" + testUserID + "/Items": itemsResponse{
+			Items: []itemJSON{
+				{
+					ID: "al-1", Name: "Abbey Road",
+					AlbumArtist:    "Beatles",
+					AlbumArtists:   []nameIDPair{{Name: "Beatles", ID: "ar-2"}},
+					ProductionYear: 1969, ChildCount: 17,
+				},
+				{
+					ID: "al-2", Name: "Arrival",
+					AlbumArtist:    "ABBA",
+					AlbumArtists:   []nameIDPair{{Name: "ABBA", ID: "ar-1"}},
+					ProductionYear: 1976, ChildCount: 10,
+				},
+			},
+			TotalRecordCount: 2,
+		},
+	})
+	defer srv.Close()
+
+	c := newClient(srv)
+	albums, err := c.GetAlbums("alphabeticalByName", 0, 20)
+	if err != nil {
+		t.Fatalf("GetAlbums: %v", err)
+	}
+
+	if len(albums) != 2 {
+		t.Fatalf("got %d albums, want 2", len(albums))
+	}
+	if albums[0].Title != "Abbey Road" {
+		t.Errorf("albums[0].Title = %q, want Abbey Road", albums[0].Title)
+	}
+	if albums[0].Year != 1969 {
+		t.Errorf("albums[0].Year = %d, want 1969", albums[0].Year)
+	}
+	if albums[0].TrackCount != 17 {
+		t.Errorf("albums[0].TrackCount = %d, want 17", albums[0].TrackCount)
+	}
+	if albums[0].ArtistID != "ar-2" {
+		t.Errorf("albums[0].ArtistID = %q, want ar-2", albums[0].ArtistID)
+	}
+}
+
+func TestGetAlbum(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"GET /Users/" + testUserID + "/Items/al-1": itemJSON{
+			ID: "al-1", Name: "Abbey Road",
+			AlbumArtist:    "Beatles",
+			AlbumArtists:   []nameIDPair{{Name: "Beatles", ID: "ar-2"}},
+			ProductionYear: 1969, ChildCount: 2,
+		},
+		"GET /Users/" + testUserID + "/Items": itemsResponse{
+			Items: []itemJSON{
+				{
+					ID: "tr-1", Name: "Come Together", Type: "Audio",
+					AlbumArtist:       "Beatles",
+					AlbumArtists:      []nameIDPair{{Name: "Beatles", ID: "ar-2"}},
+					Album:             "Abbey Road",
+					AlbumID:           "al-1",
+					RunTimeTicks:      2590000000,
+					IndexNumber:       1,
+					ParentIndexNumber: 1,
+					Genres:            []string{"Rock"},
+					MediaSources:      []mediaSource{{Container: "flac", Size: 35000000}},
+				},
+				{
+					ID: "tr-2", Name: "Something", Type: "Audio",
+					AlbumArtist:       "Beatles",
+					AlbumArtists:      []nameIDPair{{Name: "Beatles", ID: "ar-2"}},
+					Album:             "Abbey Road",
+					AlbumID:           "al-1",
+					RunTimeTicks:      1820000000,
+					IndexNumber:       2,
+					ParentIndexNumber: 1,
+					Genres:            []string{"Rock"},
+					MediaSources:      []mediaSource{{Container: "flac", Size: 25000000}},
+				},
+			},
+			TotalRecordCount: 2,
+		},
+	})
+	defer srv.Close()
+
+	c := newClient(srv)
+	album, tracks, err := c.GetAlbum("al-1")
+	if err != nil {
+		t.Fatalf("GetAlbum: %v", err)
+	}
+
+	if album.Title != "Abbey Road" {
+		t.Errorf("album.Title = %q, want Abbey Road", album.Title)
+	}
+	if album.CoverArtID != "al-1" {
+		t.Errorf("album.CoverArtID = %q, want al-1", album.CoverArtID)
+	}
+	if len(tracks) != 2 {
+		t.Fatalf("got %d tracks, want 2", len(tracks))
+	}
+	if tracks[0].DurationMs != 259000 {
+		t.Errorf("tracks[0].DurationMs = %d, want 259000", tracks[0].DurationMs)
+	}
+	if tracks[1].DurationMs != 182000 {
+		t.Errorf("tracks[1].DurationMs = %d, want 182000", tracks[1].DurationMs)
+	}
+	if tracks[0].TrackNumber != 1 {
+		t.Errorf("tracks[0].TrackNumber = %d, want 1", tracks[0].TrackNumber)
+	}
+	if tracks[0].Genre != "Rock" {
+		t.Errorf("tracks[0].Genre = %q, want Rock", tracks[0].Genre)
+	}
+	if tracks[0].ContentType != "audio/flac" {
+		t.Errorf("tracks[0].ContentType = %q, want audio/flac", tracks[0].ContentType)
+	}
+	if tracks[0].Size != 35000000 {
+		t.Errorf("tracks[0].Size = %d, want 35000000", tracks[0].Size)
+	}
+}
+
+func TestStreamURL(t *testing.T) {
+	srv := cannedServer(t, map[string]any{})
+	defer srv.Close()
+
+	c := newClient(srv)
+	// Force auth so token is populated.
+	c.authenticate()
+
+	u := c.StreamURL("tr-42")
+	if !strings.HasPrefix(u, srv.URL+"/Audio/tr-42/stream?") {
+		t.Errorf("unexpected URL prefix: %s", u)
+	}
+	if !strings.Contains(u, "static=true") {
+		t.Errorf("URL missing static=true: %s", u)
+	}
+	if !strings.Contains(u, "api_key="+testToken) {
+		t.Errorf("URL missing api_key: %s", u)
+	}
+}
+
+func TestCoverArtURL(t *testing.T) {
+	c := New("http://localhost:8096", "", "")
+	u := c.CoverArtURL("al-1")
+
+	if u != "http://localhost:8096/Items/al-1/Images/Primary?maxWidth=300" {
+		t.Errorf("unexpected URL: %s", u)
+	}
+}
+
+func TestSearch(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"GET /Users/" + testUserID + "/Items": itemsResponse{
+			Items: []itemJSON{
+				{ID: "ar-2", Name: "Beatles", Type: "MusicArtist", ChildCount: 13},
+				{
+					ID: "al-1", Name: "Abbey Road", Type: "MusicAlbum",
+					AlbumArtist:    "Beatles",
+					AlbumArtists:   []nameIDPair{{Name: "Beatles", ID: "ar-2"}},
+					ProductionYear: 1969, ChildCount: 17,
+				},
+				{
+					ID: "tr-1", Name: "Come Together", Type: "Audio",
+					AlbumArtist:  "Beatles",
+					AlbumArtists: []nameIDPair{{Name: "Beatles", ID: "ar-2"}},
+					Album:        "Abbey Road", AlbumID: "al-1",
+					RunTimeTicks: 2590000000,
+				},
+			},
+			TotalRecordCount: 3,
+		},
+	})
+	defer srv.Close()
+
+	c := newClient(srv)
+	results, err := c.Search("beatles")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	if len(results.Artists) != 1 {
+		t.Errorf("got %d artists, want 1", len(results.Artists))
+	}
+	if len(results.Albums) != 1 {
+		t.Errorf("got %d albums, want 1", len(results.Albums))
+	}
+	if len(results.Tracks) != 1 {
+		t.Errorf("got %d tracks, want 1", len(results.Tracks))
+	}
+}
+
+func TestSearchEmpty(t *testing.T) {
+	srv := cannedServer(t, map[string]any{
+		"GET /Users/" + testUserID + "/Items": itemsResponse{
+			Items:            []itemJSON{},
+			TotalRecordCount: 0,
+		},
+	})
+	defer srv.Close()
+
+	c := newClient(srv)
+	results, err := c.Search("zzzzz")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	if len(results.Artists) != 0 || len(results.Albums) != 0 || len(results.Tracks) != 0 {
+		t.Errorf("expected empty results, got artists=%d albums=%d tracks=%d",
+			len(results.Artists), len(results.Albums), len(results.Tracks))
+	}
+}
+
+func TestAuthFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/Users/AuthenticateByName" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "bad", "bad", srv.Client())
+	_, err := c.GetArtists()
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error should mention 401, got: %v", err)
+	}
+}
+
+func TestAuthCalledOnce(t *testing.T) {
+	var authCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/Users/AuthenticateByName" {
+			authCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(authResponse{
+				AccessToken: testToken,
+				User:        authUser{ID: testUserID},
+			})
+			return
+		}
+
+		// Respond to any GET with an empty items response.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(itemsResponse{})
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "admin", "admin", srv.Client())
+
+	// Make multiple requests.
+	_, _ = c.GetArtists()
+	_, _ = c.GetAlbums("alphabeticalByName", 0, 10)
+	_, _ = c.Search("test")
+
+	if n := authCalls.Load(); n != 1 {
+		t.Errorf("auth called %d times, want 1", n)
+	}
+}

--- a/internal/streaming/jellyfin/response.go
+++ b/internal/streaming/jellyfin/response.go
@@ -1,0 +1,130 @@
+package jellyfin
+
+import "github.com/willfish/forte/internal/streaming"
+
+// itemsResponse is the standard list wrapper for Jellyfin API responses.
+type itemsResponse struct {
+	Items            []itemJSON `json:"Items"`
+	TotalRecordCount int        `json:"TotalRecordCount"`
+}
+
+// itemJSON is the unified item struct used across Jellyfin API responses.
+// Artists, albums, and tracks are all represented as Items with different Type values.
+type itemJSON struct {
+	Name              string        `json:"Name"`
+	ID                string        `json:"Id"`
+	Type              string        `json:"Type"`
+	AlbumArtist       string        `json:"AlbumArtist"`
+	AlbumArtists      []nameIDPair  `json:"AlbumArtists"`
+	Artists           []string      `json:"Artists"`
+	Album             string        `json:"Album"`
+	AlbumID           string        `json:"AlbumId"`
+	ProductionYear    int           `json:"ProductionYear"`
+	ChildCount        int           `json:"ChildCount"`
+	RunTimeTicks      int64         `json:"RunTimeTicks"`
+	IndexNumber       int           `json:"IndexNumber"`
+	ParentIndexNumber int           `json:"ParentIndexNumber"`
+	MediaSources      []mediaSource `json:"MediaSources"`
+	ImageTags         map[string]string `json:"ImageTags"`
+	Genres            []string      `json:"Genres"`
+}
+
+// nameIDPair is used in AlbumArtists and ArtistItems arrays.
+type nameIDPair struct {
+	Name string `json:"Name"`
+	ID   string `json:"Id"`
+}
+
+// mediaSource holds container, size, and bitrate information for a track.
+type mediaSource struct {
+	Container string `json:"Container"`
+	Size      int64  `json:"Size"`
+	Bitrate   int    `json:"Bitrate"`
+}
+
+// authResponse is the response from /Users/AuthenticateByName.
+type authResponse struct {
+	AccessToken string   `json:"AccessToken"`
+	User        authUser `json:"User"`
+}
+
+// authUser holds the user ID from the auth response.
+type authUser struct {
+	ID string `json:"Id"`
+}
+
+// ticksToMs converts .NET ticks (100ns intervals) to milliseconds.
+func ticksToMs(ticks int64) int {
+	return int(ticks / 10_000)
+}
+
+func convertArtist(item itemJSON) streaming.Artist {
+	return streaming.Artist{
+		ID:         item.ID,
+		Name:       item.Name,
+		AlbumCount: item.ChildCount,
+	}
+}
+
+func convertAlbum(item itemJSON) streaming.Album {
+	artist := item.AlbumArtist
+	var artistID string
+	if len(item.AlbumArtists) > 0 {
+		artistID = item.AlbumArtists[0].ID
+		if artist == "" {
+			artist = item.AlbumArtists[0].Name
+		}
+	}
+
+	return streaming.Album{
+		ID:         item.ID,
+		Title:      item.Name,
+		Artist:     artist,
+		ArtistID:   artistID,
+		Year:       item.ProductionYear,
+		TrackCount: item.ChildCount,
+		CoverArtID: item.ID,
+	}
+}
+
+func convertTrack(item itemJSON) streaming.Track {
+	artist := item.AlbumArtist
+	var artistID string
+	if len(item.AlbumArtists) > 0 {
+		artistID = item.AlbumArtists[0].ID
+		if artist == "" {
+			artist = item.AlbumArtists[0].Name
+		}
+	}
+	if artist == "" && len(item.Artists) > 0 {
+		artist = item.Artists[0]
+	}
+
+	var genre string
+	if len(item.Genres) > 0 {
+		genre = item.Genres[0]
+	}
+
+	var contentType string
+	var size int64
+	if len(item.MediaSources) > 0 {
+		contentType = "audio/" + item.MediaSources[0].Container
+		size = item.MediaSources[0].Size
+	}
+
+	return streaming.Track{
+		ID:          item.ID,
+		Title:       item.Name,
+		Artist:      artist,
+		ArtistID:    artistID,
+		Album:       item.Album,
+		AlbumID:     item.AlbumID,
+		CoverArtID:  item.ID,
+		DurationMs:  ticksToMs(item.RunTimeTicks),
+		TrackNumber: item.IndexNumber,
+		DiscNumber:  item.ParentIndexNumber,
+		Genre:       genre,
+		ContentType: contentType,
+		Size:        size,
+	}
+}


### PR DESCRIPTION
Closes #37

### What?

- [x] Add Jellyfin JSON response structs and conversion functions (`response.go`)
- [x] Add Jellyfin client implementing `streaming.Provider` (`client.go`)
- [x] Add tests covering all provider methods, auth failure, and auth-called-once guarantee (`client_test.go`)

### Why?

Adds Jellyfin as a second streaming backend, mirroring the Subsonic client structure. Lazy auth via `sync.Once` keeps the constructor side-effect-free while streaming and cover art URLs are generated without HTTP calls.

### Design notes

- Auth: lazy via `sync.Once`, triggered on first authenticated request. `Ping` works without credentials.
- `DeviceId`: deterministic `sha256(baseURL + username)` to avoid ghost sessions in Jellyfin dashboard.
- Streaming: `static=true` for direct file serve - no transcoding; mpv handles all formats.
- Images: no auth needed - Jellyfin serves images publicly by default.
- `AlbumCount = ChildCount` to avoid N+1 requests.