### PR TITLE
Implement ListenBrainz scrobbling

### DIFF
--- a/frontend/bindings/github.com/willfish/forte/index.js
+++ b/frontend/bindings/github.com/willfish/forte/index.js
@@ -12,6 +12,7 @@ export {
 export {
     Album,
     AlbumTrack,
+    ListenBrainzConfigJSON,
     Playlist,
     PlaylistTrack,
     ScrobbleConfigJSON,

--- a/frontend/bindings/github.com/willfish/forte/libraryservice.js
+++ b/frontend/bindings/github.com/willfish/forte/libraryservice.js
@@ -53,6 +53,16 @@ export function CompleteLastFmAuth(token) {
 }
 
 /**
+ * ConnectListenBrainz validates the user token, retrieves the username, and saves
+ * the configuration with scrobbling enabled.
+ * @param {string} userToken
+ * @returns {$CancellablePromise<void>}
+ */
+export function ConnectListenBrainz(userToken) {
+    return $Call.ByID(1138196949, userToken);
+}
+
+/**
  * CreatePlaylist creates a new playlist and returns its ID.
  * @param {string} name
  * @returns {$CancellablePromise<number>}
@@ -88,6 +98,14 @@ export function DisconnectLastFm() {
 }
 
 /**
+ * DisconnectListenBrainz clears the ListenBrainz token and username.
+ * @returns {$CancellablePromise<void>}
+ */
+export function DisconnectListenBrainz() {
+    return $Call.ByID(902147985);
+}
+
+/**
  * GetAlbumTracks returns the tracks for a given album.
  * @param {number} albumID
  * @returns {$CancellablePromise<$models.AlbumTrack[]>}
@@ -113,13 +131,23 @@ export function GetAlbums(sort, order, source) {
 }
 
 /**
+ * GetListenBrainzConfig returns the current ListenBrainz configuration.
+ * @returns {$CancellablePromise<$models.ListenBrainzConfigJSON>}
+ */
+export function GetListenBrainzConfig() {
+    return $Call.ByID(1867711289).then(/** @type {($result: any) => any} */(($result) => {
+        return $$createType4($result);
+    }));
+}
+
+/**
  * GetPlaylistTracks returns the tracks in a playlist.
  * @param {number} playlistID
  * @returns {$CancellablePromise<$models.PlaylistTrack[]>}
  */
 export function GetPlaylistTracks(playlistID) {
     return $Call.ByID(4244880336, playlistID).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType5($result);
+        return $$createType6($result);
     }));
 }
 
@@ -129,7 +157,7 @@ export function GetPlaylistTracks(playlistID) {
  */
 export function GetPlaylists() {
     return $Call.ByID(1524576557).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType7($result);
+        return $$createType8($result);
     }));
 }
 
@@ -139,7 +167,7 @@ export function GetPlaylists() {
  */
 export function GetScrobbleConfig() {
     return $Call.ByID(3948527462).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType8($result);
+        return $$createType9($result);
     }));
 }
 
@@ -149,7 +177,7 @@ export function GetScrobbleConfig() {
  */
 export function GetServerStatuses() {
     return $Call.ByID(1839345631).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType10($result);
+        return $$createType11($result);
     }));
 }
 
@@ -159,7 +187,7 @@ export function GetServerStatuses() {
  */
 export function GetServers() {
     return $Call.ByID(3711954650).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType12($result);
+        return $$createType13($result);
     }));
 }
 
@@ -212,8 +240,17 @@ export function SaveScrobbleAPIKeys(apiKey, apiSecret) {
  */
 export function Search(query, limit) {
     return $Call.ByID(2206755262, query, limit).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType14($result);
+        return $$createType15($result);
     }));
+}
+
+/**
+ * SetListenBrainzEnabled toggles ListenBrainz scrobbling on or off.
+ * @param {boolean} enabled
+ * @returns {$CancellablePromise<void>}
+ */
+export function SetListenBrainzEnabled(enabled) {
+    return $Call.ByID(333272068, enabled);
 }
 
 /**
@@ -265,14 +302,15 @@ const $$createType0 = $models.AlbumTrack.createFrom;
 const $$createType1 = $Create.Array($$createType0);
 const $$createType2 = $models.Album.createFrom;
 const $$createType3 = $Create.Array($$createType2);
-const $$createType4 = $models.PlaylistTrack.createFrom;
-const $$createType5 = $Create.Array($$createType4);
-const $$createType6 = $models.Playlist.createFrom;
-const $$createType7 = $Create.Array($$createType6);
-const $$createType8 = $models.ScrobbleConfigJSON.createFrom;
-const $$createType9 = $models.ServerStatusJSON.createFrom;
-const $$createType10 = $Create.Array($$createType9);
-const $$createType11 = $models.ServerConfig.createFrom;
-const $$createType12 = $Create.Array($$createType11);
-const $$createType13 = $models.SearchResult.createFrom;
-const $$createType14 = $Create.Array($$createType13);
+const $$createType4 = $models.ListenBrainzConfigJSON.createFrom;
+const $$createType5 = $models.PlaylistTrack.createFrom;
+const $$createType6 = $Create.Array($$createType5);
+const $$createType7 = $models.Playlist.createFrom;
+const $$createType8 = $Create.Array($$createType7);
+const $$createType9 = $models.ScrobbleConfigJSON.createFrom;
+const $$createType10 = $models.ServerStatusJSON.createFrom;
+const $$createType11 = $Create.Array($$createType10);
+const $$createType12 = $models.ServerConfig.createFrom;
+const $$createType13 = $Create.Array($$createType12);
+const $$createType14 = $models.SearchResult.createFrom;
+const $$createType15 = $Create.Array($$createType14);

--- a/frontend/bindings/github.com/willfish/forte/models.js
+++ b/frontend/bindings/github.com/willfish/forte/models.js
@@ -167,6 +167,45 @@ export class AlbumTrack {
 }
 
 /**
+ * ListenBrainzConfigJSON is the JSON-friendly ListenBrainz config exposed to the frontend.
+ * UserToken is intentionally omitted.
+ */
+export class ListenBrainzConfigJSON {
+    /**
+     * Creates a new ListenBrainzConfigJSON instance.
+     * @param {Partial<ListenBrainzConfigJSON>} [$$source = {}] - The source object to create the ListenBrainzConfigJSON.
+     */
+    constructor($$source = {}) {
+        if (!("username" in $$source)) {
+            /**
+             * @member
+             * @type {string}
+             */
+            this["username"] = "";
+        }
+        if (!("enabled" in $$source)) {
+            /**
+             * @member
+             * @type {boolean}
+             */
+            this["enabled"] = false;
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new ListenBrainzConfigJSON instance from a string or object.
+     * @param {any} [$$source = {}]
+     * @returns {ListenBrainzConfigJSON}
+     */
+    static createFrom($$source = {}) {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new ListenBrainzConfigJSON(/** @type {Partial<ListenBrainzConfigJSON>} */($$parsedSource));
+    }
+}
+
+/**
  * Playlist is the JSON-friendly playlist type exposed to the frontend.
  */
 export class Playlist {

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -215,6 +215,66 @@
       lfmResult = { ok: false, message: err?.message || String(err) };
     }
   }
+
+  // ListenBrainz state
+  type LBConfig = {
+    username: string;
+    enabled: boolean;
+  };
+
+  let lbConfig = $state<LBConfig | null>(null);
+  let lbToken = $state('');
+  let lbConnecting = $state(false);
+  let lbResult = $state<{ ok: boolean; message: string } | null>(null);
+
+  async function loadLBConfig() {
+    try {
+      const cfg = await LibraryService.GetListenBrainzConfig();
+      lbConfig = cfg;
+    } catch {
+      lbConfig = null;
+    }
+  }
+
+  $effect(() => {
+    loadLBConfig();
+  });
+
+  async function connectListenBrainz() {
+    if (!lbToken.trim()) return;
+    lbConnecting = true;
+    lbResult = null;
+    try {
+      await LibraryService.ConnectListenBrainz(lbToken);
+      lbToken = '';
+      lbResult = { ok: true, message: 'Connected to ListenBrainz' };
+      await loadLBConfig();
+    } catch (err: any) {
+      lbResult = { ok: false, message: err?.message || String(err) };
+    } finally {
+      lbConnecting = false;
+    }
+  }
+
+  async function disconnectListenBrainz() {
+    lbResult = null;
+    try {
+      await LibraryService.DisconnectListenBrainz();
+      await loadLBConfig();
+    } catch (err: any) {
+      lbResult = { ok: false, message: err?.message || String(err) };
+    }
+  }
+
+  async function toggleLBEnabled() {
+    if (!lbConfig) return;
+    try {
+      await LibraryService.SetListenBrainzEnabled(!lbConfig.enabled);
+      await loadLBConfig();
+    } catch (err: any) {
+      lbResult = { ok: false, message: err?.message || String(err) };
+    }
+  }
 </script>
 
 <div class="settings">
@@ -399,6 +459,43 @@
     {#if lfmResult}
       <div class="test-result" class:ok={lfmResult.ok} class:err={!lfmResult.ok}>
         {lfmResult.message}
+      </div>
+    {/if}
+  </section>
+
+  <section class="section">
+    <h3>ListenBrainz</h3>
+
+    {#if lbConfig?.username}
+      <div class="lfm-connected">
+        <p class="lfm-status">Connected as <strong>{lbConfig.username}</strong></p>
+        <label class="lfm-toggle">
+          <input type="checkbox" checked={lbConfig.enabled} onchange={toggleLBEnabled} />
+          Scrobbling {lbConfig.enabled ? 'enabled' : 'disabled'}
+        </label>
+        <button class="btn-cancel" onclick={disconnectListenBrainz}>Disconnect</button>
+      </div>
+    {:else}
+      <div class="server-form">
+        <p class="lfm-status">
+          Paste your user token from
+          <a href="https://listenbrainz.org/settings/" target="_blank" rel="noopener">listenbrainz.org/settings</a>.
+        </p>
+        <div class="form-field">
+          <label for="lb-token">User Token</label>
+          <input id="lb-token" type="password" bind:value={lbToken} placeholder="Your ListenBrainz user token" />
+        </div>
+        <div class="form-actions">
+          <button class="btn-save" onclick={connectListenBrainz} disabled={!lbToken.trim() || lbConnecting}>
+            {lbConnecting ? 'Connecting...' : 'Connect'}
+          </button>
+        </div>
+      </div>
+    {/if}
+
+    {#if lbResult}
+      <div class="test-result" class:ok={lbResult.ok} class:err={!lbResult.ok}>
+        {lbResult.message}
       </div>
     {/if}
   </section>

--- a/internal/library/db.go
+++ b/internal/library/db.go
@@ -93,4 +93,5 @@ var migrations = []migration{
 	{version: 3, sql: migration003},
 	{version: 4, sql: migration004},
 	{version: 5, sql: migration005},
+	{version: 6, sql: migration006},
 }

--- a/internal/library/listenbrainz_config.go
+++ b/internal/library/listenbrainz_config.go
@@ -1,0 +1,41 @@
+package library
+
+// ListenBrainzConfig holds ListenBrainz scrobbling configuration.
+type ListenBrainzConfig struct {
+	UserToken string
+	Username  string
+	Enabled   bool
+}
+
+// SaveListenBrainzConfig upserts the single ListenBrainz config row.
+func (db *DB) SaveListenBrainzConfig(cfg ListenBrainzConfig) error {
+	enabled := 0
+	if cfg.Enabled {
+		enabled = 1
+	}
+	_, err := db.Exec(`
+		UPDATE listenbrainz_config SET
+			user_token = ?,
+			username = ?,
+			enabled = ?
+		WHERE id = 1`,
+		cfg.UserToken, cfg.Username, enabled,
+	)
+	return err
+}
+
+// LoadListenBrainzConfig reads the persisted ListenBrainz configuration.
+// Returns a zero-value config if no row exists.
+func (db *DB) LoadListenBrainzConfig() (ListenBrainzConfig, error) {
+	var cfg ListenBrainzConfig
+	var enabled int
+	err := db.QueryRow(`
+		SELECT user_token, username, enabled
+		FROM listenbrainz_config WHERE id = 1`,
+	).Scan(&cfg.UserToken, &cfg.Username, &enabled)
+	if err != nil {
+		return ListenBrainzConfig{}, err
+	}
+	cfg.Enabled = enabled != 0
+	return cfg, nil
+}

--- a/internal/library/schema.go
+++ b/internal/library/schema.go
@@ -124,3 +124,13 @@ CREATE TABLE scrobble_config (
 );
 INSERT INTO scrobble_config (id) VALUES (1);
 `
+
+const migration006 = `
+CREATE TABLE listenbrainz_config (
+	id         INTEGER PRIMARY KEY CHECK (id = 1),
+	user_token TEXT NOT NULL DEFAULT '',
+	username   TEXT NOT NULL DEFAULT '',
+	enabled    INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO listenbrainz_config (id) VALUES (1);
+`

--- a/internal/scrobbling/listenbrainz/listenbrainz.go
+++ b/internal/scrobbling/listenbrainz/listenbrainz.go
@@ -1,0 +1,138 @@
+// Package listenbrainz provides stateless functions for the ListenBrainz API.
+package listenbrainz
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const baseURL = "https://api.listenbrainz.org"
+
+// TrackInfo holds metadata for a now-playing or scrobble call.
+type TrackInfo struct {
+	Artist     string
+	Track      string
+	Album      string
+	DurationMs int
+}
+
+// ValidateToken checks a user token against the ListenBrainz API
+// and returns the associated username.
+func ValidateToken(token string) (string, error) {
+	req, err := http.NewRequest("GET", baseURL+"/1/validate-token", nil)
+	if err != nil {
+		return "", fmt.Errorf("listenbrainz: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+token)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("listenbrainz: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("listenbrainz: read response: %w", err)
+	}
+
+	var result struct {
+		Valid    bool   `json:"valid"`
+		UserName string `json:"user_name"`
+		Message  string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("listenbrainz: parse response: %w", err)
+	}
+	if !result.Valid {
+		return "", fmt.Errorf("listenbrainz: invalid token: %s", result.Message)
+	}
+	return result.UserName, nil
+}
+
+// NowPlaying sends a "playing now" notification to ListenBrainz.
+func NowPlaying(token string, t TrackInfo) error {
+	payload := submitPayload{
+		ListenType: "playing_now",
+		Payload:    []listen{{TrackMetadata: trackMeta(t)}},
+	}
+	return submit(token, payload)
+}
+
+// Scrobble submits a completed track listen to ListenBrainz.
+func Scrobble(token string, t TrackInfo, listenedAt int64) error {
+	payload := submitPayload{
+		ListenType: "single",
+		Payload:    []listen{{ListenedAt: listenedAt, TrackMetadata: trackMeta(t)}},
+	}
+	return submit(token, payload)
+}
+
+type submitPayload struct {
+	ListenType string   `json:"listen_type"`
+	Payload    []listen `json:"payload"`
+}
+
+type listen struct {
+	ListenedAt    int64         `json:"listened_at,omitempty"`
+	TrackMetadata trackMetadata `json:"track_metadata"`
+}
+
+type trackMetadata struct {
+	ArtistName     string         `json:"artist_name"`
+	TrackName      string         `json:"track_name"`
+	ReleaseName    string         `json:"release_name,omitempty"`
+	AdditionalInfo additionalInfo `json:"additional_info"`
+}
+
+type additionalInfo struct {
+	DurationMs       int    `json:"duration_ms,omitempty"`
+	MediaPlayer      string `json:"media_player"`
+	SubmissionClient string `json:"submission_client"`
+}
+
+func trackMeta(t TrackInfo) trackMetadata {
+	return trackMetadata{
+		ArtistName:  t.Artist,
+		TrackName:   t.Track,
+		ReleaseName: t.Album,
+		AdditionalInfo: additionalInfo{
+			DurationMs:       t.DurationMs,
+			MediaPlayer:      "Forte",
+			SubmissionClient: "Forte",
+		},
+	}
+}
+
+func submit(token string, payload submitPayload) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("listenbrainz: marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", baseURL+"/1/submit-listens", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("listenbrainz: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("listenbrainz: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("listenbrainz: API error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}

--- a/internal/scrobbling/listenbrainz/listenbrainz_test.go
+++ b/internal/scrobbling/listenbrainz/listenbrainz_test.go
@@ -1,0 +1,158 @@
+package listenbrainz
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTrackMetadata(t *testing.T) {
+	info := TrackInfo{
+		Artist:     "Radiohead",
+		Track:      "Idioteque",
+		Album:      "Kid A",
+		DurationMs: 310000,
+	}
+	meta := trackMeta(info)
+
+	if meta.ArtistName != "Radiohead" {
+		t.Errorf("ArtistName = %q, want %q", meta.ArtistName, "Radiohead")
+	}
+	if meta.TrackName != "Idioteque" {
+		t.Errorf("TrackName = %q, want %q", meta.TrackName, "Idioteque")
+	}
+	if meta.ReleaseName != "Kid A" {
+		t.Errorf("ReleaseName = %q, want %q", meta.ReleaseName, "Kid A")
+	}
+	if meta.AdditionalInfo.DurationMs != 310000 {
+		t.Errorf("DurationMs = %d, want %d", meta.AdditionalInfo.DurationMs, 310000)
+	}
+	if meta.AdditionalInfo.MediaPlayer != "Forte" {
+		t.Errorf("MediaPlayer = %q, want %q", meta.AdditionalInfo.MediaPlayer, "Forte")
+	}
+	if meta.AdditionalInfo.SubmissionClient != "Forte" {
+		t.Errorf("SubmissionClient = %q, want %q", meta.AdditionalInfo.SubmissionClient, "Forte")
+	}
+}
+
+func TestNowPlayingPayload(t *testing.T) {
+	info := TrackInfo{
+		Artist:     "Portishead",
+		Track:      "Glory Box",
+		Album:      "Dummy",
+		DurationMs: 305000,
+	}
+	payload := submitPayload{
+		ListenType: "playing_now",
+		Payload:    []listen{{TrackMetadata: trackMeta(info)}},
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if parsed["listen_type"] != "playing_now" {
+		t.Errorf("listen_type = %v, want %q", parsed["listen_type"], "playing_now")
+	}
+
+	payloadArr := parsed["payload"].([]any)
+	if len(payloadArr) != 1 {
+		t.Fatalf("payload length = %d, want 1", len(payloadArr))
+	}
+
+	listen := payloadArr[0].(map[string]any)
+	if _, ok := listen["listened_at"]; ok {
+		t.Error("playing_now should not have listened_at")
+	}
+
+	meta := listen["track_metadata"].(map[string]any)
+	if meta["artist_name"] != "Portishead" {
+		t.Errorf("artist_name = %v, want %q", meta["artist_name"], "Portishead")
+	}
+}
+
+func TestScrobblePayload(t *testing.T) {
+	info := TrackInfo{
+		Artist:     "Massive Attack",
+		Track:      "Teardrop",
+		Album:      "Mezzanine",
+		DurationMs: 327000,
+	}
+	payload := submitPayload{
+		ListenType: "single",
+		Payload:    []listen{{ListenedAt: 1700000000, TrackMetadata: trackMeta(info)}},
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if parsed["listen_type"] != "single" {
+		t.Errorf("listen_type = %v, want %q", parsed["listen_type"], "single")
+	}
+
+	payloadArr := parsed["payload"].([]any)
+	listen := payloadArr[0].(map[string]any)
+
+	listenedAt, ok := listen["listened_at"].(float64)
+	if !ok {
+		t.Fatal("listened_at missing or wrong type")
+	}
+	if int64(listenedAt) != 1700000000 {
+		t.Errorf("listened_at = %v, want 1700000000", listenedAt)
+	}
+}
+
+func TestValidateTokenParsing(t *testing.T) {
+	// Valid response
+	validBody := []byte(`{"code":200,"message":"Token valid.","valid":true,"user_name":"testuser"}`)
+	var valid struct {
+		Valid    bool   `json:"valid"`
+		UserName string `json:"user_name"`
+		Message  string `json:"message"`
+	}
+	if err := json.Unmarshal(validBody, &valid); err != nil {
+		t.Fatalf("unmarshal valid: %v", err)
+	}
+	if !valid.Valid {
+		t.Error("expected valid=true")
+	}
+	if valid.UserName != "testuser" {
+		t.Errorf("user_name = %q, want %q", valid.UserName, "testuser")
+	}
+
+	// Invalid response
+	invalidBody := []byte(`{"code":200,"message":"Token invalid.","valid":false}`)
+	var invalid struct {
+		Valid    bool   `json:"valid"`
+		UserName string `json:"user_name"`
+		Message  string `json:"message"`
+	}
+	if err := json.Unmarshal(invalidBody, &invalid); err != nil {
+		t.Fatalf("unmarshal invalid: %v", err)
+	}
+	if invalid.Valid {
+		t.Error("expected valid=false")
+	}
+}
+
+func TestAuthHeader(t *testing.T) {
+	// Verify the format used internally matches "Token <token>"
+	token := "my-secret-token-123"
+	want := "Token my-secret-token-123"
+	got := "Token " + token
+	if got != want {
+		t.Errorf("auth header = %q, want %q", got, want)
+	}
+}

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/willfish/forte/internal/library"
 	"github.com/willfish/forte/internal/scrobbling/lastfm"
+	"github.com/willfish/forte/internal/scrobbling/listenbrainz"
 	"github.com/willfish/forte/internal/streaming/jellyfin"
 	"github.com/willfish/forte/internal/streaming/subsonic"
 )
@@ -583,6 +584,66 @@ func (s *LibraryService) SetScrobbleEnabled(enabled bool) error {
 	}
 	cfg.Enabled = enabled
 	return s.db.SaveScrobbleConfig(cfg)
+}
+
+// ListenBrainzConfigJSON is the JSON-friendly ListenBrainz config exposed to the frontend.
+// UserToken is intentionally omitted.
+type ListenBrainzConfigJSON struct {
+	Username string `json:"username"`
+	Enabled  bool   `json:"enabled"`
+}
+
+// GetListenBrainzConfig returns the current ListenBrainz configuration.
+func (s *LibraryService) GetListenBrainzConfig() (ListenBrainzConfigJSON, error) {
+	if s.db == nil {
+		return ListenBrainzConfigJSON{}, fmt.Errorf("library not initialised")
+	}
+	cfg, err := s.db.LoadListenBrainzConfig()
+	if err != nil {
+		return ListenBrainzConfigJSON{}, err
+	}
+	return ListenBrainzConfigJSON{
+		Username: cfg.Username,
+		Enabled:  cfg.Enabled,
+	}, nil
+}
+
+// ConnectListenBrainz validates the user token, retrieves the username, and saves
+// the configuration with scrobbling enabled.
+func (s *LibraryService) ConnectListenBrainz(userToken string) error {
+	if s.db == nil {
+		return fmt.Errorf("library not initialised")
+	}
+	username, err := listenbrainz.ValidateToken(userToken)
+	if err != nil {
+		return err
+	}
+	return s.db.SaveListenBrainzConfig(library.ListenBrainzConfig{
+		UserToken: userToken,
+		Username:  username,
+		Enabled:   true,
+	})
+}
+
+// DisconnectListenBrainz clears the ListenBrainz token and username.
+func (s *LibraryService) DisconnectListenBrainz() error {
+	if s.db == nil {
+		return fmt.Errorf("library not initialised")
+	}
+	return s.db.SaveListenBrainzConfig(library.ListenBrainzConfig{})
+}
+
+// SetListenBrainzEnabled toggles ListenBrainz scrobbling on or off.
+func (s *LibraryService) SetListenBrainzEnabled(enabled bool) error {
+	if s.db == nil {
+		return fmt.Errorf("library not initialised")
+	}
+	cfg, err := s.db.LoadListenBrainzConfig()
+	if err != nil {
+		return err
+	}
+	cfg.Enabled = enabled
+	return s.db.SaveListenBrainzConfig(cfg)
 }
 
 // newUUID generates a random UUID v4 string.

--- a/playerservice.go
+++ b/playerservice.go
@@ -16,6 +16,7 @@ import (
 	"github.com/willfish/forte/internal/metadata"
 	"github.com/willfish/forte/internal/player"
 	"github.com/willfish/forte/internal/scrobbling/lastfm"
+	"github.com/willfish/forte/internal/scrobbling/listenbrainz"
 	"github.com/willfish/forte/internal/system"
 )
 
@@ -757,22 +758,38 @@ func (p *PlayerService) startScrobbleTracking() {
 	if p.db == nil {
 		return
 	}
+
+	// Last.fm now-playing.
 	cfg, err := p.db.LoadScrobbleConfig()
-	if err != nil || !cfg.Enabled || cfg.SessionKey == "" {
-		return
+	if err == nil && cfg.Enabled && cfg.SessionKey != "" {
+		track := lastfm.TrackInfo{
+			Artist:   cur.Artist,
+			Track:    cur.Title,
+			Album:    cur.Album,
+			Duration: cur.DurationMs / 1000,
+		}
+		go func() {
+			if err := lastfm.NowPlaying(cfg.APIKey, cfg.APISecret, cfg.SessionKey, track); err != nil {
+				log.Printf("lastfm now-playing: %v", err)
+			}
+		}()
 	}
 
-	track := lastfm.TrackInfo{
-		Artist:   cur.Artist,
-		Track:    cur.Title,
-		Album:    cur.Album,
-		Duration: cur.DurationMs / 1000,
-	}
-	go func() {
-		if err := lastfm.NowPlaying(cfg.APIKey, cfg.APISecret, cfg.SessionKey, track); err != nil {
-			log.Printf("lastfm now-playing: %v", err)
+	// ListenBrainz now-playing.
+	lbCfg, err := p.db.LoadListenBrainzConfig()
+	if err == nil && lbCfg.Enabled && lbCfg.UserToken != "" {
+		lbTrack := listenbrainz.TrackInfo{
+			Artist:     cur.Artist,
+			Track:      cur.Title,
+			Album:      cur.Album,
+			DurationMs: cur.DurationMs,
 		}
-	}()
+		go func() {
+			if err := listenbrainz.NowPlaying(lbCfg.UserToken, lbTrack); err != nil {
+				log.Printf("listenbrainz now-playing: %v", err)
+			}
+		}()
+	}
 }
 
 // checkScrobble accumulates play time and submits a scrobble when the
@@ -801,23 +818,40 @@ func (p *PlayerService) checkScrobble() {
 	if p.db == nil {
 		return
 	}
+
+	ts := time.Now().Unix()
+
+	// Last.fm scrobble.
 	cfg, err := p.db.LoadScrobbleConfig()
-	if err != nil || !cfg.Enabled || cfg.SessionKey == "" {
-		return
+	if err == nil && cfg.Enabled && cfg.SessionKey != "" {
+		track := lastfm.TrackInfo{
+			Artist:   cur.Artist,
+			Track:    cur.Title,
+			Album:    cur.Album,
+			Duration: cur.DurationMs / 1000,
+		}
+		go func() {
+			if err := lastfm.Scrobble(cfg.APIKey, cfg.APISecret, cfg.SessionKey, track, ts); err != nil {
+				log.Printf("lastfm scrobble: %v", err)
+			}
+		}()
 	}
 
-	track := lastfm.TrackInfo{
-		Artist:   cur.Artist,
-		Track:    cur.Title,
-		Album:    cur.Album,
-		Duration: cur.DurationMs / 1000,
-	}
-	ts := time.Now().Unix()
-	go func() {
-		if err := lastfm.Scrobble(cfg.APIKey, cfg.APISecret, cfg.SessionKey, track, ts); err != nil {
-			log.Printf("lastfm scrobble: %v", err)
+	// ListenBrainz scrobble.
+	lbCfg, err := p.db.LoadListenBrainzConfig()
+	if err == nil && lbCfg.Enabled && lbCfg.UserToken != "" {
+		lbTrack := listenbrainz.TrackInfo{
+			Artist:     cur.Artist,
+			Track:      cur.Title,
+			Album:      cur.Album,
+			DurationMs: cur.DurationMs,
 		}
-	}()
+		go func() {
+			if err := listenbrainz.Scrobble(lbCfg.UserToken, lbTrack, ts); err != nil {
+				log.Printf("listenbrainz scrobble: %v", err)
+			}
+		}()
+	}
 }
 
 // resolvePaths translates any server:// paths to streaming URLs.


### PR DESCRIPTION
Closes #42

## What?

- [x] Add `listenbrainz` API package (ValidateToken, NowPlaying, Scrobble)
- [x] Add `listenbrainz_config` table via migration006
- [x] Add LibraryService methods (Connect, Disconnect, GetConfig, SetEnabled)
- [x] Add dual scrobbling in PlayerService (fire-and-forget alongside Last.fm)
- [x] Add ListenBrainz settings section in Settings.svelte
- [x] Add tests for payload structure and response parsing

## Why?

Users want to report listens to ListenBrainz as well as Last.fm. Simpler auth flow - user pastes their token from listenbrainz.org/settings, we validate it and start scrobbling. Both services fire independently so a failure in one doesn't affect the other.