### PR TITLE
feat: RadioBrowser API client

### DIFF
--- a/internal/library/db.go
+++ b/internal/library/db.go
@@ -97,4 +97,5 @@ var migrations = []migration{
 	{version: 7, sql: migration007},
 	{version: 8, sql: migration008},
 	{version: 9, sql: migration009},
+	{version: 10, sql: migration010},
 }

--- a/internal/library/radio_favourites.go
+++ b/internal/library/radio_favourites.go
@@ -1,0 +1,66 @@
+package library
+
+import "fmt"
+
+// RadioFavourite represents a saved radio station.
+type RadioFavourite struct {
+	StationUUID string
+	Name        string
+	StreamURL   string
+	FaviconURL  string
+	Tags        string
+	AddedAt     string
+}
+
+// AddRadioFavourite saves a radio station to favourites.
+func (db *DB) AddRadioFavourite(f RadioFavourite) error {
+	_, err := db.Exec(
+		`INSERT OR IGNORE INTO radio_favourites (station_uuid, name, stream_url, favicon_url, tags)
+		 VALUES (?, ?, ?, ?, ?)`,
+		f.StationUUID, f.Name, f.StreamURL, f.FaviconURL, f.Tags,
+	)
+	if err != nil {
+		return fmt.Errorf("add radio favourite: %w", err)
+	}
+	return nil
+}
+
+// RemoveRadioFavourite removes a radio station from favourites.
+func (db *DB) RemoveRadioFavourite(stationUUID string) error {
+	_, err := db.Exec("DELETE FROM radio_favourites WHERE station_uuid = ?", stationUUID)
+	if err != nil {
+		return fmt.Errorf("remove radio favourite: %w", err)
+	}
+	return nil
+}
+
+// GetRadioFavourites returns all saved radio stations ordered by name.
+func (db *DB) GetRadioFavourites() ([]RadioFavourite, error) {
+	rows, err := db.Query(
+		"SELECT station_uuid, name, stream_url, favicon_url, tags, added_at FROM radio_favourites ORDER BY name",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get radio favourites: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var favs []RadioFavourite
+	for rows.Next() {
+		var f RadioFavourite
+		if err := rows.Scan(&f.StationUUID, &f.Name, &f.StreamURL, &f.FaviconURL, &f.Tags, &f.AddedAt); err != nil {
+			return nil, fmt.Errorf("scan radio favourite: %w", err)
+		}
+		favs = append(favs, f)
+	}
+	return favs, rows.Err()
+}
+
+// IsRadioFavourite checks if a station is in favourites.
+func (db *DB) IsRadioFavourite(stationUUID string) (bool, error) {
+	var exists bool
+	err := db.QueryRow("SELECT 1 FROM radio_favourites WHERE station_uuid = ?", stationUUID).Scan(&exists)
+	if err != nil {
+		return false, nil // Not found is not an error.
+	}
+	return true, nil
+}

--- a/internal/library/radio_favourites_test.go
+++ b/internal/library/radio_favourites_test.go
@@ -1,0 +1,167 @@
+package library
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func testDB(t *testing.T) *DB {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := OpenDB(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestRadioFavouritesRoundTrip(t *testing.T) {
+	db := testDB(t)
+
+	fav := RadioFavourite{
+		StationUUID: "abc-123",
+		Name:        "Jazz FM",
+		StreamURL:   "https://stream.example.com/jazz",
+		FaviconURL:  "https://example.com/icon.png",
+		Tags:        "jazz,smooth",
+	}
+
+	if err := db.AddRadioFavourite(fav); err != nil {
+		t.Fatalf("AddRadioFavourite: %v", err)
+	}
+
+	favs, err := db.GetRadioFavourites()
+	if err != nil {
+		t.Fatalf("GetRadioFavourites: %v", err)
+	}
+	if len(favs) != 1 {
+		t.Fatalf("expected 1 favourite, got %d", len(favs))
+	}
+
+	got := favs[0]
+	if got.StationUUID != "abc-123" {
+		t.Errorf("StationUUID = %q", got.StationUUID)
+	}
+	if got.Name != "Jazz FM" {
+		t.Errorf("Name = %q", got.Name)
+	}
+	if got.StreamURL != "https://stream.example.com/jazz" {
+		t.Errorf("StreamURL = %q", got.StreamURL)
+	}
+	if got.FaviconURL != "https://example.com/icon.png" {
+		t.Errorf("FaviconURL = %q", got.FaviconURL)
+	}
+	if got.Tags != "jazz,smooth" {
+		t.Errorf("Tags = %q", got.Tags)
+	}
+	if got.AddedAt == "" {
+		t.Error("AddedAt should not be empty")
+	}
+}
+
+func TestRadioFavouriteDuplicate(t *testing.T) {
+	db := testDB(t)
+
+	fav := RadioFavourite{
+		StationUUID: "abc-123",
+		Name:        "Jazz FM",
+		StreamURL:   "https://stream.example.com/jazz",
+	}
+
+	if err := db.AddRadioFavourite(fav); err != nil {
+		t.Fatalf("AddRadioFavourite: %v", err)
+	}
+	// Adding the same station again should not error (INSERT OR IGNORE).
+	if err := db.AddRadioFavourite(fav); err != nil {
+		t.Fatalf("AddRadioFavourite duplicate: %v", err)
+	}
+
+	favs, err := db.GetRadioFavourites()
+	if err != nil {
+		t.Fatalf("GetRadioFavourites: %v", err)
+	}
+	if len(favs) != 1 {
+		t.Fatalf("expected 1 favourite after duplicate, got %d", len(favs))
+	}
+}
+
+func TestRemoveRadioFavourite(t *testing.T) {
+	db := testDB(t)
+
+	fav := RadioFavourite{
+		StationUUID: "abc-123",
+		Name:        "Jazz FM",
+		StreamURL:   "https://stream.example.com/jazz",
+	}
+	if err := db.AddRadioFavourite(fav); err != nil {
+		t.Fatalf("AddRadioFavourite: %v", err)
+	}
+
+	if err := db.RemoveRadioFavourite("abc-123"); err != nil {
+		t.Fatalf("RemoveRadioFavourite: %v", err)
+	}
+
+	favs, err := db.GetRadioFavourites()
+	if err != nil {
+		t.Fatalf("GetRadioFavourites: %v", err)
+	}
+	if len(favs) != 0 {
+		t.Fatalf("expected 0 favourites after removal, got %d", len(favs))
+	}
+}
+
+func TestIsRadioFavourite(t *testing.T) {
+	db := testDB(t)
+
+	ok, err := db.IsRadioFavourite("nonexistent")
+	if err != nil {
+		t.Fatalf("IsRadioFavourite: %v", err)
+	}
+	if ok {
+		t.Error("expected false for nonexistent station")
+	}
+
+	fav := RadioFavourite{
+		StationUUID: "abc-123",
+		Name:        "Jazz FM",
+		StreamURL:   "https://stream.example.com/jazz",
+	}
+	if err := db.AddRadioFavourite(fav); err != nil {
+		t.Fatalf("AddRadioFavourite: %v", err)
+	}
+
+	ok, err = db.IsRadioFavourite("abc-123")
+	if err != nil {
+		t.Fatalf("IsRadioFavourite: %v", err)
+	}
+	if !ok {
+		t.Error("expected true for saved station")
+	}
+}
+
+func TestGetRadioFavouritesEmpty(t *testing.T) {
+	db := testDB(t)
+
+	favs, err := db.GetRadioFavourites()
+	if err != nil {
+		t.Fatalf("GetRadioFavourites: %v", err)
+	}
+	if favs != nil {
+		t.Errorf("expected nil for empty favourites, got %v", favs)
+	}
+}
+
+func TestRemoveNonexistentFavourite(t *testing.T) {
+	db := testDB(t)
+
+	// Should not error when removing a station that doesn't exist.
+	if err := db.RemoveRadioFavourite("nonexistent"); err != nil {
+		t.Fatalf("RemoveRadioFavourite: %v", err)
+	}
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/internal/library/schema.go
+++ b/internal/library/schema.go
@@ -174,3 +174,14 @@ CREATE TABLE artist_metadata (
 	fetched_at   TEXT NOT NULL DEFAULT (datetime('now'))
 );
 `
+
+const migration010 = `
+CREATE TABLE radio_favourites (
+	station_uuid TEXT PRIMARY KEY,
+	name         TEXT NOT NULL,
+	stream_url   TEXT NOT NULL,
+	favicon_url  TEXT NOT NULL DEFAULT '',
+	tags         TEXT NOT NULL DEFAULT '',
+	added_at     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+`

--- a/internal/radio/radiobrowser.go
+++ b/internal/radio/radiobrowser.go
@@ -1,0 +1,197 @@
+// Package radio provides a client for the RadioBrowser API.
+package radio
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Station represents a radio station from RadioBrowser.
+type Station struct {
+	UUID      string `json:"stationuuid"`
+	Name      string `json:"name"`
+	StreamURL string `json:"url_resolved"`
+	Favicon   string `json:"favicon"`
+	Country   string `json:"country"`
+	Tags      string `json:"tags"`
+	Bitrate   int    `json:"bitrate"`
+	Codec     string `json:"codec"`
+	Votes     int    `json:"votes"`
+	Clicks    int    `json:"clickcount"`
+}
+
+// Client is a RadioBrowser API client with DNS-based mirror discovery.
+type Client struct {
+	httpClient *http.Client
+	servers    []string
+}
+
+// NewClient creates a new RadioBrowser client.
+func NewClient() *Client {
+	return &Client{
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+// discoverServers resolves RadioBrowser mirrors via DNS.
+func (c *Client) discoverServers() ([]string, error) {
+	if len(c.servers) > 0 {
+		return c.servers, nil
+	}
+
+	addrs, err := net.LookupHost("all.api.radio-browser.info")
+	if err != nil {
+		return nil, fmt.Errorf("radiobrowser dns lookup: %w", err)
+	}
+
+	servers := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		names, err := net.LookupAddr(addr)
+		if err != nil || len(names) == 0 {
+			// Fall back to IP if reverse lookup fails.
+			servers = append(servers, "https://"+addr)
+			continue
+		}
+		host := names[0]
+		// Remove trailing dot from DNS name.
+		if len(host) > 0 && host[len(host)-1] == '.' {
+			host = host[:len(host)-1]
+		}
+		servers = append(servers, "https://"+host)
+	}
+
+	if len(servers) == 0 {
+		return nil, fmt.Errorf("radiobrowser: no servers found")
+	}
+
+	c.servers = servers
+	return servers, nil
+}
+
+// get makes a GET request to a random RadioBrowser mirror, falling back on failure.
+func (c *Client) get(path string, params url.Values) ([]byte, error) {
+	servers, err := c.discoverServers()
+	if err != nil {
+		return nil, err
+	}
+
+	// Shuffle for load distribution.
+	shuffled := make([]string, len(servers))
+	copy(shuffled, servers)
+	rand.Shuffle(len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+
+	var lastErr error
+	for _, server := range shuffled {
+		u := server + path
+		if len(params) > 0 {
+			u += "?" + params.Encode()
+		}
+
+		req, err := http.NewRequest(http.MethodGet, u, nil)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		req.Header.Set("User-Agent", "Forte/1.0")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("radiobrowser status %d: %s", resp.StatusCode, body)
+			continue
+		}
+
+		return body, nil
+	}
+
+	return nil, fmt.Errorf("radiobrowser: all mirrors failed: %w", lastErr)
+}
+
+// Search searches for stations by name.
+func (c *Client) Search(query string, limit int) ([]Station, error) {
+	params := url.Values{
+		"name":     {query},
+		"limit":    {fmt.Sprintf("%d", limit)},
+		"order":    {"votes"},
+		"reverse":  {"true"},
+		"hidebroken": {"true"},
+	}
+	return c.fetchStations("/json/stations/search", params)
+}
+
+// ByTag returns stations matching a tag (genre).
+func (c *Client) ByTag(tag string, limit int) ([]Station, error) {
+	params := url.Values{
+		"tag":     {tag},
+		"limit":   {fmt.Sprintf("%d", limit)},
+		"order":   {"votes"},
+		"reverse": {"true"},
+		"hidebroken": {"true"},
+	}
+	return c.fetchStations("/json/stations/search", params)
+}
+
+// ByCountry returns stations matching a country.
+func (c *Client) ByCountry(country string, limit int) ([]Station, error) {
+	params := url.Values{
+		"country":  {country},
+		"limit":    {fmt.Sprintf("%d", limit)},
+		"order":    {"votes"},
+		"reverse":  {"true"},
+		"hidebroken": {"true"},
+	}
+	return c.fetchStations("/json/stations/search", params)
+}
+
+// TopVoted returns the top voted stations.
+func (c *Client) TopVoted(limit int) ([]Station, error) {
+	params := url.Values{
+		"limit":      {fmt.Sprintf("%d", limit)},
+		"hidebroken": {"true"},
+	}
+	return c.fetchStations("/json/stations/topvote", params)
+}
+
+// TopClicked returns the most clicked stations.
+func (c *Client) TopClicked(limit int) ([]Station, error) {
+	params := url.Values{
+		"limit":      {fmt.Sprintf("%d", limit)},
+		"hidebroken": {"true"},
+	}
+	return c.fetchStations("/json/stations/topclick", params)
+}
+
+func (c *Client) fetchStations(path string, params url.Values) ([]Station, error) {
+	body, err := c.get(path, params)
+	if err != nil {
+		return nil, err
+	}
+	return parseStations(body)
+}
+
+func parseStations(body []byte) ([]Station, error) {
+	var stations []Station
+	if err := json.Unmarshal(body, &stations); err != nil {
+		return nil, fmt.Errorf("radiobrowser parse: %w", err)
+	}
+	return stations, nil
+}

--- a/internal/radio/radiobrowser_test.go
+++ b/internal/radio/radiobrowser_test.go
@@ -1,0 +1,198 @@
+package radio
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseStations(t *testing.T) {
+	raw := `[
+		{
+			"stationuuid": "abc-123",
+			"name": "Test Radio",
+			"url_resolved": "https://stream.example.com/radio",
+			"favicon": "https://example.com/icon.png",
+			"country": "United Kingdom",
+			"tags": "rock,indie",
+			"bitrate": 128,
+			"codec": "MP3",
+			"votes": 42,
+			"clickcount": 100
+		},
+		{
+			"stationuuid": "def-456",
+			"name": "Jazz FM",
+			"url_resolved": "https://stream.example.com/jazz",
+			"favicon": "",
+			"country": "Germany",
+			"tags": "jazz,smooth",
+			"bitrate": 256,
+			"codec": "AAC",
+			"votes": 10,
+			"clickcount": 50
+		}
+	]`
+
+	stations, err := parseStations([]byte(raw))
+	if err != nil {
+		t.Fatalf("parseStations: %v", err)
+	}
+
+	if len(stations) != 2 {
+		t.Fatalf("expected 2 stations, got %d", len(stations))
+	}
+
+	s := stations[0]
+	if s.UUID != "abc-123" {
+		t.Errorf("UUID = %q, want %q", s.UUID, "abc-123")
+	}
+	if s.Name != "Test Radio" {
+		t.Errorf("Name = %q, want %q", s.Name, "Test Radio")
+	}
+	if s.StreamURL != "https://stream.example.com/radio" {
+		t.Errorf("StreamURL = %q", s.StreamURL)
+	}
+	if s.Favicon != "https://example.com/icon.png" {
+		t.Errorf("Favicon = %q", s.Favicon)
+	}
+	if s.Country != "United Kingdom" {
+		t.Errorf("Country = %q", s.Country)
+	}
+	if s.Tags != "rock,indie" {
+		t.Errorf("Tags = %q", s.Tags)
+	}
+	if s.Bitrate != 128 {
+		t.Errorf("Bitrate = %d", s.Bitrate)
+	}
+	if s.Codec != "MP3" {
+		t.Errorf("Codec = %q", s.Codec)
+	}
+	if s.Votes != 42 {
+		t.Errorf("Votes = %d", s.Votes)
+	}
+	if s.Clicks != 100 {
+		t.Errorf("Clicks = %d", s.Clicks)
+	}
+}
+
+func TestParseStationsEmpty(t *testing.T) {
+	stations, err := parseStations([]byte("[]"))
+	if err != nil {
+		t.Fatalf("parseStations: %v", err)
+	}
+	if len(stations) != 0 {
+		t.Fatalf("expected 0 stations, got %d", len(stations))
+	}
+}
+
+func TestParseStationsInvalidJSON(t *testing.T) {
+	_, err := parseStations([]byte("not json"))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestClientSearch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/json/stations/search" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("name") != "jazz" {
+			t.Errorf("expected name=jazz, got %s", r.URL.Query().Get("name"))
+		}
+		if r.Header.Get("User-Agent") != "Forte/1.0" {
+			t.Errorf("unexpected User-Agent: %s", r.Header.Get("User-Agent"))
+		}
+
+		stations := []Station{
+			{UUID: "abc", Name: "Jazz FM", StreamURL: "https://stream.example.com/jazz"},
+		}
+		_ = json.NewEncoder(w).Encode(stations)
+	}))
+	defer server.Close()
+
+	c := NewClient()
+	c.servers = []string{server.URL}
+
+	stations, err := c.Search("jazz", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(stations) != 1 {
+		t.Fatalf("expected 1 station, got %d", len(stations))
+	}
+	if stations[0].Name != "Jazz FM" {
+		t.Errorf("Name = %q, want %q", stations[0].Name, "Jazz FM")
+	}
+}
+
+func TestClientTopVoted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/json/stations/topvote" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		stations := []Station{
+			{UUID: "top1", Name: "Popular Radio", Votes: 999},
+		}
+		_ = json.NewEncoder(w).Encode(stations)
+	}))
+	defer server.Close()
+
+	c := NewClient()
+	c.servers = []string{server.URL}
+
+	stations, err := c.TopVoted(5)
+	if err != nil {
+		t.Fatalf("TopVoted: %v", err)
+	}
+	if len(stations) != 1 {
+		t.Fatalf("expected 1 station, got %d", len(stations))
+	}
+	if stations[0].Votes != 999 {
+		t.Errorf("Votes = %d, want 999", stations[0].Votes)
+	}
+}
+
+func TestClientFallback(t *testing.T) {
+	// First server returns error, second succeeds.
+	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer badServer.Close()
+
+	goodServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]Station{{UUID: "ok", Name: "Working"}})
+	}))
+	defer goodServer.Close()
+
+	c := NewClient()
+	c.servers = []string{badServer.URL, goodServer.URL}
+
+	// Run multiple times to exercise the shuffle + fallback.
+	for i := 0; i < 5; i++ {
+		stations, err := c.Search("test", 10)
+		if err != nil {
+			t.Fatalf("attempt %d: Search: %v", i, err)
+		}
+		if len(stations) != 1 {
+			t.Fatalf("attempt %d: expected 1 station, got %d", i, len(stations))
+		}
+	}
+}
+
+func TestClientAllMirrorsFail(t *testing.T) {
+	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer badServer.Close()
+
+	c := NewClient()
+	c.servers = []string{badServer.URL}
+
+	_, err := c.Search("test", 10)
+	if err == nil {
+		t.Fatal("expected error when all mirrors fail")
+	}
+}

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/willfish/forte/internal/artistinfo"
 	"github.com/willfish/forte/internal/library"
+	"github.com/willfish/forte/internal/radio"
 	"github.com/willfish/forte/internal/scrobbling/lastfm"
 	"github.com/willfish/forte/internal/scrobbling/listenbrainz"
 	"github.com/willfish/forte/internal/streaming/jellyfin"
@@ -868,6 +869,149 @@ func (s *LibraryService) GetArtistByName(name string) (int64, error) {
 		return 0, fmt.Errorf("library not initialised")
 	}
 	return s.db.GetArtistByName(name)
+}
+
+// RadioStationJSON is the JSON-friendly radio station type exposed to the frontend.
+type RadioStationJSON struct {
+	UUID      string `json:"uuid"`
+	Name      string `json:"name"`
+	StreamURL string `json:"streamUrl"`
+	Favicon   string `json:"favicon"`
+	Country   string `json:"country"`
+	Tags      string `json:"tags"`
+	Bitrate   int    `json:"bitrate"`
+	Codec     string `json:"codec"`
+	Votes     int    `json:"votes"`
+	Clicks    int    `json:"clicks"`
+}
+
+func stationsToJSON(stations []radio.Station) []RadioStationJSON {
+	result := make([]RadioStationJSON, len(stations))
+	for i, s := range stations {
+		result[i] = RadioStationJSON{
+			UUID:      s.UUID,
+			Name:      s.Name,
+			StreamURL: s.StreamURL,
+			Favicon:   s.Favicon,
+			Country:   s.Country,
+			Tags:      s.Tags,
+			Bitrate:   s.Bitrate,
+			Codec:     s.Codec,
+			Votes:     s.Votes,
+			Clicks:    s.Clicks,
+		}
+	}
+	return result
+}
+
+var radioClient = radio.NewClient()
+
+// SearchRadioStations searches for radio stations by name.
+func (s *LibraryService) SearchRadioStations(query string, limit int) ([]RadioStationJSON, error) {
+	stations, err := radioClient.Search(query, limit)
+	if err != nil {
+		return nil, err
+	}
+	return stationsToJSON(stations), nil
+}
+
+// GetRadioStationsByTag returns radio stations matching a tag.
+func (s *LibraryService) GetRadioStationsByTag(tag string, limit int) ([]RadioStationJSON, error) {
+	stations, err := radioClient.ByTag(tag, limit)
+	if err != nil {
+		return nil, err
+	}
+	return stationsToJSON(stations), nil
+}
+
+// GetRadioStationsByCountry returns radio stations matching a country.
+func (s *LibraryService) GetRadioStationsByCountry(country string, limit int) ([]RadioStationJSON, error) {
+	stations, err := radioClient.ByCountry(country, limit)
+	if err != nil {
+		return nil, err
+	}
+	return stationsToJSON(stations), nil
+}
+
+// GetTopVotedRadioStations returns the top voted radio stations.
+func (s *LibraryService) GetTopVotedRadioStations(limit int) ([]RadioStationJSON, error) {
+	stations, err := radioClient.TopVoted(limit)
+	if err != nil {
+		return nil, err
+	}
+	return stationsToJSON(stations), nil
+}
+
+// GetTopClickedRadioStations returns the most clicked radio stations.
+func (s *LibraryService) GetTopClickedRadioStations(limit int) ([]RadioStationJSON, error) {
+	stations, err := radioClient.TopClicked(limit)
+	if err != nil {
+		return nil, err
+	}
+	return stationsToJSON(stations), nil
+}
+
+// RadioFavouriteJSON is the JSON-friendly radio favourite type exposed to the frontend.
+type RadioFavouriteJSON struct {
+	StationUUID string `json:"stationUuid"`
+	Name        string `json:"name"`
+	StreamURL   string `json:"streamUrl"`
+	FaviconURL  string `json:"faviconUrl"`
+	Tags        string `json:"tags"`
+	AddedAt     string `json:"addedAt"`
+}
+
+// GetRadioFavourites returns all saved radio stations.
+func (s *LibraryService) GetRadioFavourites() ([]RadioFavouriteJSON, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("library not initialised")
+	}
+	favs, err := s.db.GetRadioFavourites()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]RadioFavouriteJSON, len(favs))
+	for i, f := range favs {
+		result[i] = RadioFavouriteJSON{
+			StationUUID: f.StationUUID,
+			Name:        f.Name,
+			StreamURL:   f.StreamURL,
+			FaviconURL:  f.FaviconURL,
+			Tags:        f.Tags,
+			AddedAt:     f.AddedAt,
+		}
+	}
+	return result, nil
+}
+
+// AddRadioFavourite saves a radio station to favourites.
+func (s *LibraryService) AddRadioFavourite(stationUUID, name, streamURL, faviconURL, tags string) error {
+	if s.db == nil {
+		return fmt.Errorf("library not initialised")
+	}
+	return s.db.AddRadioFavourite(library.RadioFavourite{
+		StationUUID: stationUUID,
+		Name:        name,
+		StreamURL:   streamURL,
+		FaviconURL:  faviconURL,
+		Tags:        tags,
+	})
+}
+
+// RemoveRadioFavourite removes a radio station from favourites.
+func (s *LibraryService) RemoveRadioFavourite(stationUUID string) error {
+	if s.db == nil {
+		return fmt.Errorf("library not initialised")
+	}
+	return s.db.RemoveRadioFavourite(stationUUID)
+}
+
+// IsRadioFavourite checks if a station is in favourites.
+func (s *LibraryService) IsRadioFavourite(stationUUID string) (bool, error) {
+	if s.db == nil {
+		return false, fmt.Errorf("library not initialised")
+	}
+	return s.db.IsRadioFavourite(stationUUID)
 }
 
 // newUUID generates a random UUID v4 string.


### PR DESCRIPTION
## Summary
- Adds `internal/radio/` package with RadioBrowser API client (DNS mirror discovery, search, browse by tag/country, top voted/clicked)
- Adds `radio_favourites` SQLite table (migration010) for saving stations
- Adds DB CRUD methods for radio favourites
- Exposes radio search, browse, and favourites service methods to frontend

## Test plan
- [x] Unit tests for RadioBrowser response parsing
- [x] Unit tests for HTTP client with mock servers (search, top voted, fallback, all-fail)
- [x] Unit tests for radio favourites DB CRUD (add, remove, duplicate, empty, is-favourite)
- [x] `go vet` and `golangci-lint` pass

Closes #81