### PR TITLE
Implement Last.fm scrobbling

### DIFF
--- a/frontend/bindings/github.com/willfish/forte/index.js
+++ b/frontend/bindings/github.com/willfish/forte/index.js
@@ -14,6 +14,7 @@ export {
     AlbumTrack,
     Playlist,
     PlaylistTrack,
+    ScrobbleConfigJSON,
     SearchResult,
     ServerConfig,
     ServerStatusJSON

--- a/frontend/bindings/github.com/willfish/forte/libraryservice.js
+++ b/frontend/bindings/github.com/willfish/forte/libraryservice.js
@@ -44,6 +44,15 @@ export function AlbumArtwork(albumID) {
 }
 
 /**
+ * CompleteLastFmAuth exchanges the authorized token for a session key.
+ * @param {string} token
+ * @returns {$CancellablePromise<void>}
+ */
+export function CompleteLastFmAuth(token) {
+    return $Call.ByID(3698942302, token);
+}
+
+/**
  * CreatePlaylist creates a new playlist and returns its ID.
  * @param {string} name
  * @returns {$CancellablePromise<number>}
@@ -68,6 +77,14 @@ export function DeletePlaylist(id) {
  */
 export function DeleteServer(id) {
     return $Call.ByID(3862467038, id);
+}
+
+/**
+ * DisconnectLastFm clears the Last.fm session key and username.
+ * @returns {$CancellablePromise<void>}
+ */
+export function DisconnectLastFm() {
+    return $Call.ByID(970487533);
 }
 
 /**
@@ -117,12 +134,22 @@ export function GetPlaylists() {
 }
 
 /**
+ * GetScrobbleConfig returns the current Last.fm scrobble configuration.
+ * @returns {$CancellablePromise<$models.ScrobbleConfigJSON>}
+ */
+export function GetScrobbleConfig() {
+    return $Call.ByID(3948527462).then(/** @type {($result: any) => any} */(($result) => {
+        return $$createType8($result);
+    }));
+}
+
+/**
  * GetServerStatuses returns the online/offline status of all configured servers.
  * @returns {$CancellablePromise<$models.ServerStatusJSON[]>}
  */
 export function GetServerStatuses() {
     return $Call.ByID(1839345631).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType9($result);
+        return $$createType10($result);
     }));
 }
 
@@ -132,7 +159,7 @@ export function GetServerStatuses() {
  */
 export function GetServers() {
     return $Call.ByID(3711954650).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType11($result);
+        return $$createType12($result);
     }));
 }
 
@@ -168,6 +195,16 @@ export function RenamePlaylist(id, name) {
 }
 
 /**
+ * SaveScrobbleAPIKeys saves the Last.fm API key and secret.
+ * @param {string} apiKey
+ * @param {string} apiSecret
+ * @returns {$CancellablePromise<void>}
+ */
+export function SaveScrobbleAPIKeys(apiKey, apiSecret) {
+    return $Call.ByID(1590775235, apiKey, apiSecret);
+}
+
+/**
  * Search searches the library for tracks matching the query.
  * @param {string} query
  * @param {number} limit
@@ -175,8 +212,26 @@ export function RenamePlaylist(id, name) {
  */
 export function Search(query, limit) {
     return $Call.ByID(2206755262, query, limit).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType13($result);
+        return $$createType14($result);
     }));
+}
+
+/**
+ * SetScrobbleEnabled toggles scrobbling on or off.
+ * @param {boolean} enabled
+ * @returns {$CancellablePromise<void>}
+ */
+export function SetScrobbleEnabled(enabled) {
+    return $Call.ByID(22544365, enabled);
+}
+
+/**
+ * StartLastFmAuth begins the Last.fm auth flow: requests a token and opens
+ * the browser for user approval. Returns the token for use with CompleteLastFmAuth.
+ * @returns {$CancellablePromise<string>}
+ */
+export function StartLastFmAuth() {
+    return $Call.ByID(1558738173);
 }
 
 /**
@@ -214,9 +269,10 @@ const $$createType4 = $models.PlaylistTrack.createFrom;
 const $$createType5 = $Create.Array($$createType4);
 const $$createType6 = $models.Playlist.createFrom;
 const $$createType7 = $Create.Array($$createType6);
-const $$createType8 = $models.ServerStatusJSON.createFrom;
-const $$createType9 = $Create.Array($$createType8);
-const $$createType10 = $models.ServerConfig.createFrom;
-const $$createType11 = $Create.Array($$createType10);
-const $$createType12 = $models.SearchResult.createFrom;
-const $$createType13 = $Create.Array($$createType12);
+const $$createType8 = $models.ScrobbleConfigJSON.createFrom;
+const $$createType9 = $models.ServerStatusJSON.createFrom;
+const $$createType10 = $Create.Array($$createType9);
+const $$createType11 = $models.ServerConfig.createFrom;
+const $$createType12 = $Create.Array($$createType11);
+const $$createType13 = $models.SearchResult.createFrom;
+const $$createType14 = $Create.Array($$createType13);

--- a/frontend/bindings/github.com/willfish/forte/models.js
+++ b/frontend/bindings/github.com/willfish/forte/models.js
@@ -278,6 +278,59 @@ export class PlaylistTrack {
 }
 
 /**
+ * ScrobbleConfigJSON is the JSON-friendly scrobble config exposed to the frontend.
+ * APISecret is intentionally omitted.
+ */
+export class ScrobbleConfigJSON {
+    /**
+     * Creates a new ScrobbleConfigJSON instance.
+     * @param {Partial<ScrobbleConfigJSON>} [$$source = {}] - The source object to create the ScrobbleConfigJSON.
+     */
+    constructor($$source = {}) {
+        if (!("apiKey" in $$source)) {
+            /**
+             * @member
+             * @type {string}
+             */
+            this["apiKey"] = "";
+        }
+        if (!("sessionKey" in $$source)) {
+            /**
+             * @member
+             * @type {string}
+             */
+            this["sessionKey"] = "";
+        }
+        if (!("username" in $$source)) {
+            /**
+             * @member
+             * @type {string}
+             */
+            this["username"] = "";
+        }
+        if (!("enabled" in $$source)) {
+            /**
+             * @member
+             * @type {boolean}
+             */
+            this["enabled"] = false;
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new ScrobbleConfigJSON instance from a string or object.
+     * @param {any} [$$source = {}]
+     * @returns {ScrobbleConfigJSON}
+     */
+    static createFrom($$source = {}) {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new ScrobbleConfigJSON(/** @type {Partial<ScrobbleConfigJSON>} */($$parsedSource));
+    }
+}
+
+/**
  * SearchResult is the JSON-friendly search result type exposed to the frontend.
  */
 export class SearchResult {

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -124,6 +124,97 @@
     if (!editing) return false;
     return editing.name.trim() !== '' && editing.url.trim() !== '' && editing.username.trim() !== '';
   }
+
+  // Last.fm scrobble state
+  type ScrobbleConfig = {
+    apiKey: string;
+    sessionKey: string;
+    username: string;
+    enabled: boolean;
+  };
+
+  let scrobbleConfig = $state<ScrobbleConfig | null>(null);
+  let lfmApiKey = $state('');
+  let lfmApiSecret = $state('');
+  let lfmAuthToken = $state('');
+  let lfmConnecting = $state(false);
+  let lfmResult = $state<{ ok: boolean; message: string } | null>(null);
+
+  async function loadScrobbleConfig() {
+    try {
+      const cfg = await LibraryService.GetScrobbleConfig();
+      scrobbleConfig = cfg;
+      lfmApiKey = cfg.apiKey || '';
+    } catch {
+      scrobbleConfig = null;
+    }
+  }
+
+  $effect(() => {
+    loadScrobbleConfig();
+  });
+
+  async function saveApiKeys() {
+    lfmResult = null;
+    try {
+      await LibraryService.SaveScrobbleAPIKeys(lfmApiKey, lfmApiSecret);
+      lfmApiSecret = '';
+      lfmResult = { ok: true, message: 'API keys saved' };
+      await loadScrobbleConfig();
+    } catch (err: any) {
+      lfmResult = { ok: false, message: err?.message || String(err) };
+    }
+  }
+
+  async function startLastFmAuth() {
+    lfmConnecting = true;
+    lfmResult = null;
+    try {
+      const token = await LibraryService.StartLastFmAuth();
+      lfmAuthToken = token;
+      lfmResult = { ok: true, message: 'Browser opened - approve the request, then click "Complete authentication"' };
+    } catch (err: any) {
+      lfmResult = { ok: false, message: err?.message || String(err) };
+    } finally {
+      lfmConnecting = false;
+    }
+  }
+
+  async function completeLastFmAuth() {
+    lfmConnecting = true;
+    lfmResult = null;
+    try {
+      await LibraryService.CompleteLastFmAuth(lfmAuthToken);
+      lfmAuthToken = '';
+      lfmResult = { ok: true, message: 'Connected to Last.fm' };
+      await loadScrobbleConfig();
+    } catch (err: any) {
+      lfmResult = { ok: false, message: err?.message || String(err) };
+    } finally {
+      lfmConnecting = false;
+    }
+  }
+
+  async function disconnectLastFm() {
+    lfmResult = null;
+    try {
+      await LibraryService.DisconnectLastFm();
+      lfmAuthToken = '';
+      await loadScrobbleConfig();
+    } catch (err: any) {
+      lfmResult = { ok: false, message: err?.message || String(err) };
+    }
+  }
+
+  async function toggleScrobbleEnabled() {
+    if (!scrobbleConfig) return;
+    try {
+      await LibraryService.SetScrobbleEnabled(!scrobbleConfig.enabled);
+      await loadScrobbleConfig();
+    } catch (err: any) {
+      lfmResult = { ok: false, message: err?.message || String(err) };
+    }
+  }
 </script>
 
 <div class="settings">
@@ -258,6 +349,57 @@
           {/if}
         </div>
       {/if}
+    {/if}
+  </section>
+
+  <section class="section">
+    <h3>Last.fm</h3>
+
+    {#if scrobbleConfig?.sessionKey}
+      <div class="lfm-connected">
+        <p class="lfm-status">Connected as <strong>{scrobbleConfig.username}</strong></p>
+        <label class="lfm-toggle">
+          <input type="checkbox" checked={scrobbleConfig.enabled} onchange={toggleScrobbleEnabled} />
+          Scrobbling {scrobbleConfig.enabled ? 'enabled' : 'disabled'}
+        </label>
+        <button class="btn-cancel" onclick={disconnectLastFm}>Disconnect</button>
+      </div>
+    {:else if scrobbleConfig?.apiKey && !lfmAuthToken}
+      <div class="lfm-auth">
+        <p class="lfm-status">API key configured. Connect your Last.fm account to start scrobbling.</p>
+        <button class="btn-save" onclick={startLastFmAuth} disabled={lfmConnecting}>
+          {lfmConnecting ? 'Opening browser...' : 'Connect to Last.fm'}
+        </button>
+      </div>
+    {:else if lfmAuthToken}
+      <div class="lfm-auth">
+        <p class="lfm-status">Approve the request in your browser, then click below.</p>
+        <button class="btn-save" onclick={completeLastFmAuth} disabled={lfmConnecting}>
+          {lfmConnecting ? 'Verifying...' : 'Complete authentication'}
+        </button>
+      </div>
+    {:else}
+      <div class="server-form">
+        <div class="form-field">
+          <label for="lfm-key">API Key</label>
+          <input id="lfm-key" type="text" bind:value={lfmApiKey} placeholder="Your Last.fm API key" />
+        </div>
+        <div class="form-field">
+          <label for="lfm-secret">API Secret</label>
+          <input id="lfm-secret" type="password" bind:value={lfmApiSecret} placeholder="Your Last.fm API secret" />
+        </div>
+        <div class="form-actions">
+          <button class="btn-save" onclick={saveApiKeys} disabled={!lfmApiKey.trim() || !lfmApiSecret.trim()}>
+            Save
+          </button>
+        </div>
+      </div>
+    {/if}
+
+    {#if lfmResult}
+      <div class="test-result" class:ok={lfmResult.ok} class:err={!lfmResult.ok}>
+        {lfmResult.message}
+      </div>
     {/if}
   </section>
 </div>
@@ -678,5 +820,37 @@
 
   .sync-result.err {
     color: #e55;
+  }
+
+  /* Last.fm */
+  .lfm-connected {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .lfm-status {
+    font-size: 0.9rem;
+    color: var(--text-primary);
+    margin: 0;
+  }
+
+  .lfm-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--text-primary);
+    cursor: pointer;
+  }
+
+  .lfm-toggle input {
+    accent-color: var(--accent);
+  }
+
+  .lfm-auth {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
   }
 </style>

--- a/internal/library/db.go
+++ b/internal/library/db.go
@@ -92,4 +92,5 @@ var migrations = []migration{
 	{version: 2, sql: migration002},
 	{version: 3, sql: migration003},
 	{version: 4, sql: migration004},
+	{version: 5, sql: migration005},
 }

--- a/internal/library/schema.go
+++ b/internal/library/schema.go
@@ -112,3 +112,15 @@ ALTER TABLE albums ADD COLUMN remote_id TEXT NOT NULL DEFAULT '';
 CREATE INDEX idx_albums_server ON albums (server_id);
 CREATE INDEX idx_tracks_server ON tracks (server_id);
 `
+
+const migration005 = `
+CREATE TABLE scrobble_config (
+	id          INTEGER PRIMARY KEY CHECK (id = 1),
+	api_key     TEXT NOT NULL DEFAULT '',
+	api_secret  TEXT NOT NULL DEFAULT '',
+	session_key TEXT NOT NULL DEFAULT '',
+	username    TEXT NOT NULL DEFAULT '',
+	enabled     INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO scrobble_config (id) VALUES (1);
+`

--- a/internal/library/scrobble_config.go
+++ b/internal/library/scrobble_config.go
@@ -1,0 +1,45 @@
+package library
+
+// ScrobbleConfig holds Last.fm scrobbling configuration.
+type ScrobbleConfig struct {
+	APIKey     string
+	APISecret  string
+	SessionKey string
+	Username   string
+	Enabled    bool
+}
+
+// SaveScrobbleConfig upserts the single scrobble config row.
+func (db *DB) SaveScrobbleConfig(cfg ScrobbleConfig) error {
+	enabled := 0
+	if cfg.Enabled {
+		enabled = 1
+	}
+	_, err := db.Exec(`
+		UPDATE scrobble_config SET
+			api_key = ?,
+			api_secret = ?,
+			session_key = ?,
+			username = ?,
+			enabled = ?
+		WHERE id = 1`,
+		cfg.APIKey, cfg.APISecret, cfg.SessionKey, cfg.Username, enabled,
+	)
+	return err
+}
+
+// LoadScrobbleConfig reads the persisted scrobble configuration.
+// Returns a zero-value config if no row exists.
+func (db *DB) LoadScrobbleConfig() (ScrobbleConfig, error) {
+	var cfg ScrobbleConfig
+	var enabled int
+	err := db.QueryRow(`
+		SELECT api_key, api_secret, session_key, username, enabled
+		FROM scrobble_config WHERE id = 1`,
+	).Scan(&cfg.APIKey, &cfg.APISecret, &cfg.SessionKey, &cfg.Username, &enabled)
+	if err != nil {
+		return ScrobbleConfig{}, err
+	}
+	cfg.Enabled = enabled != 0
+	return cfg, nil
+}

--- a/internal/scrobbling/lastfm/lastfm.go
+++ b/internal/scrobbling/lastfm/lastfm.go
@@ -1,0 +1,180 @@
+// Package lastfm provides stateless functions for the Last.fm Scrobbling API v2.
+package lastfm
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+const apiURL = "https://ws.audioscrobbler.com/2.0/"
+
+// TrackInfo holds metadata for a now-playing or scrobble call.
+type TrackInfo struct {
+	Artist   string
+	Track    string
+	Album    string
+	Duration int // seconds
+}
+
+// GetToken requests an unauthorized request token from Last.fm.
+func GetToken(apiKey, apiSecret string) (string, error) {
+	params := map[string]string{
+		"method":  "auth.getToken",
+		"api_key": apiKey,
+	}
+	body, err := apiCall(params, apiSecret)
+	if err != nil {
+		return "", err
+	}
+	var resp struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("lastfm: parse token response: %w", err)
+	}
+	if resp.Token == "" {
+		return "", fmt.Errorf("lastfm: empty token in response")
+	}
+	return resp.Token, nil
+}
+
+// AuthURL returns the Last.fm URL the user should visit to authorize the token.
+func AuthURL(apiKey, token string) string {
+	return fmt.Sprintf("https://www.last.fm/api/auth/?api_key=%s&token=%s", url.QueryEscape(apiKey), url.QueryEscape(token))
+}
+
+// GetSession exchanges an authorized token for a session key.
+func GetSession(apiKey, apiSecret, token string) (sessionKey, username string, err error) {
+	params := map[string]string{
+		"method":  "auth.getSession",
+		"api_key": apiKey,
+		"token":   token,
+	}
+	body, err := apiCall(params, apiSecret)
+	if err != nil {
+		return "", "", err
+	}
+	var resp struct {
+		Session struct {
+			Key  string `json:"key"`
+			Name string `json:"name"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", "", fmt.Errorf("lastfm: parse session response: %w", err)
+	}
+	if resp.Session.Key == "" {
+		return "", "", fmt.Errorf("lastfm: empty session key in response")
+	}
+	return resp.Session.Key, resp.Session.Name, nil
+}
+
+// NowPlaying sends a "now playing" notification to Last.fm.
+func NowPlaying(apiKey, apiSecret, sessionKey string, t TrackInfo) error {
+	params := map[string]string{
+		"method":  "track.updateNowPlaying",
+		"api_key": apiKey,
+		"sk":      sessionKey,
+		"artist":  t.Artist,
+		"track":   t.Track,
+	}
+	if t.Album != "" {
+		params["album"] = t.Album
+	}
+	if t.Duration > 0 {
+		params["duration"] = fmt.Sprintf("%d", t.Duration)
+	}
+	_, err := apiCall(params, apiSecret)
+	return err
+}
+
+// Scrobble submits a completed track listen to Last.fm.
+func Scrobble(apiKey, apiSecret, sessionKey string, t TrackInfo, timestamp int64) error {
+	params := map[string]string{
+		"method":    "track.scrobble",
+		"api_key":   apiKey,
+		"sk":        sessionKey,
+		"artist":    t.Artist,
+		"track":     t.Track,
+		"timestamp": fmt.Sprintf("%d", timestamp),
+	}
+	if t.Album != "" {
+		params["album"] = t.Album
+	}
+	_, err := apiCall(params, apiSecret)
+	return err
+}
+
+// ScrobbleThreshold returns the duration in milliseconds after which a track
+// should be scrobbled: 50% of duration or 4 minutes, whichever is smaller.
+func ScrobbleThreshold(durationMs int) int {
+	half := durationMs / 2
+	fourMin := 240_000
+	if half < fourMin {
+		return half
+	}
+	return fourMin
+}
+
+// sign computes the Last.fm API signature: sort params by key, concat
+// key+value pairs, append secret, MD5 the result.
+func sign(params map[string]string, secret string) string {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		if k == "format" {
+			continue // format is excluded from signature
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf strings.Builder
+	for _, k := range keys {
+		buf.WriteString(k)
+		buf.WriteString(params[k])
+	}
+	buf.WriteString(secret)
+
+	return fmt.Sprintf("%x", md5.Sum([]byte(buf.String())))
+}
+
+// apiCall signs and POSTs to the Last.fm API, returning the JSON response body.
+func apiCall(params map[string]string, secret string) ([]byte, error) {
+	params["format"] = "json"
+	params["api_sig"] = sign(params, secret)
+
+	form := url.Values{}
+	for k, v := range params {
+		form.Set(k, v)
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.PostForm(apiURL, form)
+	if err != nil {
+		return nil, fmt.Errorf("lastfm: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("lastfm: read response: %w", err)
+	}
+
+	// Check for API-level errors.
+	var errResp struct {
+		Error   int    `json:"error"`
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(body, &errResp) == nil && errResp.Error != 0 {
+		return nil, fmt.Errorf("lastfm: API error %d: %s", errResp.Error, errResp.Message)
+	}
+
+	return body, nil
+}

--- a/internal/scrobbling/lastfm/lastfm_test.go
+++ b/internal/scrobbling/lastfm/lastfm_test.go
@@ -1,0 +1,150 @@
+package lastfm
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSign(t *testing.T) {
+	params := map[string]string{
+		"api_key": "xxxxxxxxxx",
+		"method":  "auth.getToken",
+		"format":  "json",
+	}
+	got := sign(params, "secret123")
+
+	// sorted keys (excluding "format"): api_key, method
+	// concat: "api_keyxxxxxxxxxxmethodauth.getTokensecret123"
+	want := "50e53cda5eb80b3e7aec64150f0d8f90"
+	if got != want {
+		t.Errorf("sign() = %q, want %q", got, want)
+	}
+}
+
+func TestSignExcludesFormat(t *testing.T) {
+	params1 := map[string]string{
+		"api_key": "key",
+		"method":  "test",
+	}
+	params2 := map[string]string{
+		"api_key": "key",
+		"method":  "test",
+		"format":  "json",
+	}
+	if sign(params1, "sec") != sign(params2, "sec") {
+		t.Error("sign() should produce the same result regardless of 'format' param")
+	}
+}
+
+func TestScrobbleThreshold(t *testing.T) {
+	tests := []struct {
+		name       string
+		durationMs int
+		want       int
+	}{
+		{"short track 60s", 60_000, 30_000},
+		{"medium track 5m", 300_000, 150_000},
+		{"long track 10m", 600_000, 240_000},
+		{"very long track 20m", 1_200_000, 240_000},
+		{"exact 8m boundary", 480_000, 240_000},
+		{"zero duration", 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScrobbleThreshold(tt.durationMs)
+			if got != tt.want {
+				t.Errorf("ScrobbleThreshold(%d) = %d, want %d", tt.durationMs, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNowPlayingParams(t *testing.T) {
+	track := TrackInfo{
+		Artist:   "Radiohead",
+		Track:    "Idioteque",
+		Album:    "Kid A",
+		Duration: 300,
+	}
+	params := map[string]string{
+		"method":   "track.updateNowPlaying",
+		"api_key":  "testkey",
+		"sk":       "testsession",
+		"artist":   track.Artist,
+		"track":    track.Track,
+		"album":    track.Album,
+		"duration": "300",
+	}
+	sig := sign(params, "testsecret")
+	if sig == "" {
+		t.Error("sign() returned empty string")
+	}
+	for _, key := range []string{"method", "api_key", "sk", "artist", "track", "album", "duration"} {
+		if _, ok := params[key]; !ok {
+			t.Errorf("missing expected param %q", key)
+		}
+	}
+}
+
+func TestScrobbleParams(t *testing.T) {
+	params := map[string]string{
+		"method":    "track.scrobble",
+		"api_key":   "testkey",
+		"sk":        "testsession",
+		"artist":    "Portishead",
+		"track":     "Glory Box",
+		"album":     "Dummy",
+		"timestamp": "1700000000",
+	}
+	sig := sign(params, "testsecret")
+	if sig == "" {
+		t.Error("sign() returned empty string")
+	}
+	if params["method"] != "track.scrobble" {
+		t.Error("method should be track.scrobble")
+	}
+}
+
+func TestAuthURL(t *testing.T) {
+	got := AuthURL("mykey", "mytoken")
+	want := "https://www.last.fm/api/auth/?api_key=mykey&token=mytoken"
+	if got != want {
+		t.Errorf("AuthURL() = %q, want %q", got, want)
+	}
+}
+
+func TestGetSessionResponseParsing(t *testing.T) {
+	body := []byte(`{"session":{"name":"testuser","key":"abc123","subscriber":0}}`)
+	var resp struct {
+		Session struct {
+			Key  string `json:"key"`
+			Name string `json:"name"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Session.Key != "abc123" {
+		t.Errorf("session key = %q, want %q", resp.Session.Key, "abc123")
+	}
+	if resp.Session.Name != "testuser" {
+		t.Errorf("username = %q, want %q", resp.Session.Name, "testuser")
+	}
+}
+
+func TestAPIErrorParsing(t *testing.T) {
+	body := []byte(`{"error":14,"message":"Unauthorized Token"}`)
+	var errResp struct {
+		Error   int    `json:"error"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if errResp.Error != 14 {
+		t.Errorf("error code = %d, want 14", errResp.Error)
+	}
+	if errResp.Message != "Unauthorized Token" {
+		t.Errorf("message = %q, want %q", errResp.Message, "Unauthorized Token")
+	}
+}

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/pkg/browser"
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/willfish/forte/internal/library"
+	"github.com/willfish/forte/internal/scrobbling/lastfm"
 	"github.com/willfish/forte/internal/streaming/jellyfin"
 	"github.com/willfish/forte/internal/streaming/subsonic"
 )
@@ -470,6 +472,117 @@ func (s *LibraryService) TestConnection(cfg ServerConfig) error {
 	default:
 		return fmt.Errorf("unknown server type: %s", cfg.Type)
 	}
+}
+
+// ScrobbleConfigJSON is the JSON-friendly scrobble config exposed to the frontend.
+// APISecret is intentionally omitted.
+type ScrobbleConfigJSON struct {
+	APIKey     string `json:"apiKey"`
+	SessionKey string `json:"sessionKey"`
+	Username   string `json:"username"`
+	Enabled    bool   `json:"enabled"`
+}
+
+// GetScrobbleConfig returns the current Last.fm scrobble configuration.
+func (s *LibraryService) GetScrobbleConfig() (ScrobbleConfigJSON, error) {
+	if s.db == nil {
+		return ScrobbleConfigJSON{}, fmt.Errorf("library not initialised")
+	}
+	cfg, err := s.db.LoadScrobbleConfig()
+	if err != nil {
+		return ScrobbleConfigJSON{}, err
+	}
+	return ScrobbleConfigJSON{
+		APIKey:     cfg.APIKey,
+		SessionKey: cfg.SessionKey,
+		Username:   cfg.Username,
+		Enabled:    cfg.Enabled,
+	}, nil
+}
+
+// SaveScrobbleAPIKeys saves the Last.fm API key and secret.
+func (s *LibraryService) SaveScrobbleAPIKeys(apiKey, apiSecret string) error {
+	if s.db == nil {
+		return fmt.Errorf("library not initialised")
+	}
+	cfg, err := s.db.LoadScrobbleConfig()
+	if err != nil {
+		return err
+	}
+	cfg.APIKey = apiKey
+	cfg.APISecret = apiSecret
+	return s.db.SaveScrobbleConfig(cfg)
+}
+
+// StartLastFmAuth begins the Last.fm auth flow: requests a token and opens
+// the browser for user approval. Returns the token for use with CompleteLastFmAuth.
+func (s *LibraryService) StartLastFmAuth() (string, error) {
+	if s.db == nil {
+		return "", fmt.Errorf("library not initialised")
+	}
+	cfg, err := s.db.LoadScrobbleConfig()
+	if err != nil {
+		return "", err
+	}
+	if cfg.APIKey == "" || cfg.APISecret == "" {
+		return "", fmt.Errorf("API key and secret must be configured first")
+	}
+	token, err := lastfm.GetToken(cfg.APIKey, cfg.APISecret)
+	if err != nil {
+		return "", err
+	}
+	authURL := lastfm.AuthURL(cfg.APIKey, token)
+	if err := browser.OpenURL(authURL); err != nil {
+		log.Printf("lastfm: failed to open browser: %v", err)
+	}
+	return token, nil
+}
+
+// CompleteLastFmAuth exchanges the authorized token for a session key.
+func (s *LibraryService) CompleteLastFmAuth(token string) error {
+	if s.db == nil {
+		return fmt.Errorf("library not initialised")
+	}
+	cfg, err := s.db.LoadScrobbleConfig()
+	if err != nil {
+		return err
+	}
+	sessionKey, username, err := lastfm.GetSession(cfg.APIKey, cfg.APISecret, token)
+	if err != nil {
+		return err
+	}
+	cfg.SessionKey = sessionKey
+	cfg.Username = username
+	cfg.Enabled = true
+	return s.db.SaveScrobbleConfig(cfg)
+}
+
+// DisconnectLastFm clears the Last.fm session key and username.
+func (s *LibraryService) DisconnectLastFm() error {
+	if s.db == nil {
+		return fmt.Errorf("library not initialised")
+	}
+	cfg, err := s.db.LoadScrobbleConfig()
+	if err != nil {
+		return err
+	}
+	cfg.SessionKey = ""
+	cfg.Username = ""
+	cfg.Enabled = false
+	return s.db.SaveScrobbleConfig(cfg)
+}
+
+// SetScrobbleEnabled toggles scrobbling on or off.
+func (s *LibraryService) SetScrobbleEnabled(enabled bool) error {
+	if s.db == nil {
+		return fmt.Errorf("library not initialised")
+	}
+	cfg, err := s.db.LoadScrobbleConfig()
+	if err != nil {
+		return err
+	}
+	cfg.Enabled = enabled
+	return s.db.SaveScrobbleConfig(cfg)
 }
 
 // newUUID generates a random UUID v4 string.

--- a/playerservice.go
+++ b/playerservice.go
@@ -15,6 +15,7 @@ import (
 	"github.com/willfish/forte/internal/library"
 	"github.com/willfish/forte/internal/metadata"
 	"github.com/willfish/forte/internal/player"
+	"github.com/willfish/forte/internal/scrobbling/lastfm"
 	"github.com/willfish/forte/internal/system"
 )
 
@@ -31,6 +32,11 @@ type PlayerService struct {
 	onTrayUpdate   func(title, artist string) // set by main.go for tooltip updates
 	manualSkip     int32                      // atomic: set before explicit Next/Previous to suppress auto-advance
 	stopSave       chan struct{}
+
+	// Scrobble tracking state.
+	scrobbleTrackID int64
+	scrobbleElapsed time.Duration
+	scrobbled       bool
 }
 
 // ServiceStartup initialises the mpv engine when the application starts.
@@ -66,6 +72,7 @@ func (p *PlayerService) ServiceStartup(_ context.Context, _ application.ServiceO
 		}
 		p.queue.Next()
 		p.pushMPRISMetadata()
+		p.startScrobbleTracking()
 	})
 
 	// When the mpv playlist ends, loop back if repeat-all is on.
@@ -123,6 +130,7 @@ func (p *PlayerService) ServiceStartup(_ context.Context, _ application.ServiceO
 				if p.mpris != nil && p.engine != nil {
 					p.mpris.UpdatePosition(p.engine.Position())
 				}
+				p.checkScrobble()
 			case <-saveTicker.C:
 				p.saveState()
 			case <-p.stopSave:
@@ -325,6 +333,7 @@ func (p *PlayerService) PlayQueue(tracks []player.QueueTrack, startAt int) error
 	atomic.StoreInt32(&p.manualSkip, 1) // suppress callback for initial load
 	err := p.engine.PlayAll(resolved)
 	p.pushMPRISMetadata()
+	p.startScrobbleTracking()
 	return err
 }
 
@@ -732,6 +741,83 @@ func (p *PlayerService) skipToNextPlayable() {
 		p.mpris.UpdatePlaybackStatus("stopped")
 		p.mpris.ClearMetadata()
 	}
+}
+
+// startScrobbleTracking resets scrobble state for the current track and
+// sends a "now playing" notification to Last.fm if configured.
+func (p *PlayerService) startScrobbleTracking() {
+	cur := p.queue.Current()
+	if cur == nil {
+		return
+	}
+	p.scrobbleTrackID = cur.TrackID
+	p.scrobbleElapsed = 0
+	p.scrobbled = false
+
+	if p.db == nil {
+		return
+	}
+	cfg, err := p.db.LoadScrobbleConfig()
+	if err != nil || !cfg.Enabled || cfg.SessionKey == "" {
+		return
+	}
+
+	track := lastfm.TrackInfo{
+		Artist:   cur.Artist,
+		Track:    cur.Title,
+		Album:    cur.Album,
+		Duration: cur.DurationMs / 1000,
+	}
+	go func() {
+		if err := lastfm.NowPlaying(cfg.APIKey, cfg.APISecret, cfg.SessionKey, track); err != nil {
+			log.Printf("lastfm now-playing: %v", err)
+		}
+	}()
+}
+
+// checkScrobble accumulates play time and submits a scrobble when the
+// threshold is reached (50% of duration or 4 minutes, whichever is first).
+func (p *PlayerService) checkScrobble() {
+	if p.scrobbled || p.engine == nil {
+		return
+	}
+	if p.engine.State().String() != "playing" {
+		return
+	}
+	p.scrobbleElapsed += time.Second
+
+	cur := p.queue.Current()
+	if cur == nil || cur.TrackID != p.scrobbleTrackID {
+		return
+	}
+
+	threshold := time.Duration(lastfm.ScrobbleThreshold(cur.DurationMs)) * time.Millisecond
+	if threshold <= 0 || p.scrobbleElapsed < threshold {
+		return
+	}
+
+	p.scrobbled = true
+
+	if p.db == nil {
+		return
+	}
+	cfg, err := p.db.LoadScrobbleConfig()
+	if err != nil || !cfg.Enabled || cfg.SessionKey == "" {
+		return
+	}
+
+	track := lastfm.TrackInfo{
+		Artist:   cur.Artist,
+		Track:    cur.Title,
+		Album:    cur.Album,
+		Duration: cur.DurationMs / 1000,
+	}
+	ts := time.Now().Unix()
+	go func() {
+		if err := lastfm.Scrobble(cfg.APIKey, cfg.APISecret, cfg.SessionKey, track, ts); err != nil {
+			log.Printf("lastfm scrobble: %v", err)
+		}
+	}()
 }
 
 // resolvePaths translates any server:// paths to streaming URLs.


### PR DESCRIPTION
## What?

- [x] Add `scrobble_config` table (migration005) with single-row pattern
- [x] Add stateless Last.fm API package (`internal/scrobbling/lastfm`) with auth, now-playing, and scrobble functions
- [x] Wire auth flow into LibraryService (get token, open browser, get session, disconnect, toggle)
- [x] Add scrobble tracking to PlayerService via existing 1s ticker
- [x] Add Last.fm section to Settings UI (API key input, connect/disconnect, enable/disable toggle)
- [x] Add tests for API signing, threshold logic, and response parsing

## Why?

Tracks played in Forte should be automatically reported to the listener's Last.fm account. "Now playing" is sent on track start; a scrobble is submitted at 50% of duration or 4 minutes (whichever comes first).

## Design notes

- **User-provided API credentials** - user supplies their own Last.fm API key/secret via Settings
- **Stateless API functions** - each call takes credentials as arguments, no long-lived client
- **Scrobble tracking in existing 1s ticker** - no extra goroutines, handles pause/resume naturally
- **Auth flow** - `auth.getToken` -> open browser -> user approves -> `auth.getSession` -> store session key
- **Config on LibraryService, tracking on PlayerService** - settings concern vs playback concern