### PR TITLE
Add nix package derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,21 @@ The Go backend handles all I/O (database, network, playback). The Svelte fronten
 - [go-task](https://taskfile.dev) (or use `go install` directly)
 - [Wails 3](https://wails.io): `go install github.com/wailsapp/wails/v3/cmd/wails3@latest`
 
-### With Nix
+### Install with Nix
+
+```sh
+nix build github:willfish/forte
+```
+
+Or add to a NixOS/home-manager configuration:
+
+```nix
+environment.systemPackages = [
+  (builtins.getFlake "github:willfish/forte").packages.${system}.default
+];
+```
+
+### With Nix (development)
 
 The repository includes a `flake.nix` that provides all dependencies:
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,8 +10,75 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
+
+        frontend = pkgs.buildNpmPackage {
+          pname = "forte-frontend";
+          version = "0.1.0";
+          src = ./frontend;
+          npmDepsHash = "sha256-izThZlAW9yVoqlLB4qvs/G1epJqiMTESxQpVUfT19f8=";
+          buildPhase = ''
+            npm run build
+          '';
+          installPhase = ''
+            mkdir -p $out
+            cp -r dist/* $out/
+          '';
+        };
+
+        forte = pkgs.buildGoModule {
+          pname = "forte";
+          version = "0.1.0";
+          src = ./.;
+          vendorHash = "sha256-9jLpRJQGgsUotSOS5ikr3WOvuXAqZWqmXRvI3ewn36c=";
+          tags = [ "production" "nocgo" "gtk4" ];
+          ldflags = [ "-s" "-w" ];
+          subPackages = [ "." ];
+          doCheck = false; # Tests need libmpv.so at runtime
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            wrapGAppsHook4
+          ];
+
+          buildInputs = with pkgs; [
+            gtk4
+            webkitgtk_6_0
+            mpv
+          ];
+
+          preBuild = ''
+            rm -rf frontend/dist
+            mkdir -p frontend/dist
+            cp -r ${frontend}/* frontend/dist/
+          '';
+
+          postInstall = ''
+            install -Dm644 build/appicon.png $out/share/icons/hicolor/1024x1024/apps/forte.png
+            install -Dm644 build/linux/forte.desktop $out/share/applications/forte.desktop
+          '';
+
+          preFixup = ''
+            gappsWrapperArgs+=(
+              --prefix LD_LIBRARY_PATH : "${pkgs.lib.makeLibraryPath [ pkgs.mpv ]}"
+            )
+          '';
+
+          meta = with pkgs.lib; {
+            description = "A modern desktop music player with local library and streaming server support";
+            homepage = "https://github.com/willfish/forte";
+            license = licenses.gpl3Only;
+            maintainers = [ ];
+            platforms = platforms.linux;
+            mainProgram = "forte";
+          };
+        };
       in
       {
+        packages = {
+          default = forte;
+          forte = forte;
+        };
+
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             go


### PR DESCRIPTION
Closes #96

## Summary
- flake.nix now exports `packages.default` (and `packages.forte`)
- Frontend built with `buildNpmPackage`, embedded into the Go binary
- Go backend built with `buildGoModule` (tags: production, nocgo, gtk4)
- Runtime dependencies (mpv, GTK4, WebKitGTK 6.0) wrapped via `wrapGAppsHook4`
- Desktop entry and 1024x1024 app icon installed to standard XDG paths
- README updated with `nix build` installation instructions

## Test plan
- [x] `nix build .#forte` succeeds locally
- [x] Binary is an ELF 64-bit executable
- [x] Desktop file and icon are installed correctly
- [x] Only `forte` binary installed (not `demo`)
- [ ] CI passes (no Go/frontend code changes)