### PR TITLE
Add Playwright e2e tests for Svelte frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
 
       - run: npm ci
       - run: npm run check
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
 
   build:
     name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ bin/
 frontend/.vite/
 frontend/dist
 frontend/node_modules
+frontend/test-results
 
 # Nix/direnv
 .direnv/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@wailsio/runtime": "latest"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@tsconfig/svelte": "^5.0.4",
         "svelte": "^5.0.0",
@@ -509,6 +510,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1215,6 +1232,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,12 +8,14 @@
     "build:dev": "vite build --minify false --mode development",
     "build": "vite build --mode production",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "test:e2e": "npx playwright test"
   },
   "dependencies": {
     "@wailsio/runtime": "latest"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tsconfig/svelte": "^5.0.4",
     "svelte": "^5.0.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        ...(process.env.CHROME_PATH ? { launchOptions: { executablePath: process.env.CHROME_PATH } } : {}),
+      },
+    },
+  ],
+  webServer: {
+    command: "npx vite --config vite.config.test.ts",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+});

--- a/frontend/tests/album-browse.spec.ts
+++ b/frontend/tests/album-browse.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Album browsing", () => {
+  test("displays album grid with fixture data", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".album-title").first()).toBeVisible();
+    const titles = await page.locator(".album-title").allTextContents();
+    expect(titles).toContain("OK Computer");
+    expect(titles).toContain("Kid A");
+    expect(titles).toContain("Homogenic");
+  });
+
+  test("shows album count in toolbar", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".count")).toContainText("3 albums");
+  });
+
+  test("sort buttons are visible", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: "Title" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Artist" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Year" })).toBeVisible();
+  });
+
+  test("source filter buttons are visible", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: "All" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Local" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Server" })).toBeVisible();
+  });
+
+  test("clicking an album opens album detail view", async ({ page }) => {
+    await page.goto("/");
+    await page.locator(".album-card").first().click();
+    // AlbumView shows track list with track titles from GetAlbumTracks fixture.
+    await expect(page.getByText("Airbag")).toBeVisible();
+    await expect(page.getByText("Paranoid Android")).toBeVisible();
+  });
+});

--- a/frontend/tests/mocks/wails-runtime.ts
+++ b/frontend/tests/mocks/wails-runtime.ts
@@ -1,0 +1,212 @@
+// Mock @wailsio/runtime for Playwright e2e tests.
+// Maps Wails Call.ByID numeric identifiers to fixture responses.
+
+const fixtures: Record<number, (...args: any[]) => any> = {
+  // --- LibraryService ---
+  // GetAlbums
+  1337880606: () => [
+    { id: 1, title: "OK Computer", artist: "Radiohead", year: 1997, trackCount: 12, source: "local", serverId: "" },
+    { id: 2, title: "Kid A", artist: "Radiohead", year: 2000, trackCount: 10, source: "local", serverId: "" },
+    { id: 3, title: "Homogenic", artist: "Bjork", year: 1997, trackCount: 10, source: "server", serverId: "srv-1" },
+  ],
+  // AlbumArtwork
+  866920135: () => "",
+  // GetAlbumTracks
+  207489145: () => [
+    { trackId: 1, title: "Airbag", artist: "Radiohead", trackNumber: 1, discNumber: 1, durationMs: 282000, filePath: "/music/airbag.flac", source: "local", serverId: "" },
+    { trackId: 2, title: "Paranoid Android", artist: "Radiohead", trackNumber: 2, discNumber: 1, durationMs: 386000, filePath: "/music/paranoid.flac", source: "local", serverId: "" },
+    { trackId: 3, title: "Subterranean Homesick Alien", artist: "Radiohead", trackNumber: 3, discNumber: 1, durationMs: 267000, filePath: "/music/sha.flac", source: "local", serverId: "" },
+  ],
+  // Search
+  2206755262: (query: string) => {
+    if (!query) return [];
+    return [
+      { trackId: 1, title: "Airbag", artist: "Radiohead", album: "OK Computer", genre: "Rock", trackNumber: 1, discNumber: 1, durationMs: 282000, filePath: "/music/airbag.flac", source: "local", serverId: "" },
+    ];
+  },
+  // GetPlaylists
+  1524576557: () => [
+    { id: 1, name: "Favourites" },
+    { id: 2, name: "Chill" },
+  ],
+  // CreatePlaylist
+  4167498172: () => 3,
+  // RenamePlaylist
+  3081673158: () => undefined,
+  // DeletePlaylist
+  2018893399: () => undefined,
+  // GetPlaylistTracks
+  4244880336: () => [
+    { trackId: 1, title: "Airbag", artist: "Radiohead", album: "OK Computer", durationMs: 282000, filePath: "/music/airbag.flac", position: 0 },
+  ],
+  // AddTrackToPlaylist
+  2287316659: () => undefined,
+  // RemoveTrackFromPlaylist
+  970681807: () => undefined,
+  // MoveTrackInPlaylist
+  465154155: () => undefined,
+  // GetServers
+  3711954650: () => [],
+  // AddServer
+  477958106: () => undefined,
+  // UpdateServer
+  1667032524: () => undefined,
+  // DeleteServer
+  3862467038: () => undefined,
+  // GetServerStatuses
+  1839345631: () => [],
+  // TestConnection
+  3263505778: () => undefined,
+  // SyncServers
+  545152779: () => undefined,
+  // GetScrobbleConfig
+  3948527462: () => ({ apiKey: "", sessionKey: "", username: "", enabled: false }),
+  // SaveScrobbleAPIKeys
+  1590775235: () => undefined,
+  // StartLastFmAuth
+  1558738173: () => "mock-token",
+  // CompleteLastFmAuth
+  3698942302: () => undefined,
+  // DisconnectLastFm
+  970487533: () => undefined,
+  // SetScrobbleEnabled
+  22544365: () => undefined,
+  // GetListenBrainzConfig
+  1867711289: () => ({ username: "", enabled: false }),
+  // ConnectListenBrainz
+  1138196949: () => undefined,
+  // DisconnectListenBrainz
+  902147985: () => undefined,
+  // SetListenBrainzEnabled
+  333272068: () => undefined,
+  // GetScrobbleQueueSize
+  4199289054: () => 0,
+  // GetTopArtists
+  2628386383: () => [
+    { name: "Radiohead", secondLine: "", playCount: 42, totalMs: 5040000 },
+    { name: "Bjork", secondLine: "", playCount: 18, totalMs: 2160000 },
+  ],
+  // GetTopAlbums
+  1740480677: () => [
+    { name: "OK Computer", secondLine: "Radiohead", playCount: 30, totalMs: 3600000 },
+  ],
+  // GetTopTracks
+  3437861925: () => [
+    { name: "Airbag", secondLine: "Radiohead", playCount: 15, totalMs: 4230000 },
+  ],
+  // GetRecentlyPlayed
+  3884039413: () => [
+    { trackId: 1, title: "Airbag", artist: "Radiohead", album: "OK Computer", durationMs: 282000, playedAt: new Date().toISOString().replace("T", " ").slice(0, 19) },
+  ],
+  // GetArtistByName
+  1148779767: () => 1,
+  // GetArtistInfo
+  2345670893: () => ({
+    name: "Radiohead", bio: "English rock band from Oxfordshire.", imageUrl: "",
+    area: "Oxfordshire", type: "Group", activeYears: "1985 - present",
+    similar: [{ name: "Bjork", inLibrary: true }],
+    albums: [{ id: 1, title: "OK Computer", artist: "Radiohead", year: 1997, trackCount: 12, source: "local", serverId: "" }],
+    tags: "alternative, rock, electronic",
+  }),
+
+  // --- PlayerService ---
+  // State
+  2570357237: () => "stopped",
+  // Play
+  1808111650: () => undefined,
+  // Pause
+  191671602: () => undefined,
+  // Resume
+  4192344979: () => undefined,
+  // Stop
+  2311398648: () => undefined,
+  // Seek
+  1479346536: () => undefined,
+  // Position
+  3379668963: () => 0,
+  // Duration
+  1985222848: () => 0,
+  // Volume
+  2798880050: () => 80,
+  // SetVolume
+  671101282: () => undefined,
+  // GetShuffle
+  4278779269: () => false,
+  // SetShuffle
+  3896707945: () => undefined,
+  // GetRepeat
+  3949558547: () => "off",
+  // SetRepeat
+  76083775: () => undefined,
+  // Next
+  1009561457: () => undefined,
+  // Previous
+  2487521925: () => undefined,
+  // MediaTitle
+  3116228434: () => "",
+  // MediaArtist
+  3929664599: () => "",
+  // MediaAlbum
+  3994078579: () => "",
+  // MediaPath
+  3316771859: () => "",
+  // Artwork
+  468839008: () => "",
+  // Enqueue
+  1683307842: () => undefined,
+  // PlayAll
+  3674799417: () => undefined,
+  // PlayQueue
+  3857677157: () => undefined,
+  // GetQueue
+  1525514291: () => [],
+  // GetQueuePosition
+  752141504: () => -1,
+  // QueueAppend
+  3799532135: () => undefined,
+  // QueueInsertNext
+  125730107: () => undefined,
+  // QueueRemove
+  1743380467: () => undefined,
+  // QueueMove
+  3873105318: () => undefined,
+  // QueueClear
+  3052298016: () => undefined,
+  // GetNotifications
+  3578942832: () => false,
+  // SetNotifications
+  2522355060: () => undefined,
+  // GetToasts
+  327853480: () => [],
+  // ReplayGain
+  3252990072: () => "no",
+  // SetReplayGain
+  804885384: () => undefined,
+  // Version
+  1040332204: () => "mock-1.0",
+};
+
+class MockCancellablePromise<T> extends Promise<T> {
+  cancel() {}
+}
+
+export const Call = {
+  ByID(id: number, ...args: any[]): MockCancellablePromise<any> {
+    const handler = fixtures[id];
+    if (handler) {
+      return MockCancellablePromise.resolve(handler(...args));
+    }
+    console.warn(`[wails-mock] Unhandled Call.ByID: ${id}`);
+    return MockCancellablePromise.resolve(null);
+  },
+};
+
+export const CancellablePromise = MockCancellablePromise;
+
+export const Create = {
+  Array(createFn: (source: any) => any) {
+    return (arr: any[]) => (arr ?? []).map(createFn);
+  },
+};
+
+export default { Call, CancellablePromise, Create };

--- a/frontend/tests/navigation.spec.ts
+++ b/frontend/tests/navigation.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Sidebar navigation", () => {
+  test("shows brand name", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".brand")).toContainText("Forte");
+  });
+
+  test("library view is active by default", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: "Library" })).toHaveClass(/active/);
+  });
+
+  test("navigates to playlists view", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Playlists" }).click();
+    await expect(page.getByRole("button", { name: "Playlists" })).toHaveClass(/active/);
+    // PlaylistView should show the fixture playlists.
+    await expect(page.getByText("Favourites")).toBeVisible();
+    await expect(page.getByText("Chill")).toBeVisible();
+  });
+
+  test("navigates to stats view", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Stats" }).click();
+    await expect(page.getByRole("button", { name: "Stats" })).toHaveClass(/active/);
+    await expect(page.getByText("Listening Stats")).toBeVisible();
+  });
+
+  test("navigates to settings view", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Settings" }).click();
+    await expect(page.getByRole("button", { name: "Settings" })).toHaveClass(/active/);
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+  });
+
+  test("navigates back to library from settings", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Settings" }).click();
+    await page.getByRole("button", { name: "Library" }).click();
+    await expect(page.getByRole("button", { name: "Library" })).toHaveClass(/active/);
+    await expect(page.locator(".album-title").first()).toBeVisible();
+  });
+});

--- a/frontend/tests/search.spec.ts
+++ b/frontend/tests/search.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Search", () => {
+  test("search input is visible in library view", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".search-input")).toBeVisible();
+  });
+
+  test("typing in search shows results", async ({ page }) => {
+    await page.goto("/");
+    await page.locator(".search-input").fill("Airbag");
+    // Wait for debounce (300ms) + render.
+    await expect(page.getByText("Airbag").first()).toBeVisible({ timeout: 2000 });
+  });
+
+  test("clearing search returns to album grid", async ({ page }) => {
+    await page.goto("/");
+    await page.locator(".search-input").fill("Airbag");
+    await expect(page.getByText("Airbag").first()).toBeVisible({ timeout: 2000 });
+
+    await page.locator(".search-clear").click();
+    await expect(page.locator(".album-title").first()).toBeVisible();
+  });
+
+  test("search is not visible in settings view", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Settings" }).click();
+    await expect(page.locator(".search-input")).not.toBeVisible();
+  });
+});

--- a/frontend/tests/settings.spec.ts
+++ b/frontend/tests/settings.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Settings", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Settings" }).click();
+  });
+
+  test("shows theme options", async ({ page }) => {
+    await expect(page.getByText("Dark", { exact: true })).toBeVisible();
+    await expect(page.getByText("Light", { exact: true })).toBeVisible();
+    await expect(page.getByText("System", { exact: true })).toBeVisible();
+  });
+
+  test("shows servers section", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: "Servers" })).toBeVisible();
+    await expect(page.getByText("No servers configured")).toBeVisible();
+  });
+
+  test("add server button opens form", async ({ page }) => {
+    await page.getByRole("button", { name: "Add server" }).click();
+    await expect(page.locator("#srv-name")).toBeVisible();
+    await expect(page.locator("#srv-url")).toBeVisible();
+    await expect(page.locator("#srv-user")).toBeVisible();
+    await expect(page.getByText("Subsonic")).toBeVisible();
+    await expect(page.getByText("Jellyfin")).toBeVisible();
+  });
+
+  test("cancel closes server form", async ({ page }) => {
+    await page.getByRole("button", { name: "Add server" }).click();
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByText("No servers configured")).toBeVisible();
+  });
+
+  test("shows Last.fm section", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: "Last.fm" })).toBeVisible();
+    // No API key configured - should show the API key form.
+    await expect(page.locator("#lfm-key")).toBeVisible();
+  });
+
+  test("shows ListenBrainz section", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: "ListenBrainz" })).toBeVisible();
+    await expect(page.locator("#lb-token")).toBeVisible();
+  });
+});

--- a/frontend/tests/stats.spec.ts
+++ b/frontend/tests/stats.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Stats view", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Stats" }).click();
+  });
+
+  test("shows listening stats heading", async ({ page }) => {
+    await expect(page.getByText("Listening Stats")).toBeVisible();
+  });
+
+  test("shows period tabs", async ({ page }) => {
+    await expect(page.getByRole("button", { name: "7 days" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "30 days" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "12 months" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "All time" })).toBeVisible();
+  });
+
+  test("30 days tab is active by default", async ({ page }) => {
+    await expect(page.getByRole("button", { name: "30 days" })).toHaveClass(/active/);
+  });
+
+  test("shows top artists from fixture data", async ({ page }) => {
+    await expect(page.getByText("Top Artists")).toBeVisible();
+    await expect(page.getByText("Radiohead").first()).toBeVisible();
+    await expect(page.getByText("Bjork").first()).toBeVisible();
+  });
+
+  test("shows top albums from fixture data", async ({ page }) => {
+    await expect(page.getByText("Top Albums")).toBeVisible();
+    await expect(page.getByText("OK Computer").first()).toBeVisible();
+  });
+
+  test("shows top tracks from fixture data", async ({ page }) => {
+    await expect(page.getByText("Top Tracks")).toBeVisible();
+    await expect(page.getByText("Airbag").first()).toBeVisible();
+  });
+
+  test("shows recently played section", async ({ page }) => {
+    await expect(page.getByText("Recently Played")).toBeVisible();
+  });
+
+  test("switching period tab updates active state", async ({ page }) => {
+    await page.getByRole("button", { name: "All time" }).click();
+    await expect(page.getByRole("button", { name: "All time" })).toHaveClass(/active/);
+    await expect(page.getByRole("button", { name: "30 days" })).not.toHaveClass(/active/);
+  });
+});

--- a/frontend/vite.config.test.ts
+++ b/frontend/vite.config.test.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import path from "path";
+
+// Test-specific Vite config: replaces @wailsio/runtime with a mock
+// so the frontend can run standalone without the Go backend.
+export default defineConfig({
+  plugins: [svelte()],
+  resolve: {
+    alias: {
+      "@wailsio/runtime": path.resolve(__dirname, "tests/mocks/wails-runtime.ts"),
+    },
+  },
+});


### PR DESCRIPTION
Closes #91

## Summary
- Mock `@wailsio/runtime` via a Vite alias in a test-specific config (`vite.config.test.ts`) so the Svelte frontend can run in a real browser without the Wails desktop runtime
- 29 Playwright specs across 5 files: album browsing, sidebar navigation, search, settings, and stats
- Add `test:e2e` npm script and Playwright step to CI frontend job
- `CHROME_PATH` env var allows NixOS users to point at their system Chrome

## Test plan
- [x] All 29 specs pass locally
- [ ] CI frontend job installs Playwright browsers and runs `npm run test:e2e`