### PR TITLE
Fetch artist metadata from Last.fm and MusicBrainz

### DIFF
--- a/frontend/bindings/github.com/willfish/forte/index.js
+++ b/frontend/bindings/github.com/willfish/forte/index.js
@@ -12,6 +12,7 @@ export {
 export {
     Album,
     AlbumTrack,
+    ArtistInfoJSON,
     ListenBrainzConfigJSON,
     Playlist,
     PlaylistTrack,
@@ -20,5 +21,6 @@ export {
     SearchResult,
     ServerConfig,
     ServerStatusJSON,
+    SimilarArtistJSON,
     StatEntryJSON
 } from "./models.js";

--- a/frontend/bindings/github.com/willfish/forte/libraryservice.js
+++ b/frontend/bindings/github.com/willfish/forte/libraryservice.js
@@ -131,12 +131,32 @@ export function GetAlbums(sort, order, source) {
 }
 
 /**
+ * GetArtistByName returns the artist ID for the given name.
+ * @param {string} name
+ * @returns {$CancellablePromise<number>}
+ */
+export function GetArtistByName(name) {
+    return $Call.ByID(1148779767, name);
+}
+
+/**
+ * GetArtistInfo returns metadata for the named artist, using cache with 30-day TTL.
+ * @param {string} artistName
+ * @returns {$CancellablePromise<$models.ArtistInfoJSON>}
+ */
+export function GetArtistInfo(artistName) {
+    return $Call.ByID(2345670893, artistName).then(/** @type {($result: any) => any} */(($result) => {
+        return $$createType4($result);
+    }));
+}
+
+/**
  * GetListenBrainzConfig returns the current ListenBrainz configuration.
  * @returns {$CancellablePromise<$models.ListenBrainzConfigJSON>}
  */
 export function GetListenBrainzConfig() {
     return $Call.ByID(1867711289).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType4($result);
+        return $$createType5($result);
     }));
 }
 
@@ -147,7 +167,7 @@ export function GetListenBrainzConfig() {
  */
 export function GetPlaylistTracks(playlistID) {
     return $Call.ByID(4244880336, playlistID).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType6($result);
+        return $$createType7($result);
     }));
 }
 
@@ -157,7 +177,7 @@ export function GetPlaylistTracks(playlistID) {
  */
 export function GetPlaylists() {
     return $Call.ByID(1524576557).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType8($result);
+        return $$createType9($result);
     }));
 }
 
@@ -168,7 +188,7 @@ export function GetPlaylists() {
  */
 export function GetRecentlyPlayed(limit) {
     return $Call.ByID(3884039413, limit).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType10($result);
+        return $$createType11($result);
     }));
 }
 
@@ -178,7 +198,7 @@ export function GetRecentlyPlayed(limit) {
  */
 export function GetScrobbleConfig() {
     return $Call.ByID(3948527462).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType11($result);
+        return $$createType12($result);
     }));
 }
 
@@ -196,7 +216,7 @@ export function GetScrobbleQueueSize() {
  */
 export function GetServerStatuses() {
     return $Call.ByID(1839345631).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType13($result);
+        return $$createType14($result);
     }));
 }
 
@@ -206,7 +226,7 @@ export function GetServerStatuses() {
  */
 export function GetServers() {
     return $Call.ByID(3711954650).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType15($result);
+        return $$createType16($result);
     }));
 }
 
@@ -218,7 +238,7 @@ export function GetServers() {
  */
 export function GetTopAlbums(period, limit) {
     return $Call.ByID(1740480677, period, limit).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType17($result);
+        return $$createType18($result);
     }));
 }
 
@@ -230,7 +250,7 @@ export function GetTopAlbums(period, limit) {
  */
 export function GetTopArtists(period, limit) {
     return $Call.ByID(2628386383, period, limit).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType17($result);
+        return $$createType18($result);
     }));
 }
 
@@ -242,7 +262,7 @@ export function GetTopArtists(period, limit) {
  */
 export function GetTopTracks(period, limit) {
     return $Call.ByID(3437861925, period, limit).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType17($result);
+        return $$createType18($result);
     }));
 }
 
@@ -295,7 +315,7 @@ export function SaveScrobbleAPIKeys(apiKey, apiSecret) {
  */
 export function Search(query, limit) {
     return $Call.ByID(2206755262, query, limit).then(/** @type {($result: any) => any} */(($result) => {
-        return $$createType19($result);
+        return $$createType20($result);
     }));
 }
 
@@ -357,19 +377,20 @@ const $$createType0 = $models.AlbumTrack.createFrom;
 const $$createType1 = $Create.Array($$createType0);
 const $$createType2 = $models.Album.createFrom;
 const $$createType3 = $Create.Array($$createType2);
-const $$createType4 = $models.ListenBrainzConfigJSON.createFrom;
-const $$createType5 = $models.PlaylistTrack.createFrom;
-const $$createType6 = $Create.Array($$createType5);
-const $$createType7 = $models.Playlist.createFrom;
-const $$createType8 = $Create.Array($$createType7);
-const $$createType9 = $models.RecentPlayJSON.createFrom;
-const $$createType10 = $Create.Array($$createType9);
-const $$createType11 = $models.ScrobbleConfigJSON.createFrom;
-const $$createType12 = $models.ServerStatusJSON.createFrom;
-const $$createType13 = $Create.Array($$createType12);
-const $$createType14 = $models.ServerConfig.createFrom;
-const $$createType15 = $Create.Array($$createType14);
-const $$createType16 = $models.StatEntryJSON.createFrom;
-const $$createType17 = $Create.Array($$createType16);
-const $$createType18 = $models.SearchResult.createFrom;
-const $$createType19 = $Create.Array($$createType18);
+const $$createType4 = $models.ArtistInfoJSON.createFrom;
+const $$createType5 = $models.ListenBrainzConfigJSON.createFrom;
+const $$createType6 = $models.PlaylistTrack.createFrom;
+const $$createType7 = $Create.Array($$createType6);
+const $$createType8 = $models.Playlist.createFrom;
+const $$createType9 = $Create.Array($$createType8);
+const $$createType10 = $models.RecentPlayJSON.createFrom;
+const $$createType11 = $Create.Array($$createType10);
+const $$createType12 = $models.ScrobbleConfigJSON.createFrom;
+const $$createType13 = $models.ServerStatusJSON.createFrom;
+const $$createType14 = $Create.Array($$createType13);
+const $$createType15 = $models.ServerConfig.createFrom;
+const $$createType16 = $Create.Array($$createType15);
+const $$createType17 = $models.StatEntryJSON.createFrom;
+const $$createType18 = $Create.Array($$createType17);
+const $$createType19 = $models.SearchResult.createFrom;
+const $$createType20 = $Create.Array($$createType19);

--- a/frontend/bindings/github.com/willfish/forte/models.js
+++ b/frontend/bindings/github.com/willfish/forte/models.js
@@ -167,6 +167,101 @@ export class AlbumTrack {
 }
 
 /**
+ * ArtistInfoJSON is the JSON-friendly artist info type exposed to the frontend.
+ */
+export class ArtistInfoJSON {
+    /**
+     * Creates a new ArtistInfoJSON instance.
+     * @param {Partial<ArtistInfoJSON>} [$$source = {}] - The source object to create the ArtistInfoJSON.
+     */
+    constructor($$source = {}) {
+        if (!("name" in $$source)) {
+            /**
+             * @member
+             * @type {string}
+             */
+            this["name"] = "";
+        }
+        if (!("bio" in $$source)) {
+            /**
+             * @member
+             * @type {string}
+             */
+            this["bio"] = "";
+        }
+        if (!("imageUrl" in $$source)) {
+            /**
+             * @member
+             * @type {string}
+             */
+            this["imageUrl"] = "";
+        }
+        if (!("area" in $$source)) {
+            /**
+             * @member
+             * @type {string}
+             */
+            this["area"] = "";
+        }
+        if (!("type" in $$source)) {
+            /**
+             * @member
+             * @type {string}
+             */
+            this["type"] = "";
+        }
+        if (!("activeYears" in $$source)) {
+            /**
+             * @member
+             * @type {string}
+             */
+            this["activeYears"] = "";
+        }
+        if (!("similar" in $$source)) {
+            /**
+             * @member
+             * @type {SimilarArtistJSON[]}
+             */
+            this["similar"] = [];
+        }
+        if (!("albums" in $$source)) {
+            /**
+             * @member
+             * @type {Album[]}
+             */
+            this["albums"] = [];
+        }
+        if (!("tags" in $$source)) {
+            /**
+             * @member
+             * @type {string}
+             */
+            this["tags"] = "";
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new ArtistInfoJSON instance from a string or object.
+     * @param {any} [$$source = {}]
+     * @returns {ArtistInfoJSON}
+     */
+    static createFrom($$source = {}) {
+        const $$createField6_0 = $$createType1;
+        const $$createField7_0 = $$createType3;
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("similar" in $$parsedSource) {
+            $$parsedSource["similar"] = $$createField6_0($$parsedSource["similar"]);
+        }
+        if ("albums" in $$parsedSource) {
+            $$parsedSource["albums"] = $$createField7_0($$parsedSource["albums"]);
+        }
+        return new ArtistInfoJSON(/** @type {Partial<ArtistInfoJSON>} */($$parsedSource));
+    }
+}
+
+/**
  * ListenBrainzConfigJSON is the JSON-friendly ListenBrainz config exposed to the frontend.
  * UserToken is intentionally omitted.
  */
@@ -648,6 +743,44 @@ export class ServerStatusJSON {
 }
 
 /**
+ * SimilarArtistJSON is the JSON-friendly similar artist type exposed to the frontend.
+ */
+export class SimilarArtistJSON {
+    /**
+     * Creates a new SimilarArtistJSON instance.
+     * @param {Partial<SimilarArtistJSON>} [$$source = {}] - The source object to create the SimilarArtistJSON.
+     */
+    constructor($$source = {}) {
+        if (!("name" in $$source)) {
+            /**
+             * @member
+             * @type {string}
+             */
+            this["name"] = "";
+        }
+        if (!("inLibrary" in $$source)) {
+            /**
+             * @member
+             * @type {boolean}
+             */
+            this["inLibrary"] = false;
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new SimilarArtistJSON instance from a string or object.
+     * @param {any} [$$source = {}]
+     * @returns {SimilarArtistJSON}
+     */
+    static createFrom($$source = {}) {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new SimilarArtistJSON(/** @type {Partial<SimilarArtistJSON>} */($$parsedSource));
+    }
+}
+
+/**
  * StatEntryJSON is the JSON-friendly stat entry type exposed to the frontend.
  */
 export class StatEntryJSON {
@@ -698,3 +831,9 @@ export class StatEntryJSON {
         return new StatEntryJSON(/** @type {Partial<StatEntryJSON>} */($$parsedSource));
     }
 }
+
+// Private type creation functions
+const $$createType0 = SimilarArtistJSON.createFrom;
+const $$createType1 = $Create.Array($$createType0);
+const $$createType2 = Album.createFrom;
+const $$createType3 = $Create.Array($$createType2);

--- a/frontend/src/AlbumView.svelte
+++ b/frontend/src/AlbumView.svelte
@@ -23,7 +23,7 @@
     totalDurationMs: number;
   };
 
-  const { albumId, onback }: { albumId: number; onback: () => void } = $props();
+  const { albumId, onback, onartist }: { albumId: number; onback: () => void; onartist: (name: string) => void } = $props();
 
   let albumInfo = $state<AlbumInfo>({ title: '', artist: '', year: 0, trackCount: 0, artworkSrc: '', totalDurationMs: 0 });
   let tracks = $state<Track[]>([]);
@@ -163,7 +163,7 @@
     {/if}
     <div class="album-meta">
       <h1 class="album-title">{albumInfo.title}</h1>
-      <p class="album-artist">{albumInfo.artist}</p>
+      <button class="album-artist artist-link" onclick={() => onartist(albumInfo.artist)}>{albumInfo.artist}</button>
       <p class="album-details">
         {#if albumInfo.year > 0}{albumInfo.year} &middot; {/if}
         {albumInfo.trackCount} track{albumInfo.trackCount !== 1 ? 's' : ''} &middot;
@@ -287,6 +287,19 @@
     font-size: 1rem;
     color: var(--text-secondary);
     margin: 0 0 0.5rem;
+  }
+
+  .artist-link {
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .artist-link:hover {
+    color: var(--accent);
+    text-decoration: underline;
   }
 
   .album-details {

--- a/frontend/src/ArtistView.svelte
+++ b/frontend/src/ArtistView.svelte
@@ -1,0 +1,365 @@
+<script lang="ts">
+  import { LibraryService } from "../bindings/github.com/willfish/forte";
+
+  type ArtistInfo = {
+    name: string;
+    bio: string;
+    imageUrl: string;
+    area: string;
+    type: string;
+    activeYears: string;
+    similar: { name: string; inLibrary: boolean }[];
+    albums: { id: number; title: string; artist: string; year: number; trackCount: number; source: string; serverId: string }[];
+    tags: string;
+  };
+
+  const { artistName, onback, onalbum, onartist }: {
+    artistName: string;
+    onback: () => void;
+    onalbum: (albumId: number) => void;
+    onartist: (name: string) => void;
+  } = $props();
+
+  let info = $state<ArtistInfo | null>(null);
+  let loading = $state(true);
+  let error = $state('');
+  let artworkCache = $state<Record<number, string>>({});
+
+  async function loadArtist() {
+    loading = true;
+    error = '';
+    try {
+      const result = await LibraryService.GetArtistInfo(artistName);
+      info = result;
+
+      // Load artwork for each album.
+      const cache: Record<number, string> = {};
+      if (result.albums) {
+        for (const album of result.albums) {
+          try {
+            const art = await LibraryService.AlbumArtwork(album.id);
+            if (art) cache[album.id] = art;
+          } catch {
+            // ignore missing artwork
+          }
+        }
+      }
+      artworkCache = cache;
+    } catch (e: any) {
+      error = e?.message || 'Failed to load artist info';
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    loadArtist();
+  });
+</script>
+
+<div class="artist-view">
+  <button class="back-btn" onclick={onback}>
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+      <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+    </svg>
+    Back
+  </button>
+
+  {#if loading}
+    <div class="loading">Loading artist info...</div>
+  {:else if error}
+    <div class="error-state">{error}</div>
+  {:else if info}
+    <div class="artist-header">
+      {#if info.imageUrl}
+        <img class="artist-image" src={info.imageUrl} alt="{info.name}" />
+      {:else}
+        <div class="artist-image-placeholder">
+          <svg viewBox="0 0 24 24" width="48" height="48" fill="currentColor" opacity="0.3">
+            <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
+          </svg>
+        </div>
+      {/if}
+      <div class="artist-meta">
+        <h1 class="artist-name">{info.name}</h1>
+        <div class="artist-details">
+          {#if info.type}
+            <span class="detail">{info.type}</span>
+          {/if}
+          {#if info.area}
+            <span class="detail">{info.area}</span>
+          {/if}
+          {#if info.activeYears}
+            <span class="detail">{info.activeYears}</span>
+          {/if}
+        </div>
+        {#if info.tags}
+          <div class="tags">
+            {#each info.tags.split(', ') as tag}
+              <span class="tag">{tag}</span>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </div>
+
+    {#if info.bio}
+      <section class="bio-section">
+        <h3>Biography</h3>
+        <p class="bio-text">{info.bio}</p>
+      </section>
+    {/if}
+
+    {#if info.albums && info.albums.length > 0}
+      <section class="albums-section">
+        <h3>Albums ({info.albums.length})</h3>
+        <div class="albums-grid">
+          {#each info.albums as album (album.id)}
+            <button class="album-card" onclick={() => onalbum(album.id)}>
+              {#if artworkCache[album.id]}
+                <img class="album-art" src={artworkCache[album.id]} alt="{album.title}" />
+              {:else}
+                <div class="album-art-placeholder">
+                  <svg viewBox="0 0 24 24" width="32" height="32" fill="currentColor" opacity="0.3">
+                    <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55C7.79 13 6 14.79 6 17s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/>
+                  </svg>
+                </div>
+              {/if}
+              <span class="album-title">{album.title}</span>
+              {#if album.year > 0}
+                <span class="album-year">{album.year}</span>
+              {/if}
+            </button>
+          {/each}
+        </div>
+      </section>
+    {/if}
+
+    {#if info.similar && info.similar.length > 0}
+      <section class="similar-section">
+        <h3>Similar Artists</h3>
+        <div class="similar-list">
+          {#each info.similar as sim}
+            {#if sim.inLibrary}
+              <button class="similar-link" onclick={() => onartist(sim.name)}>
+                {sim.name}
+              </button>
+            {:else}
+              <span class="similar-name">{sim.name}</span>
+            {/if}
+          {/each}
+        </div>
+      </section>
+    {/if}
+
+    {#if !info.bio && (!info.albums || info.albums.length === 0)}
+      <div class="empty-state">No information available for this artist.</div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .artist-view {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    gap: 1.5rem;
+  }
+
+  .back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.4rem 0.6rem;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.85rem;
+    align-self: flex-start;
+  }
+
+  .back-btn:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  .loading, .error-state, .empty-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+
+  .artist-header {
+    display: flex;
+    gap: 1.5rem;
+    flex-shrink: 0;
+  }
+
+  .artist-image {
+    width: 200px;
+    height: 200px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .artist-image-placeholder {
+    width: 200px;
+    height: 200px;
+    border-radius: 50%;
+    background: var(--bg-hover);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    flex-shrink: 0;
+  }
+
+  .artist-meta {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    padding-bottom: 0.5rem;
+    gap: 0.5rem;
+  }
+
+  .artist-name {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin: 0;
+  }
+
+  .artist-details {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .detail {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+  }
+
+  .detail + .detail::before {
+    content: '\00B7';
+    margin-right: 0.5rem;
+  }
+
+  .tags {
+    display: flex;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+  }
+
+  .tag {
+    font-size: 0.7rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 10px;
+    background: var(--bg-hover);
+    color: var(--text-secondary);
+  }
+
+  section h3 {
+    margin: 0 0 0.75rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .bio-text {
+    font-size: 0.9rem;
+    color: var(--text-primary);
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  .albums-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 1rem;
+  }
+
+  .album-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    text-align: left;
+    padding: 0.5rem;
+    border-radius: 6px;
+    color: inherit;
+  }
+
+  .album-card:hover {
+    background: var(--bg-hover);
+  }
+
+  .album-art {
+    width: 100%;
+    aspect-ratio: 1;
+    border-radius: 6px;
+    object-fit: cover;
+  }
+
+  .album-art-placeholder {
+    width: 100%;
+    aspect-ratio: 1;
+    border-radius: 6px;
+    background: var(--bg-hover);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+  }
+
+  .album-title {
+    font-size: 0.8rem;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .album-year {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+  }
+
+  .similar-list {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .similar-link {
+    font-size: 0.85rem;
+    color: var(--accent);
+    background: transparent;
+    border: 1px solid var(--border);
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .similar-link:hover {
+    background: var(--bg-hover);
+  }
+
+  .similar-name {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    padding: 0.3rem 0.6rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+  }
+</style>

--- a/frontend/src/Content.svelte
+++ b/frontend/src/Content.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { getCurrentView, onViewChange, setServerStatuses, type View } from './lib/stores';
+  import { getCurrentView, onViewChange, setCurrentView, setServerStatuses, type View } from './lib/stores';
   import { LibraryService } from "../bindings/github.com/willfish/forte";
   import AlbumGrid from './AlbumGrid.svelte';
   import AlbumView from './AlbumView.svelte';
+  import ArtistView from './ArtistView.svelte';
   import PlaylistView from './PlaylistView.svelte';
   import StatsView from './StatsView.svelte';
   import Settings from './Settings.svelte';
@@ -10,6 +11,7 @@
 
   let currentView = $state<View>(getCurrentView());
   let selectedAlbumId = $state<number | null>(null);
+  let selectedArtistName = $state<string | null>(null);
 
   // Search state.
   let searchQuery = $state('');
@@ -24,6 +26,7 @@
     return onViewChange((v) => {
       currentView = v;
       selectedAlbumId = null;
+      selectedArtistName = null;
       clearSearch();
     });
   });
@@ -51,6 +54,17 @@
 
   function handleAlbumSelect(albumId: number) {
     selectedAlbumId = albumId;
+    selectedArtistName = null;
+  }
+
+  function handleArtistSelect(name: string) {
+    selectedArtistName = name;
+    selectedAlbumId = null;
+    clearSearch();
+    if (currentView !== 'library') {
+      currentView = 'library';
+      setCurrentView('library');
+    }
   }
 
   function handleSearchInput(e: Event) {
@@ -141,17 +155,24 @@
       {#if searching}
         <div class="searching">Searching...</div>
       {:else}
-        <SearchResults results={searchResults} query={searchQuery.trim()} />
+        <SearchResults results={searchResults} query={searchQuery.trim()} onartist={handleArtistSelect} />
       {/if}
+    {:else if selectedArtistName !== null}
+      <ArtistView
+        artistName={selectedArtistName}
+        onback={() => selectedArtistName = null}
+        onalbum={handleAlbumSelect}
+        onartist={handleArtistSelect}
+      />
     {:else if selectedAlbumId !== null}
-      <AlbumView albumId={selectedAlbumId} onback={() => selectedAlbumId = null} />
+      <AlbumView albumId={selectedAlbumId} onback={() => selectedAlbumId = null} onartist={handleArtistSelect} />
     {:else}
       <AlbumGrid onselect={handleAlbumSelect} />
     {/if}
   {:else if currentView === 'playlists'}
     <PlaylistView />
   {:else if currentView === 'stats'}
-    <StatsView />
+    <StatsView onartist={handleArtistSelect} />
   {:else if currentView === 'settings'}
     <Settings />
   {/if}

--- a/frontend/src/SearchResults.svelte
+++ b/frontend/src/SearchResults.svelte
@@ -14,7 +14,7 @@
     serverId: string;
   };
 
-  const { results, query }: { results: Result[]; query: string } = $props();
+  const { results, query, onartist }: { results: Result[]; query: string; onartist: (name: string) => void } = $props();
 
   let currentFilePath = $state('');
   let pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -112,7 +112,8 @@
             </svg>
           {/if}
         </span>
-        <span class="col-artist">{result.artist}</span>
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <span class="col-artist artist-link" role="link" tabindex="0" onclick={(e: MouseEvent) => { e.stopPropagation(); onartist(result.artist); }} onkeydown={(e: KeyboardEvent) => { if (e.key === 'Enter') { e.stopPropagation(); onartist(result.artist); }}}>{result.artist}</span>
         <span class="col-album">{result.album}</span>
         <span class="col-duration">{formatDuration(result.durationMs)}</span>
       </button>
@@ -218,6 +219,19 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .artist-link {
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .artist-link:hover {
+    color: var(--accent);
+    text-decoration: underline;
   }
 
   .col-duration {

--- a/frontend/src/StatsView.svelte
+++ b/frontend/src/StatsView.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { LibraryService } from "../bindings/github.com/willfish/forte";
 
+  const { onartist }: { onartist: (name: string) => void } = $props();
+
   type StatEntry = {
     name: string;
     secondLine: string;
@@ -124,7 +126,7 @@
               <li class="stat-row">
                 <span class="rank">{i + 1}</span>
                 <div class="stat-info">
-                  <span class="stat-name">{entry.name}</span>
+                  <button class="stat-name artist-link" onclick={() => onartist(entry.name)}>{entry.name}</button>
                 </div>
                 <span class="stat-meta">{entry.playCount} plays</span>
                 <span class="stat-duration">{formatDuration(entry.totalMs)}</span>
@@ -144,7 +146,7 @@
                 <div class="stat-info">
                   <span class="stat-name">{entry.name}</span>
                   {#if entry.secondLine}
-                    <span class="stat-secondary">{entry.secondLine}</span>
+                    <button class="stat-secondary artist-link" onclick={() => onartist(entry.secondLine)}>{entry.secondLine}</button>
                   {/if}
                 </div>
                 <span class="stat-meta">{entry.playCount} plays</span>
@@ -165,7 +167,7 @@
                 <div class="stat-info">
                   <span class="stat-name">{entry.name}</span>
                   {#if entry.secondLine}
-                    <span class="stat-secondary">{entry.secondLine}</span>
+                    <button class="stat-secondary artist-link" onclick={() => onartist(entry.secondLine)}>{entry.secondLine}</button>
                   {/if}
                 </div>
                 <span class="stat-meta">{entry.playCount} plays</span>
@@ -185,7 +187,9 @@
             <li class="stat-row">
               <div class="stat-info">
                 <span class="stat-name">{play.title}</span>
-                <span class="stat-secondary">{play.artist}{play.album ? ` - ${play.album}` : ''}</span>
+                <span class="stat-secondary">
+                  <button class="artist-link inline-link" onclick={() => onartist(play.artist)}>{play.artist}</button>{play.album ? ` - ${play.album}` : ''}
+                </span>
               </div>
               <span class="stat-duration">{formatTrackDuration(play.durationMs)}</span>
               <span class="stat-meta">{relativeTime(play.playedAt)}</span>
@@ -342,5 +346,24 @@
     color: var(--text-secondary);
     flex-shrink: 0;
     white-space: nowrap;
+  }
+
+  .artist-link {
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    text-align: left;
+    font-size: inherit;
+    color: inherit;
+  }
+
+  .artist-link:hover {
+    color: var(--accent);
+    text-decoration: underline;
+  }
+
+  .inline-link {
+    display: inline;
   }
 </style>

--- a/internal/artistinfo/fetch.go
+++ b/internal/artistinfo/fetch.go
@@ -1,0 +1,81 @@
+package artistinfo
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// Result is the combined metadata from Last.fm and MusicBrainz.
+type Result struct {
+	Bio      string
+	ImageURL string
+	Similar  []SimilarArtist
+	MbID     string
+	MbArea   string
+	MbType   string
+	MbBegin  string
+	MbEnd    string
+	MbTags   string
+}
+
+var (
+	mu             sync.Mutex
+	lastLastFmCall time.Time
+	lastMBCall     time.Time
+)
+
+const (
+	lastFmMinInterval = 200 * time.Millisecond
+	mbMinInterval     = 1 * time.Second
+)
+
+func throttleLastFm() {
+	mu.Lock()
+	defer mu.Unlock()
+	if elapsed := time.Since(lastLastFmCall); elapsed < lastFmMinInterval {
+		time.Sleep(lastFmMinInterval - elapsed)
+	}
+	lastLastFmCall = time.Now()
+}
+
+func throttleMB() {
+	mu.Lock()
+	defer mu.Unlock()
+	if elapsed := time.Since(lastMBCall); elapsed < mbMinInterval {
+		time.Sleep(mbMinInterval - elapsed)
+	}
+	lastMBCall = time.Now()
+}
+
+// Fetch retrieves artist metadata from Last.fm (primary) and MusicBrainz (supplementary).
+func Fetch(apiKey, artistName string) (*Result, error) {
+	result := &Result{}
+
+	// Last.fm for bio, image, similar artists.
+	if apiKey != "" {
+		throttleLastFm()
+		lfm, err := FetchLastFm(apiKey, artistName)
+		if err == nil && lfm != nil {
+			result.Bio = lfm.Bio
+			result.ImageURL = lfm.ImageURL
+			result.Similar = lfm.Similar
+		}
+	}
+
+	// MusicBrainz for supplementary metadata.
+	throttleMB()
+	mb, err := FetchMusicBrainz(artistName)
+	if err == nil && mb != nil {
+		result.MbID = mb.ID
+		result.MbArea = mb.Area
+		result.MbType = mb.Type
+		result.MbBegin = mb.Begin
+		result.MbEnd = mb.End
+		if len(mb.Tags) > 0 {
+			result.MbTags = strings.Join(mb.Tags, ", ")
+		}
+	}
+
+	return result, nil
+}

--- a/internal/artistinfo/lastfm.go
+++ b/internal/artistinfo/lastfm.go
@@ -1,0 +1,105 @@
+package artistinfo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// ArtistInfo holds metadata fetched from Last.fm.
+type ArtistInfo struct {
+	Bio      string
+	ImageURL string
+	Similar  []SimilarArtist
+}
+
+// SimilarArtist is a name returned from the similar artists list.
+type SimilarArtist struct {
+	Name string
+}
+
+var htmlTagRe = regexp.MustCompile(`<[^>]*>`)
+
+// FetchLastFm fetches artist info from the Last.fm API.
+func FetchLastFm(apiKey, artistName string) (*ArtistInfo, error) {
+	u := "https://ws.audioscrobbler.com/2.0/?" + url.Values{
+		"method":  {"artist.getinfo"},
+		"artist":  {artistName},
+		"api_key": {apiKey},
+		"format":  {"json"},
+	}.Encode()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(u)
+	if err != nil {
+		return nil, fmt.Errorf("lastfm request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("lastfm read body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("lastfm status %d: %s", resp.StatusCode, body)
+	}
+
+	return parseLastFmResponse(body)
+}
+
+// lastFmResponse maps the relevant parts of the Last.fm artist.getinfo JSON.
+type lastFmResponse struct {
+	Artist struct {
+		Bio struct {
+			Summary string `json:"summary"`
+		} `json:"bio"`
+		Image []struct {
+			Text string `json:"#text"`
+			Size string `json:"size"`
+		} `json:"image"`
+		Similar struct {
+			Artist []struct {
+				Name string `json:"name"`
+			} `json:"artist"`
+		} `json:"similar"`
+	} `json:"artist"`
+	Error   int    `json:"error"`
+	Message string `json:"message"`
+}
+
+func parseLastFmResponse(body []byte) (*ArtistInfo, error) {
+	var resp lastFmResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("lastfm parse: %w", err)
+	}
+	if resp.Error != 0 {
+		return nil, fmt.Errorf("lastfm api error %d: %s", resp.Error, resp.Message)
+	}
+
+	info := &ArtistInfo{}
+
+	// Strip HTML from bio summary.
+	bio := htmlTagRe.ReplaceAllString(resp.Artist.Bio.Summary, "")
+	info.Bio = strings.TrimSpace(bio)
+
+	// Pick the largest available image.
+	for _, img := range resp.Artist.Image {
+		if img.Text != "" {
+			info.ImageURL = img.Text
+		}
+	}
+
+	for _, s := range resp.Artist.Similar.Artist {
+		if s.Name != "" {
+			info.Similar = append(info.Similar, SimilarArtist{Name: s.Name})
+		}
+	}
+
+	return info, nil
+}

--- a/internal/artistinfo/lastfm_test.go
+++ b/internal/artistinfo/lastfm_test.go
@@ -1,0 +1,77 @@
+package artistinfo
+
+import "testing"
+
+func TestParseLastFmResponse(t *testing.T) {
+	body := []byte(`{
+		"artist": {
+			"name": "Radiohead",
+			"bio": {
+				"summary": "Radiohead are an English rock band from <a href=\"https://last.fm\">Abingdon</a>, Oxfordshire."
+			},
+			"image": [
+				{"#text": "https://img.fm/small.jpg", "size": "small"},
+				{"#text": "https://img.fm/medium.jpg", "size": "medium"},
+				{"#text": "https://img.fm/large.jpg", "size": "large"},
+				{"#text": "", "size": "mega"}
+			],
+			"similar": {
+				"artist": [
+					{"name": "Muse"},
+					{"name": "Thom Yorke"}
+				]
+			}
+		}
+	}`)
+
+	info, err := parseLastFmResponse(body)
+	if err != nil {
+		t.Fatalf("parseLastFmResponse: %v", err)
+	}
+	if info.Bio != "Radiohead are an English rock band from Abingdon, Oxfordshire." {
+		t.Errorf("bio = %q", info.Bio)
+	}
+	if info.ImageURL != "https://img.fm/large.jpg" {
+		t.Errorf("image = %q, want large.jpg", info.ImageURL)
+	}
+	if len(info.Similar) != 2 {
+		t.Fatalf("similar count = %d, want 2", len(info.Similar))
+	}
+	if info.Similar[0].Name != "Muse" {
+		t.Errorf("similar[0] = %q", info.Similar[0].Name)
+	}
+}
+
+func TestParseLastFmMissingFields(t *testing.T) {
+	body := []byte(`{
+		"artist": {
+			"name": "Unknown",
+			"bio": {"summary": ""},
+			"image": [],
+			"similar": {"artist": []}
+		}
+	}`)
+
+	info, err := parseLastFmResponse(body)
+	if err != nil {
+		t.Fatalf("parseLastFmResponse: %v", err)
+	}
+	if info.Bio != "" {
+		t.Errorf("bio = %q, want empty", info.Bio)
+	}
+	if info.ImageURL != "" {
+		t.Errorf("image = %q, want empty", info.ImageURL)
+	}
+	if len(info.Similar) != 0 {
+		t.Errorf("similar = %d, want 0", len(info.Similar))
+	}
+}
+
+func TestParseLastFmApiError(t *testing.T) {
+	body := []byte(`{"error": 6, "message": "The artist you supplied could not be found"}`)
+
+	_, err := parseLastFmResponse(body)
+	if err == nil {
+		t.Error("expected error for API error response")
+	}
+}

--- a/internal/artistinfo/musicbrainz.go
+++ b/internal/artistinfo/musicbrainz.go
@@ -1,0 +1,100 @@
+package artistinfo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// MBInfo holds metadata fetched from MusicBrainz.
+type MBInfo struct {
+	ID             string
+	Disambiguation string
+	Type           string
+	Area           string
+	Begin          string
+	End            string
+	Tags           []string
+}
+
+// FetchMusicBrainz searches MusicBrainz for the named artist and returns metadata.
+func FetchMusicBrainz(artistName string) (*MBInfo, error) {
+	u := "https://musicbrainz.org/ws/2/artist/?" + url.Values{
+		"query": {"artist:" + artistName},
+		"fmt":   {"json"},
+		"limit": {"1"},
+	}.Encode()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("musicbrainz request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Forte/1.0 (github.com/willfish/forte)")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("musicbrainz request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("musicbrainz read body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("musicbrainz status %d: %s", resp.StatusCode, body)
+	}
+
+	return parseMusicBrainzResponse(body)
+}
+
+// mbResponse maps the relevant parts of the MusicBrainz artist search JSON.
+type mbResponse struct {
+	Artists []struct {
+		ID             string `json:"id"`
+		Name           string `json:"name"`
+		Disambiguation string `json:"disambiguation"`
+		Type           string `json:"type"`
+		Area           struct {
+			Name string `json:"name"`
+		} `json:"area"`
+		LifeSpan struct {
+			Begin string `json:"begin"`
+			End   string `json:"end"`
+		} `json:"life-span"`
+		Tags []struct {
+			Name string `json:"name"`
+		} `json:"tags"`
+	} `json:"artists"`
+}
+
+func parseMusicBrainzResponse(body []byte) (*MBInfo, error) {
+	var resp mbResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("musicbrainz parse: %w", err)
+	}
+	if len(resp.Artists) == 0 {
+		return nil, nil
+	}
+
+	a := resp.Artists[0]
+	info := &MBInfo{
+		ID:             a.ID,
+		Disambiguation: a.Disambiguation,
+		Type:           a.Type,
+		Area:           a.Area.Name,
+		Begin:          a.LifeSpan.Begin,
+		End:            a.LifeSpan.End,
+	}
+	for _, tag := range a.Tags {
+		if tag.Name != "" {
+			info.Tags = append(info.Tags, tag.Name)
+		}
+	}
+	return info, nil
+}

--- a/internal/artistinfo/musicbrainz_test.go
+++ b/internal/artistinfo/musicbrainz_test.go
@@ -1,0 +1,89 @@
+package artistinfo
+
+import "testing"
+
+func TestParseMusicBrainzResponse(t *testing.T) {
+	body := []byte(`{
+		"artists": [
+			{
+				"id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+				"name": "Radiohead",
+				"disambiguation": "English rock band",
+				"type": "Group",
+				"area": {"name": "United Kingdom"},
+				"life-span": {"begin": "1985", "end": ""},
+				"tags": [
+					{"name": "rock"},
+					{"name": "alternative rock"},
+					{"name": "electronic"}
+				]
+			}
+		]
+	}`)
+
+	info, err := parseMusicBrainzResponse(body)
+	if err != nil {
+		t.Fatalf("parseMusicBrainzResponse: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if info.ID != "a74b1b7f-71a5-4011-9441-d0b5e4122711" {
+		t.Errorf("id = %q", info.ID)
+	}
+	if info.Type != "Group" {
+		t.Errorf("type = %q", info.Type)
+	}
+	if info.Area != "United Kingdom" {
+		t.Errorf("area = %q", info.Area)
+	}
+	if info.Begin != "1985" {
+		t.Errorf("begin = %q", info.Begin)
+	}
+	if len(info.Tags) != 3 {
+		t.Fatalf("tags count = %d, want 3", len(info.Tags))
+	}
+	if info.Tags[0] != "rock" {
+		t.Errorf("tags[0] = %q", info.Tags[0])
+	}
+}
+
+func TestParseMusicBrainzEmptyResults(t *testing.T) {
+	body := []byte(`{"artists": []}`)
+
+	info, err := parseMusicBrainzResponse(body)
+	if err != nil {
+		t.Fatalf("parseMusicBrainzResponse: %v", err)
+	}
+	if info != nil {
+		t.Error("expected nil for empty results")
+	}
+}
+
+func TestParseMusicBrainzMinimalArtist(t *testing.T) {
+	body := []byte(`{
+		"artists": [
+			{
+				"id": "abc123",
+				"name": "Solo Artist"
+			}
+		]
+	}`)
+
+	info, err := parseMusicBrainzResponse(body)
+	if err != nil {
+		t.Fatalf("parseMusicBrainzResponse: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if info.ID != "abc123" {
+		t.Errorf("id = %q", info.ID)
+	}
+	if info.Type != "" {
+		t.Errorf("type = %q, want empty", info.Type)
+	}
+	if len(info.Tags) != 0 {
+		t.Errorf("tags = %d, want 0", len(info.Tags))
+	}
+}

--- a/internal/library/artist_metadata.go
+++ b/internal/library/artist_metadata.go
@@ -1,0 +1,130 @@
+package library
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// SimilarArtist represents an artist similar to the queried one.
+type SimilarArtist struct {
+	Name string `json:"name"`
+}
+
+// ArtistMeta holds cached metadata for an artist.
+type ArtistMeta struct {
+	ArtistID    int64           `json:"artistId"`
+	Bio         string          `json:"bio"`
+	ImageURL    string          `json:"imageUrl"`
+	Similar     []SimilarArtist `json:"similar"`
+	MbID        string          `json:"mbId"`
+	MbArea      string          `json:"mbArea"`
+	MbType      string          `json:"mbType"`
+	MbBegin     string          `json:"mbBegin"`
+	MbEnd       string          `json:"mbEnd"`
+	MbTags      string          `json:"mbTags"`
+	FetchedAt   time.Time       `json:"fetchedAt"`
+}
+
+const cacheTTL = 30 * 24 * time.Hour
+
+// GetArtistByName returns the artist ID for the given name, or sql.ErrNoRows if not found.
+func (db *DB) GetArtistByName(name string) (int64, error) {
+	var id int64
+	err := db.QueryRow("SELECT id FROM artists WHERE name = ? LIMIT 1", name).Scan(&id)
+	if err != nil {
+		return 0, fmt.Errorf("get artist by name: %w", err)
+	}
+	return id, nil
+}
+
+// GetArtistMeta returns cached metadata for the artist, or nil if missing or expired.
+func (db *DB) GetArtistMeta(artistID int64) (*ArtistMeta, error) {
+	var meta ArtistMeta
+	var similarJSON, fetchedAtStr string
+
+	err := db.QueryRow(`
+		SELECT artist_id, bio, image_url, similar_json, mb_id, mb_area, mb_type, mb_begin, mb_end, mb_tags, fetched_at
+		FROM artist_metadata WHERE artist_id = ?`, artistID,
+	).Scan(
+		&meta.ArtistID, &meta.Bio, &meta.ImageURL, &similarJSON,
+		&meta.MbID, &meta.MbArea, &meta.MbType, &meta.MbBegin, &meta.MbEnd, &meta.MbTags,
+		&fetchedAtStr,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get artist meta: %w", err)
+	}
+
+	fetched, err := time.Parse("2006-01-02 15:04:05", fetchedAtStr)
+	if err != nil {
+		return nil, fmt.Errorf("parse fetched_at: %w", err)
+	}
+	if time.Since(fetched) > cacheTTL {
+		return nil, nil
+	}
+	meta.FetchedAt = fetched
+
+	if err := json.Unmarshal([]byte(similarJSON), &meta.Similar); err != nil {
+		meta.Similar = nil
+	}
+
+	return &meta, nil
+}
+
+// SaveArtistMeta upserts artist metadata into the cache.
+func (db *DB) SaveArtistMeta(artistID int64, meta ArtistMeta) error {
+	similarJSON, err := json.Marshal(meta.Similar)
+	if err != nil {
+		return fmt.Errorf("marshal similar: %w", err)
+	}
+
+	_, err = db.Exec(`
+		INSERT INTO artist_metadata (artist_id, bio, image_url, similar_json, mb_id, mb_area, mb_type, mb_begin, mb_end, mb_tags, fetched_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+		ON CONFLICT(artist_id) DO UPDATE SET
+			bio = excluded.bio,
+			image_url = excluded.image_url,
+			similar_json = excluded.similar_json,
+			mb_id = excluded.mb_id,
+			mb_area = excluded.mb_area,
+			mb_type = excluded.mb_type,
+			mb_begin = excluded.mb_begin,
+			mb_end = excluded.mb_end,
+			mb_tags = excluded.mb_tags,
+			fetched_at = excluded.fetched_at`,
+		artistID, meta.Bio, meta.ImageURL, string(similarJSON),
+		meta.MbID, meta.MbArea, meta.MbType, meta.MbBegin, meta.MbEnd, meta.MbTags,
+	)
+	if err != nil {
+		return fmt.Errorf("save artist meta: %w", err)
+	}
+	return nil
+}
+
+// GetArtistAlbums returns all albums for a given artist, sorted by year.
+func (db *DB) GetArtistAlbums(artistID int64) ([]Album, error) {
+	rows, err := db.Query(`
+		SELECT a.id, a.title, ar.name, a.year, a.track_count, a.server_id
+		FROM albums a
+		JOIN artists ar ON ar.id = a.artist_id
+		WHERE a.artist_id = ?
+		ORDER BY a.year ASC, a.title ASC`, artistID)
+	if err != nil {
+		return nil, fmt.Errorf("get artist albums: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var albums []Album
+	for rows.Next() {
+		var a Album
+		if err := rows.Scan(&a.ID, &a.Title, &a.Artist, &a.Year, &a.TrackCount, &a.ServerID); err != nil {
+			return nil, fmt.Errorf("scan artist album: %w", err)
+		}
+		albums = append(albums, a)
+	}
+	return albums, rows.Err()
+}

--- a/internal/library/artist_metadata_test.go
+++ b/internal/library/artist_metadata_test.go
@@ -1,0 +1,142 @@
+package library
+
+import "testing"
+
+func TestGetArtistByName(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'Radiohead')")
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (2, 'Bjork')")
+
+	id, err := db.GetArtistByName("Radiohead")
+	if err != nil {
+		t.Fatalf("GetArtistByName: %v", err)
+	}
+	if id != 1 {
+		t.Errorf("got id %d, want 1", id)
+	}
+
+	_, err = db.GetArtistByName("Nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent artist")
+	}
+}
+
+func TestSaveAndGetArtistMeta(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'Radiohead')")
+
+	meta := ArtistMeta{
+		Bio:      "English rock band",
+		ImageURL: "https://example.com/radiohead.jpg",
+		Similar:  []SimilarArtist{{Name: "Muse"}, {Name: "Coldplay"}},
+		MbID:     "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+		MbArea:   "United Kingdom",
+		MbType:   "Group",
+		MbBegin:  "1985",
+		MbEnd:    "",
+		MbTags:   "rock, alternative",
+	}
+
+	if err := db.SaveArtistMeta(1, meta); err != nil {
+		t.Fatalf("SaveArtistMeta: %v", err)
+	}
+
+	got, err := db.GetArtistMeta(1)
+	if err != nil {
+		t.Fatalf("GetArtistMeta: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetArtistMeta returned nil")
+	}
+	if got.Bio != "English rock band" {
+		t.Errorf("bio = %q, want 'English rock band'", got.Bio)
+	}
+	if got.ImageURL != "https://example.com/radiohead.jpg" {
+		t.Errorf("image_url = %q", got.ImageURL)
+	}
+	if len(got.Similar) != 2 {
+		t.Fatalf("similar count = %d, want 2", len(got.Similar))
+	}
+	if got.Similar[0].Name != "Muse" {
+		t.Errorf("similar[0] = %q, want 'Muse'", got.Similar[0].Name)
+	}
+	if got.MbArea != "United Kingdom" {
+		t.Errorf("mb_area = %q", got.MbArea)
+	}
+}
+
+func TestGetArtistMetaMissingEntry(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'Radiohead')")
+
+	got, err := db.GetArtistMeta(1)
+	if err != nil {
+		t.Fatalf("GetArtistMeta: %v", err)
+	}
+	if got != nil {
+		t.Error("expected nil for missing entry")
+	}
+}
+
+func TestGetArtistMetaExpired(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'Radiohead')")
+
+	// Insert with a fetched_at 60 days ago.
+	mustExec(t, db, `INSERT INTO artist_metadata (artist_id, bio, fetched_at)
+		VALUES (1, 'old bio', datetime('now', '-60 days'))`)
+
+	got, err := db.GetArtistMeta(1)
+	if err != nil {
+		t.Fatalf("GetArtistMeta: %v", err)
+	}
+	if got != nil {
+		t.Error("expected nil for expired cache entry")
+	}
+}
+
+func TestSaveArtistMetaUpsert(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'Radiohead')")
+
+	meta1 := ArtistMeta{Bio: "first bio"}
+	if err := db.SaveArtistMeta(1, meta1); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	meta2 := ArtistMeta{Bio: "updated bio"}
+	if err := db.SaveArtistMeta(1, meta2); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+
+	got, err := db.GetArtistMeta(1)
+	if err != nil {
+		t.Fatalf("GetArtistMeta: %v", err)
+	}
+	if got == nil || got.Bio != "updated bio" {
+		t.Errorf("expected 'updated bio', got %v", got)
+	}
+}
+
+func TestGetArtistAlbums(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'Radiohead')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year) VALUES (1, 1, 'OK Computer', 1997)")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year) VALUES (2, 1, 'Kid A', 2000)")
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (2, 'Bjork')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year) VALUES (3, 2, 'Homogenic', 1997)")
+
+	albums, err := db.GetArtistAlbums(1)
+	if err != nil {
+		t.Fatalf("GetArtistAlbums: %v", err)
+	}
+	if len(albums) != 2 {
+		t.Fatalf("got %d albums, want 2", len(albums))
+	}
+	if albums[0].Title != "OK Computer" {
+		t.Errorf("first album = %q, want 'OK Computer'", albums[0].Title)
+	}
+	if albums[1].Title != "Kid A" {
+		t.Errorf("second album = %q, want 'Kid A'", albums[1].Title)
+	}
+}

--- a/internal/library/db.go
+++ b/internal/library/db.go
@@ -96,4 +96,5 @@ var migrations = []migration{
 	{version: 6, sql: migration006},
 	{version: 7, sql: migration007},
 	{version: 8, sql: migration008},
+	{version: 9, sql: migration009},
 }

--- a/internal/library/schema.go
+++ b/internal/library/schema.go
@@ -158,3 +158,19 @@ CREATE TABLE play_history (
 CREATE INDEX idx_play_history_played_at ON play_history (played_at);
 CREATE INDEX idx_play_history_track ON play_history (track_id);
 `
+
+const migration009 = `
+CREATE TABLE artist_metadata (
+	artist_id    INTEGER PRIMARY KEY REFERENCES artists(id) ON DELETE CASCADE,
+	bio          TEXT NOT NULL DEFAULT '',
+	image_url    TEXT NOT NULL DEFAULT '',
+	similar_json TEXT NOT NULL DEFAULT '[]',
+	mb_id        TEXT NOT NULL DEFAULT '',
+	mb_area      TEXT NOT NULL DEFAULT '',
+	mb_type      TEXT NOT NULL DEFAULT '',
+	mb_begin     TEXT NOT NULL DEFAULT '',
+	mb_end       TEXT NOT NULL DEFAULT '',
+	mb_tags      TEXT NOT NULL DEFAULT '',
+	fetched_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+`

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/browser"
 	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/willfish/forte/internal/artistinfo"
 	"github.com/willfish/forte/internal/library"
 	"github.com/willfish/forte/internal/scrobbling/lastfm"
 	"github.com/willfish/forte/internal/scrobbling/listenbrainz"
@@ -742,6 +743,131 @@ func toStatJSON(entries []library.StatEntry) []StatEntryJSON {
 		}
 	}
 	return result
+}
+
+// SimilarArtistJSON is the JSON-friendly similar artist type exposed to the frontend.
+type SimilarArtistJSON struct {
+	Name     string `json:"name"`
+	InLibrary bool   `json:"inLibrary"`
+}
+
+// ArtistInfoJSON is the JSON-friendly artist info type exposed to the frontend.
+type ArtistInfoJSON struct {
+	Name        string              `json:"name"`
+	Bio         string              `json:"bio"`
+	ImageURL    string              `json:"imageUrl"`
+	Area        string              `json:"area"`
+	Type        string              `json:"type"`
+	ActiveYears string              `json:"activeYears"`
+	Similar     []SimilarArtistJSON `json:"similar"`
+	Albums      []Album             `json:"albums"`
+	Tags        string              `json:"tags"`
+}
+
+// GetArtistInfo returns metadata for the named artist, using cache with 30-day TTL.
+func (s *LibraryService) GetArtistInfo(artistName string) (ArtistInfoJSON, error) {
+	if s.db == nil {
+		return ArtistInfoJSON{}, fmt.Errorf("library not initialised")
+	}
+
+	artistID, err := s.db.GetArtistByName(artistName)
+	if err != nil {
+		return ArtistInfoJSON{}, fmt.Errorf("artist not found: %w", err)
+	}
+
+	// Check cache.
+	cached, err := s.db.GetArtistMeta(artistID)
+	if err != nil {
+		return ArtistInfoJSON{}, err
+	}
+
+	var meta library.ArtistMeta
+	if cached != nil {
+		meta = *cached
+	} else {
+		// Fetch from external services.
+		apiKey := ""
+		cfg, err := s.db.LoadScrobbleConfig()
+		if err == nil {
+			apiKey = cfg.APIKey
+		}
+
+		result, err := artistinfo.Fetch(apiKey, artistName)
+		if err != nil {
+			return ArtistInfoJSON{}, err
+		}
+
+		meta = library.ArtistMeta{
+			Bio:      result.Bio,
+			ImageURL: result.ImageURL,
+			MbID:     result.MbID,
+			MbArea:   result.MbArea,
+			MbType:   result.MbType,
+			MbBegin:  result.MbBegin,
+			MbEnd:    result.MbEnd,
+			MbTags:   result.MbTags,
+		}
+		for _, sim := range result.Similar {
+			meta.Similar = append(meta.Similar, library.SimilarArtist{Name: sim.Name})
+		}
+
+		_ = s.db.SaveArtistMeta(artistID, meta)
+	}
+
+	// Build albums list.
+	dbAlbums, err := s.db.GetArtistAlbums(artistID)
+	if err != nil {
+		return ArtistInfoJSON{}, err
+	}
+	albums := make([]Album, len(dbAlbums))
+	for i, a := range dbAlbums {
+		albums[i] = Album{
+			ID:         a.ID,
+			Title:      a.Title,
+			Artist:     a.Artist,
+			Year:       a.Year,
+			TrackCount: a.TrackCount,
+			Source:     sourceFromServerID(a.ServerID),
+			ServerID:   a.ServerID,
+		}
+	}
+
+	// Check which similar artists are in the library.
+	similar := make([]SimilarArtistJSON, len(meta.Similar))
+	for i, sim := range meta.Similar {
+		_, lookupErr := s.db.GetArtistByName(sim.Name)
+		similar[i] = SimilarArtistJSON{
+			Name:     sim.Name,
+			InLibrary: lookupErr == nil,
+		}
+	}
+
+	activeYears := meta.MbBegin
+	if meta.MbEnd != "" {
+		activeYears += " - " + meta.MbEnd
+	} else if meta.MbBegin != "" {
+		activeYears += " - present"
+	}
+
+	return ArtistInfoJSON{
+		Name:        artistName,
+		Bio:         meta.Bio,
+		ImageURL:    meta.ImageURL,
+		Area:        meta.MbArea,
+		Type:        meta.MbType,
+		ActiveYears: activeYears,
+		Similar:     similar,
+		Albums:      albums,
+		Tags:        meta.MbTags,
+	}, nil
+}
+
+// GetArtistByName returns the artist ID for the given name.
+func (s *LibraryService) GetArtistByName(name string) (int64, error) {
+	if s.db == nil {
+		return 0, fmt.Errorf("library not initialised")
+	}
+	return s.db.GetArtistByName(name)
 }
 
 // newUUID generates a random UUID v4 string.


### PR DESCRIPTION
Closes #44

### What?

- [x] Add `artist_metadata` table (migration009) with bio, image, similar artists, MusicBrainz fields, and 30-day TTL
- [x] Add `internal/artistinfo/` package - Last.fm `artist.getInfo` client, MusicBrainz artist search client, orchestrator with rate limiting (200ms Last.fm, 1s MusicBrainz)
- [x] Add cache CRUD methods (`GetArtistByName`, `GetArtistMeta`, `SaveArtistMeta`, `GetArtistAlbums`)
- [x] Add `GetArtistInfo` service method - checks cache, fetches on miss, returns combined data
- [x] Add `ArtistView.svelte` - artist page with header, bio, albums grid, similar artists, tags
- [x] Make artist names clickable in AlbumView, SearchResults, and StatsView
- [x] Add routing in Content.svelte for artist navigation (including cross-view from stats)

### Why?

Artist pages give context about the music in your library - biographies, discographies, and discovery via similar artists. Last.fm provides rich bio/image/similar data, MusicBrainz supplements with area, type, active years, and tags.

### Design decisions

- **Last.fm primary, MusicBrainz supplementary** - Last.fm has better bio/image/similar coverage. MusicBrainz adds structured metadata (area, type, lifespan, tags). Both are always queried.
- **Cache in SQLite with 30-day TTL** - avoids repeated API calls. Keyed on artist_id, upserted on refresh.
- **Rate limiting via sleep** - simple and sufficient for on-demand single-artist fetches.
- **Reuses Last.fm API key from scrobble config** - no additional configuration needed. Falls back to MusicBrainz-only if no key configured.
- **Navigation by name, not ID** - some contexts (search results, stats) don't have the artist ID readily available.