### PR TITLE
Unit test coverage audit and gap filling

### DIFF
--- a/internal/artistinfo/fetch_test.go
+++ b/internal/artistinfo/fetch_test.go
@@ -1,0 +1,30 @@
+package artistinfo
+
+import "testing"
+
+func TestFetchNoAPIKey(t *testing.T) {
+	// With empty API key, Last.fm is skipped but MusicBrainz is still called.
+	// We can't test the actual HTTP call, but we can verify it doesn't panic
+	// and returns a result even when both services are unreachable.
+	result, err := Fetch("", "Nonexistent Artist 12345")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	// Bio should be empty since no API key was provided.
+	if result.Bio != "" {
+		t.Errorf("Bio = %q, expected empty without API key", result.Bio)
+	}
+}
+
+func TestResultFieldsZeroValue(t *testing.T) {
+	r := &Result{}
+	if r.Bio != "" || r.ImageURL != "" || r.MbID != "" {
+		t.Error("expected zero-value Result to have empty strings")
+	}
+	if r.Similar != nil {
+		t.Error("expected nil Similar slice")
+	}
+}

--- a/internal/library/albums_test.go
+++ b/internal/library/albums_test.go
@@ -1,0 +1,219 @@
+package library
+
+import (
+	"testing"
+)
+
+func TestGetAlbumsDefaultSort(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'Radiohead')")
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (2, 'Bjork')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year) VALUES (1, 1, 'OK Computer', 1997)")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year) VALUES (2, 2, 'Homogenic', 1997)")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year) VALUES (3, 1, 'Kid A', 2000)")
+
+	albums, err := db.GetAlbums("title", "asc", "")
+	if err != nil {
+		t.Fatalf("GetAlbums: %v", err)
+	}
+	if len(albums) != 3 {
+		t.Fatalf("got %d albums, want 3", len(albums))
+	}
+	if albums[0].Title != "Homogenic" {
+		t.Errorf("first album = %q, want 'Homogenic'", albums[0].Title)
+	}
+}
+
+func TestGetAlbumsSortByYear(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'Radiohead')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year) VALUES (1, 1, 'Kid A', 2000)")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year) VALUES (2, 1, 'OK Computer', 1997)")
+
+	albums, err := db.GetAlbums("year", "desc", "")
+	if err != nil {
+		t.Fatalf("GetAlbums: %v", err)
+	}
+	if len(albums) != 2 {
+		t.Fatalf("got %d albums, want 2", len(albums))
+	}
+	if albums[0].Title != "Kid A" {
+		t.Errorf("first album = %q, want 'Kid A'", albums[0].Title)
+	}
+}
+
+func TestGetAlbumsSortByArtist(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'Radiohead')")
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (2, 'Bjork')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year) VALUES (1, 1, 'OK Computer', 1997)")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year) VALUES (2, 2, 'Homogenic', 1997)")
+
+	albums, err := db.GetAlbums("artist", "asc", "")
+	if err != nil {
+		t.Fatalf("GetAlbums: %v", err)
+	}
+	if albums[0].Artist != "Bjork" {
+		t.Errorf("first artist = %q, want 'Bjork'", albums[0].Artist)
+	}
+}
+
+func TestGetAlbumsSourceFilter(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'Radiohead')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year, server_id) VALUES (1, 1, 'OK Computer', 1997, '')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year, server_id) VALUES (2, 1, 'Kid A', 2000, 'srv-1')")
+
+	local, err := db.GetAlbums("title", "asc", "local")
+	if err != nil {
+		t.Fatalf("GetAlbums local: %v", err)
+	}
+	if len(local) != 1 {
+		t.Fatalf("local: got %d albums, want 1", len(local))
+	}
+	if local[0].Title != "OK Computer" {
+		t.Errorf("local album = %q", local[0].Title)
+	}
+
+	server, err := db.GetAlbums("title", "asc", "server")
+	if err != nil {
+		t.Fatalf("GetAlbums server: %v", err)
+	}
+	if len(server) != 1 {
+		t.Fatalf("server: got %d albums, want 1", len(server))
+	}
+	if server[0].Title != "Kid A" {
+		t.Errorf("server album = %q", server[0].Title)
+	}
+}
+
+func TestGetAlbumsDedup(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'Radiohead')")
+	// Same album locally and from server - local should win.
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year, server_id) VALUES (1, 1, 'OK Computer', 1997, '')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year, server_id) VALUES (2, 1, 'OK Computer', 1997, 'srv-1')")
+
+	albums, err := db.GetAlbums("title", "asc", "")
+	if err != nil {
+		t.Fatalf("GetAlbums: %v", err)
+	}
+	if len(albums) != 1 {
+		t.Fatalf("got %d albums, want 1 (deduped)", len(albums))
+	}
+	if albums[0].ServerID != "" {
+		t.Error("expected local album to win dedup, got server album")
+	}
+}
+
+func TestGetAlbumsEmpty(t *testing.T) {
+	db := openTestDB(t)
+	albums, err := db.GetAlbums("title", "asc", "")
+	if err != nil {
+		t.Fatalf("GetAlbums: %v", err)
+	}
+	if len(albums) != 0 {
+		t.Errorf("expected empty, got %d albums", len(albums))
+	}
+}
+
+func TestAlbumArtwork(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'A')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title) VALUES (1, 1, 'Album')")
+
+	// No artwork yet.
+	art, err := db.AlbumArtwork(1)
+	if err != nil {
+		t.Fatalf("AlbumArtwork: %v", err)
+	}
+	if art != "" {
+		t.Errorf("expected empty, got %q", art)
+	}
+
+	// Set artwork.
+	mustExec(t, db, "UPDATE albums SET artwork_blob = X'89504E47' WHERE id = 1")
+	art, err = db.AlbumArtwork(1)
+	if err != nil {
+		t.Fatalf("AlbumArtwork: %v", err)
+	}
+	if art == "" {
+		t.Fatal("expected non-empty artwork")
+	}
+	if art[:len("data:image/jpeg;base64,")] != "data:image/jpeg;base64," {
+		t.Errorf("unexpected prefix: %q", art[:30])
+	}
+}
+
+func TestAlbumArtworkMissingAlbum(t *testing.T) {
+	db := openTestDB(t)
+	art, err := db.AlbumArtwork(999)
+	if err != nil {
+		t.Fatalf("AlbumArtwork: %v", err)
+	}
+	if art != "" {
+		t.Errorf("expected empty for missing album, got %q", art)
+	}
+}
+
+func TestGetAlbumTracks(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'Radiohead')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title, year) VALUES (1, 1, 'OK Computer', 1997)")
+	mustExec(t, db, `INSERT INTO tracks (id, album_id, artist_id, title, track_number, disc_number, duration_ms, file_path)
+		VALUES (1, 1, 1, 'Airbag', 1, 1, 282000, '/music/airbag.flac')`)
+	mustExec(t, db, `INSERT INTO tracks (id, album_id, artist_id, title, track_number, disc_number, duration_ms, file_path)
+		VALUES (2, 1, 1, 'Paranoid Android', 2, 1, 386000, '/music/paranoid.flac')`)
+
+	tracks, err := db.GetAlbumTracks(1)
+	if err != nil {
+		t.Fatalf("GetAlbumTracks: %v", err)
+	}
+	if len(tracks) != 2 {
+		t.Fatalf("got %d tracks, want 2", len(tracks))
+	}
+	if tracks[0].Title != "Airbag" {
+		t.Errorf("first track = %q, want 'Airbag'", tracks[0].Title)
+	}
+	if tracks[0].Artist != "Radiohead" {
+		t.Errorf("artist = %q, want 'Radiohead'", tracks[0].Artist)
+	}
+	if tracks[1].TrackNumber != 2 {
+		t.Errorf("track number = %d, want 2", tracks[1].TrackNumber)
+	}
+}
+
+func TestGetAlbumTracksEmpty(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'A')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title) VALUES (1, 1, 'Album')")
+
+	tracks, err := db.GetAlbumTracks(1)
+	if err != nil {
+		t.Fatalf("GetAlbumTracks: %v", err)
+	}
+	if len(tracks) != 0 {
+		t.Errorf("expected empty, got %d tracks", len(tracks))
+	}
+}
+
+func TestGetAlbumTracksDiscOrdering(t *testing.T) {
+	db := openTestDB(t)
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'A')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title) VALUES (1, 1, 'Double Album')")
+	mustExec(t, db, `INSERT INTO tracks (id, album_id, artist_id, title, track_number, disc_number, file_path)
+		VALUES (1, 1, 1, 'Disc 2 Track 1', 1, 2, '/music/d2t1.flac')`)
+	mustExec(t, db, `INSERT INTO tracks (id, album_id, artist_id, title, track_number, disc_number, file_path)
+		VALUES (2, 1, 1, 'Disc 1 Track 1', 1, 1, '/music/d1t1.flac')`)
+
+	tracks, err := db.GetAlbumTracks(1)
+	if err != nil {
+		t.Fatalf("GetAlbumTracks: %v", err)
+	}
+	if tracks[0].DiscNumber != 1 {
+		t.Errorf("first track disc = %d, want 1", tracks[0].DiscNumber)
+	}
+	if tracks[1].DiscNumber != 2 {
+		t.Errorf("second track disc = %d, want 2", tracks[1].DiscNumber)
+	}
+}

--- a/internal/library/config_test.go
+++ b/internal/library/config_test.go
@@ -1,0 +1,111 @@
+package library
+
+import "testing"
+
+func TestSaveAndLoadScrobbleConfig(t *testing.T) {
+	db := openTestDB(t)
+
+	cfg := ScrobbleConfig{
+		APIKey:     "key123",
+		APISecret:  "secret456",
+		SessionKey: "session789",
+		Username:   "testuser",
+		Enabled:    true,
+	}
+
+	if err := db.SaveScrobbleConfig(cfg); err != nil {
+		t.Fatalf("SaveScrobbleConfig: %v", err)
+	}
+
+	got, err := db.LoadScrobbleConfig()
+	if err != nil {
+		t.Fatalf("LoadScrobbleConfig: %v", err)
+	}
+
+	if got.APIKey != "key123" {
+		t.Errorf("APIKey = %q", got.APIKey)
+	}
+	if got.APISecret != "secret456" {
+		t.Errorf("APISecret = %q", got.APISecret)
+	}
+	if got.SessionKey != "session789" {
+		t.Errorf("SessionKey = %q", got.SessionKey)
+	}
+	if got.Username != "testuser" {
+		t.Errorf("Username = %q", got.Username)
+	}
+	if !got.Enabled {
+		t.Error("Enabled = false, want true")
+	}
+}
+
+func TestLoadScrobbleConfigDefault(t *testing.T) {
+	db := openTestDB(t)
+
+	got, err := db.LoadScrobbleConfig()
+	if err != nil {
+		t.Fatalf("LoadScrobbleConfig: %v", err)
+	}
+	if got.APIKey != "" {
+		t.Errorf("default APIKey = %q, want empty", got.APIKey)
+	}
+	if got.Enabled {
+		t.Error("default Enabled = true, want false")
+	}
+}
+
+func TestScrobbleConfigDisable(t *testing.T) {
+	db := openTestDB(t)
+
+	_ = db.SaveScrobbleConfig(ScrobbleConfig{Enabled: true})
+	_ = db.SaveScrobbleConfig(ScrobbleConfig{Enabled: false})
+
+	got, _ := db.LoadScrobbleConfig()
+	if got.Enabled {
+		t.Error("Enabled = true after disabling")
+	}
+}
+
+func TestSaveAndLoadListenBrainzConfig(t *testing.T) {
+	db := openTestDB(t)
+
+	cfg := ListenBrainzConfig{
+		UserToken: "token-abc",
+		Username:  "lbuser",
+		Enabled:   true,
+	}
+
+	if err := db.SaveListenBrainzConfig(cfg); err != nil {
+		t.Fatalf("SaveListenBrainzConfig: %v", err)
+	}
+
+	got, err := db.LoadListenBrainzConfig()
+	if err != nil {
+		t.Fatalf("LoadListenBrainzConfig: %v", err)
+	}
+
+	if got.UserToken != "token-abc" {
+		t.Errorf("UserToken = %q", got.UserToken)
+	}
+	if got.Username != "lbuser" {
+		t.Errorf("Username = %q", got.Username)
+	}
+	if !got.Enabled {
+		t.Error("Enabled = false, want true")
+	}
+}
+
+func TestLoadListenBrainzConfigDefault(t *testing.T) {
+	db := openTestDB(t)
+
+	got, err := db.LoadListenBrainzConfig()
+	if err != nil {
+		t.Fatalf("LoadListenBrainzConfig: %v", err)
+	}
+	if got.UserToken != "" {
+		t.Errorf("default UserToken = %q", got.UserToken)
+	}
+	if got.Enabled {
+		t.Error("default Enabled = true, want false")
+	}
+}

--- a/internal/library/playback_state_test.go
+++ b/internal/library/playback_state_test.go
@@ -1,0 +1,89 @@
+package library
+
+import "testing"
+
+func TestSaveAndLoadPlaybackState(t *testing.T) {
+	db := openTestDB(t)
+
+	state := PlaybackState{
+		QueueJSON:       `[{"path":"/a.flac"}]`,
+		Position:        3,
+		TrackPositionMs: 45000,
+		Volume:          80,
+		Shuffle:         true,
+		RepeatMode:      "all",
+	}
+
+	if err := db.SavePlaybackState(state); err != nil {
+		t.Fatalf("SavePlaybackState: %v", err)
+	}
+
+	got, err := db.LoadPlaybackState()
+	if err != nil {
+		t.Fatalf("LoadPlaybackState: %v", err)
+	}
+
+	if got.QueueJSON != state.QueueJSON {
+		t.Errorf("QueueJSON = %q", got.QueueJSON)
+	}
+	if got.Position != 3 {
+		t.Errorf("Position = %d, want 3", got.Position)
+	}
+	if got.TrackPositionMs != 45000 {
+		t.Errorf("TrackPositionMs = %d", got.TrackPositionMs)
+	}
+	if got.Volume != 80 {
+		t.Errorf("Volume = %d", got.Volume)
+	}
+	if !got.Shuffle {
+		t.Error("Shuffle = false, want true")
+	}
+	if got.RepeatMode != "all" {
+		t.Errorf("RepeatMode = %q", got.RepeatMode)
+	}
+}
+
+func TestLoadPlaybackStateDefault(t *testing.T) {
+	db := openTestDB(t)
+
+	got, err := db.LoadPlaybackState()
+	if err != nil {
+		t.Fatalf("LoadPlaybackState: %v", err)
+	}
+	if got.Position != -1 {
+		t.Errorf("default Position = %d, want -1", got.Position)
+	}
+	if got.Volume != 100 {
+		t.Errorf("default Volume = %d, want 100", got.Volume)
+	}
+	if got.Shuffle {
+		t.Error("default Shuffle = true, want false")
+	}
+	if got.RepeatMode != "off" {
+		t.Errorf("default RepeatMode = %q, want 'off'", got.RepeatMode)
+	}
+}
+
+func TestSavePlaybackStateOverwrite(t *testing.T) {
+	db := openTestDB(t)
+
+	_ = db.SavePlaybackState(PlaybackState{Volume: 50})
+	_ = db.SavePlaybackState(PlaybackState{Volume: 75})
+
+	got, _ := db.LoadPlaybackState()
+	if got.Volume != 75 {
+		t.Errorf("Volume = %d, want 75", got.Volume)
+	}
+}
+
+func TestPlaybackStateShuffleFalse(t *testing.T) {
+	db := openTestDB(t)
+
+	_ = db.SavePlaybackState(PlaybackState{Shuffle: true})
+	_ = db.SavePlaybackState(PlaybackState{Shuffle: false})
+
+	got, _ := db.LoadPlaybackState()
+	if got.Shuffle {
+		t.Error("Shuffle = true, want false")
+	}
+}

--- a/internal/library/playlists_test.go
+++ b/internal/library/playlists_test.go
@@ -1,0 +1,239 @@
+package library
+
+import "testing"
+
+func TestCreateAndGetPlaylists(t *testing.T) {
+	db := openTestDB(t)
+
+	id, err := db.CreatePlaylist("My Playlist")
+	if err != nil {
+		t.Fatalf("CreatePlaylist: %v", err)
+	}
+	if id <= 0 {
+		t.Errorf("expected positive id, got %d", id)
+	}
+
+	playlists, err := db.GetPlaylists()
+	if err != nil {
+		t.Fatalf("GetPlaylists: %v", err)
+	}
+	if len(playlists) != 1 {
+		t.Fatalf("got %d playlists, want 1", len(playlists))
+	}
+	if playlists[0].Name != "My Playlist" {
+		t.Errorf("name = %q, want 'My Playlist'", playlists[0].Name)
+	}
+}
+
+func TestGetPlaylistsOrdering(t *testing.T) {
+	db := openTestDB(t)
+	_, _ = db.CreatePlaylist("Zebra")
+	_, _ = db.CreatePlaylist("Alpha")
+
+	playlists, err := db.GetPlaylists()
+	if err != nil {
+		t.Fatalf("GetPlaylists: %v", err)
+	}
+	if len(playlists) != 2 {
+		t.Fatalf("got %d playlists", len(playlists))
+	}
+	if playlists[0].Name != "Alpha" {
+		t.Errorf("first = %q, want 'Alpha'", playlists[0].Name)
+	}
+}
+
+func TestGetPlaylistsEmpty(t *testing.T) {
+	db := openTestDB(t)
+	playlists, err := db.GetPlaylists()
+	if err != nil {
+		t.Fatalf("GetPlaylists: %v", err)
+	}
+	if len(playlists) != 0 {
+		t.Errorf("expected empty, got %d", len(playlists))
+	}
+}
+
+func TestRenamePlaylist(t *testing.T) {
+	db := openTestDB(t)
+	id, _ := db.CreatePlaylist("Old Name")
+
+	if err := db.RenamePlaylist(id, "New Name"); err != nil {
+		t.Fatalf("RenamePlaylist: %v", err)
+	}
+
+	playlists, _ := db.GetPlaylists()
+	if playlists[0].Name != "New Name" {
+		t.Errorf("name = %q, want 'New Name'", playlists[0].Name)
+	}
+}
+
+func TestDeletePlaylist(t *testing.T) {
+	db := openTestDB(t)
+	id, _ := db.CreatePlaylist("To Delete")
+
+	if err := db.DeletePlaylist(id); err != nil {
+		t.Fatalf("DeletePlaylist: %v", err)
+	}
+
+	playlists, _ := db.GetPlaylists()
+	if len(playlists) != 0 {
+		t.Errorf("expected empty after delete, got %d", len(playlists))
+	}
+}
+
+func TestDeletePlaylistCascade(t *testing.T) {
+	db := openTestDB(t)
+	id, _ := db.CreatePlaylist("Playlist")
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'A')")
+	mustExec(t, db, `INSERT INTO tracks (id, artist_id, title, file_path) VALUES (1, 1, 'T', '/a.flac')`)
+	_ = db.AddTrackToPlaylist(id, 1)
+
+	if err := db.DeletePlaylist(id); err != nil {
+		t.Fatalf("DeletePlaylist: %v", err)
+	}
+
+	var count int
+	_ = db.QueryRow("SELECT COUNT(*) FROM playlist_tracks WHERE playlist_id = ?", id).Scan(&count)
+	if count != 0 {
+		t.Errorf("playlist_tracks count = %d after delete, want 0", count)
+	}
+}
+
+func TestPlaylistTracksCRUD(t *testing.T) {
+	db := openTestDB(t)
+	plID, _ := db.CreatePlaylist("Playlist")
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'A')")
+	mustExec(t, db, "INSERT INTO albums (id, artist_id, title) VALUES (1, 1, 'Album')")
+	mustExec(t, db, `INSERT INTO tracks (id, album_id, artist_id, title, duration_ms, file_path)
+		VALUES (1, 1, 1, 'Track 1', 180000, '/a.flac')`)
+	mustExec(t, db, `INSERT INTO tracks (id, album_id, artist_id, title, duration_ms, file_path)
+		VALUES (2, 1, 1, 'Track 2', 200000, '/b.flac')`)
+
+	// Add tracks.
+	if err := db.AddTrackToPlaylist(plID, 1); err != nil {
+		t.Fatalf("AddTrackToPlaylist: %v", err)
+	}
+	if err := db.AddTrackToPlaylist(plID, 2); err != nil {
+		t.Fatalf("AddTrackToPlaylist: %v", err)
+	}
+
+	tracks, err := db.GetPlaylistTracks(plID)
+	if err != nil {
+		t.Fatalf("GetPlaylistTracks: %v", err)
+	}
+	if len(tracks) != 2 {
+		t.Fatalf("got %d tracks, want 2", len(tracks))
+	}
+	if tracks[0].Title != "Track 1" || tracks[0].Position != 0 {
+		t.Errorf("track[0] = %q pos %d", tracks[0].Title, tracks[0].Position)
+	}
+	if tracks[1].Title != "Track 2" || tracks[1].Position != 1 {
+		t.Errorf("track[1] = %q pos %d", tracks[1].Title, tracks[1].Position)
+	}
+
+	// Remove first track.
+	if err := db.RemoveTrackFromPlaylist(plID, 1); err != nil {
+		t.Fatalf("RemoveTrackFromPlaylist: %v", err)
+	}
+
+	tracks, _ = db.GetPlaylistTracks(plID)
+	if len(tracks) != 1 {
+		t.Fatalf("got %d tracks after remove, want 1", len(tracks))
+	}
+	if tracks[0].Title != "Track 2" {
+		t.Errorf("remaining track = %q", tracks[0].Title)
+	}
+	if tracks[0].Position != 0 {
+		t.Errorf("position = %d after reorder, want 0", tracks[0].Position)
+	}
+}
+
+func TestGetPlaylistTracksEmpty(t *testing.T) {
+	db := openTestDB(t)
+	plID, _ := db.CreatePlaylist("Empty")
+
+	tracks, err := db.GetPlaylistTracks(plID)
+	if err != nil {
+		t.Fatalf("GetPlaylistTracks: %v", err)
+	}
+	if len(tracks) != 0 {
+		t.Errorf("expected empty, got %d", len(tracks))
+	}
+}
+
+func TestMoveTrackInPlaylistDown(t *testing.T) {
+	db := openTestDB(t)
+	plID, _ := db.CreatePlaylist("Playlist")
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'A')")
+	mustExec(t, db, `INSERT INTO tracks (id, artist_id, title, file_path) VALUES (1, 1, 'T1', '/1.flac')`)
+	mustExec(t, db, `INSERT INTO tracks (id, artist_id, title, file_path) VALUES (2, 1, 'T2', '/2.flac')`)
+	mustExec(t, db, `INSERT INTO tracks (id, artist_id, title, file_path) VALUES (3, 1, 'T3', '/3.flac')`)
+	_ = db.AddTrackToPlaylist(plID, 1)
+	_ = db.AddTrackToPlaylist(plID, 2)
+	_ = db.AddTrackToPlaylist(plID, 3)
+
+	// Move first track to last position.
+	if err := db.MoveTrackInPlaylist(plID, 0, 2); err != nil {
+		t.Fatalf("MoveTrackInPlaylist: %v", err)
+	}
+
+	tracks, _ := db.GetPlaylistTracks(plID)
+	if len(tracks) != 3 {
+		t.Fatalf("got %d tracks", len(tracks))
+	}
+	// Expected order: T2, T3, T1
+	if tracks[0].Title != "T2" {
+		t.Errorf("pos 0 = %q, want T2", tracks[0].Title)
+	}
+	if tracks[1].Title != "T3" {
+		t.Errorf("pos 1 = %q, want T3", tracks[1].Title)
+	}
+	if tracks[2].Title != "T1" {
+		t.Errorf("pos 2 = %q, want T1", tracks[2].Title)
+	}
+}
+
+func TestMoveTrackInPlaylistUp(t *testing.T) {
+	db := openTestDB(t)
+	plID, _ := db.CreatePlaylist("Playlist")
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'A')")
+	mustExec(t, db, `INSERT INTO tracks (id, artist_id, title, file_path) VALUES (1, 1, 'T1', '/1.flac')`)
+	mustExec(t, db, `INSERT INTO tracks (id, artist_id, title, file_path) VALUES (2, 1, 'T2', '/2.flac')`)
+	mustExec(t, db, `INSERT INTO tracks (id, artist_id, title, file_path) VALUES (3, 1, 'T3', '/3.flac')`)
+	_ = db.AddTrackToPlaylist(plID, 1)
+	_ = db.AddTrackToPlaylist(plID, 2)
+	_ = db.AddTrackToPlaylist(plID, 3)
+
+	// Move last track to first position.
+	if err := db.MoveTrackInPlaylist(plID, 2, 0); err != nil {
+		t.Fatalf("MoveTrackInPlaylist: %v", err)
+	}
+
+	tracks, _ := db.GetPlaylistTracks(plID)
+	// Expected order: T3, T1, T2
+	if tracks[0].Title != "T3" {
+		t.Errorf("pos 0 = %q, want T3", tracks[0].Title)
+	}
+	if tracks[1].Title != "T1" {
+		t.Errorf("pos 1 = %q, want T1", tracks[1].Title)
+	}
+	if tracks[2].Title != "T2" {
+		t.Errorf("pos 2 = %q, want T2", tracks[2].Title)
+	}
+}
+
+func TestAddDuplicateTrackToPlaylist(t *testing.T) {
+	db := openTestDB(t)
+	plID, _ := db.CreatePlaylist("Playlist")
+	mustExec(t, db, "INSERT INTO artists (id, name) VALUES (1, 'A')")
+	mustExec(t, db, `INSERT INTO tracks (id, artist_id, title, file_path) VALUES (1, 1, 'T', '/a.flac')`)
+
+	_ = db.AddTrackToPlaylist(plID, 1)
+	// Adding same track again should be ignored (INSERT OR IGNORE).
+	_ = db.AddTrackToPlaylist(plID, 1)
+
+	tracks, _ := db.GetPlaylistTracks(plID)
+	if len(tracks) != 1 {
+		t.Errorf("expected 1 track (no duplicate), got %d", len(tracks))
+	}
+}

--- a/internal/library/resolver_test.go
+++ b/internal/library/resolver_test.go
@@ -1,0 +1,66 @@
+package library
+
+import "testing"
+
+func TestIsServerPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"server://srv-1/track-42", true},
+		{"server://", true},
+		{"/home/user/music/song.flac", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsServerPath(tt.path); got != tt.want {
+			t.Errorf("IsServerPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestParseServerPath(t *testing.T) {
+	serverID, remoteID, err := ParseServerPath("server://srv-1/track-42")
+	if err != nil {
+		t.Fatalf("ParseServerPath: %v", err)
+	}
+	if serverID != "srv-1" {
+		t.Errorf("serverID = %q, want 'srv-1'", serverID)
+	}
+	if remoteID != "track-42" {
+		t.Errorf("remoteID = %q, want 'track-42'", remoteID)
+	}
+}
+
+func TestParseServerPathInvalid(t *testing.T) {
+	_, _, err := ParseServerPath("server://no-slash")
+	if err == nil {
+		t.Error("expected error for path without second slash")
+	}
+}
+
+func TestParseServerPathNestedRemoteID(t *testing.T) {
+	serverID, remoteID, err := ParseServerPath("server://srv/a/b/c")
+	if err != nil {
+		t.Fatalf("ParseServerPath: %v", err)
+	}
+	if serverID != "srv" {
+		t.Errorf("serverID = %q", serverID)
+	}
+	if remoteID != "a/b/c" {
+		t.Errorf("remoteID = %q, want 'a/b/c'", remoteID)
+	}
+}
+
+func TestResolveLocalPath(t *testing.T) {
+	db := openTestDB(t)
+	r := NewPathResolver(db)
+
+	path, err := r.Resolve("/home/user/music/song.flac")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if path != "/home/user/music/song.flac" {
+		t.Errorf("got %q, want unchanged local path", path)
+	}
+}

--- a/internal/library/sync_test.go
+++ b/internal/library/sync_test.go
@@ -1,0 +1,41 @@
+package library
+
+import "testing"
+
+func TestServerFilePath(t *testing.T) {
+	got := serverFilePath("srv-1", "track-42")
+	want := "server://srv-1/track-42"
+	if got != want {
+		t.Errorf("serverFilePath = %q, want %q", got, want)
+	}
+}
+
+func TestNewProviderSubsonic(t *testing.T) {
+	srv := Server{ID: "1", Name: "Test", Type: "subsonic", URL: "http://localhost", Username: "u", Password: "p"}
+	p, err := newProvider(srv)
+	if err != nil {
+		t.Fatalf("newProvider subsonic: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestNewProviderJellyfin(t *testing.T) {
+	srv := Server{ID: "1", Name: "Test", Type: "jellyfin", URL: "http://localhost", Username: "u", Password: "p"}
+	p, err := newProvider(srv)
+	if err != nil {
+		t.Fatalf("newProvider jellyfin: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestNewProviderUnknown(t *testing.T) {
+	srv := Server{ID: "1", Name: "Test", Type: "unknown", URL: "http://localhost"}
+	_, err := newProvider(srv)
+	if err == nil {
+		t.Error("expected error for unknown server type")
+	}
+}

--- a/internal/player/notifications_test.go
+++ b/internal/player/notifications_test.go
@@ -1,0 +1,65 @@
+package player
+
+import "testing"
+
+func TestNewNotifications(t *testing.T) {
+	n := NewNotifications()
+	if n == nil {
+		t.Fatal("NewNotifications returned nil")
+	}
+}
+
+func TestPushAndDrain(t *testing.T) {
+	n := NewNotifications()
+	n.Push("hello", "info")
+	n.Push("error occurred", "error")
+
+	toasts := n.Drain()
+	if len(toasts) != 2 {
+		t.Fatalf("got %d toasts, want 2", len(toasts))
+	}
+	if toasts[0].Message != "hello" {
+		t.Errorf("toast[0].Message = %q", toasts[0].Message)
+	}
+	if toasts[0].Type != "info" {
+		t.Errorf("toast[0].Type = %q", toasts[0].Type)
+	}
+	if toasts[1].Type != "error" {
+		t.Errorf("toast[1].Type = %q", toasts[1].Type)
+	}
+}
+
+func TestDrainEmpty(t *testing.T) {
+	n := NewNotifications()
+	toasts := n.Drain()
+	if toasts != nil {
+		t.Errorf("expected nil for empty drain, got %v", toasts)
+	}
+}
+
+func TestDrainClearsQueue(t *testing.T) {
+	n := NewNotifications()
+	n.Push("msg", "info")
+
+	_ = n.Drain()
+
+	toasts := n.Drain()
+	if toasts != nil {
+		t.Errorf("expected nil after second drain, got %v", toasts)
+	}
+}
+
+func TestPushAfterDrain(t *testing.T) {
+	n := NewNotifications()
+	n.Push("first", "info")
+	_ = n.Drain()
+
+	n.Push("second", "warn")
+	toasts := n.Drain()
+	if len(toasts) != 1 {
+		t.Fatalf("got %d toasts, want 1", len(toasts))
+	}
+	if toasts[0].Message != "second" {
+		t.Errorf("message = %q, want 'second'", toasts[0].Message)
+	}
+}


### PR DESCRIPTION
## Summary

- Add tests for `internal/library/albums.go` - sorting, source filtering, dedup, artwork, album tracks
- Add tests for `internal/library/playlists.go` - full CRUD, track add/remove/move/reorder, cascade delete
- Add tests for `internal/library/playback_state.go` - save/load roundtrip, defaults, overwrite
- Add tests for `internal/library/scrobble_config.go` and `listenbrainz_config.go` - save/load/defaults
- Add tests for `internal/library/resolver.go` - IsServerPath, ParseServerPath, local path passthrough
- Add tests for `internal/library/sync.go` - serverFilePath, newProvider for subsonic/jellyfin/unknown
- Add tests for `internal/player/notifications.go` - push, drain, empty drain, drain clears queue
- Add tests for `internal/artistinfo/fetch.go` - fetch without API key, zero-value result

## Test plan

- [x] `go test -tags nocgo ./internal/library/ ./internal/player/ ./internal/artistinfo/` passes
- [x] `golangci-lint run --build-tags nocgo` passes
- [ ] CI green

Closes #90