### PR TITLE
feat: Stream playback integration with now-playing bar

### DIFF
--- a/frontend/bindings/github.com/willfish/forte/playerservice.js
+++ b/frontend/bindings/github.com/willfish/forte/playerservice.js
@@ -94,6 +94,14 @@ export function GetToasts() {
 }
 
 /**
+ * IsRadioMode returns whether the player is currently in radio mode.
+ * @returns {$CancellablePromise<boolean>}
+ */
+export function IsRadioMode() {
+    return $Call.ByID(2964685828);
+}
+
+/**
  * MediaAlbum returns the album of the currently playing track.
  * @returns {$CancellablePromise<string>}
  */
@@ -171,6 +179,18 @@ export function PlayQueue(tracks, startAt) {
 }
 
 /**
+ * PlayRadio starts playback of a radio stream. It saves the current library
+ * queue and enters radio mode where next/prev/shuffle/repeat are disabled.
+ * @param {string} stationName
+ * @param {string} streamURL
+ * @param {string} artworkURL
+ * @returns {$CancellablePromise<void>}
+ */
+export function PlayRadio(stationName, streamURL, artworkURL) {
+    return $Call.ByID(1236378929, stationName, streamURL, artworkURL);
+}
+
+/**
  * Position returns the current playback position in seconds.
  * @returns {$CancellablePromise<number>}
  */
@@ -232,6 +252,22 @@ export function QueueMove($from, to) {
  */
 export function QueueRemove(index) {
     return $Call.ByID(1743380467, index);
+}
+
+/**
+ * RadioArtworkURL returns the artwork URL of the currently playing radio station.
+ * @returns {$CancellablePromise<string>}
+ */
+export function RadioArtworkURL() {
+    return $Call.ByID(1282363134);
+}
+
+/**
+ * RadioStationName returns the name of the currently playing radio station.
+ * @returns {$CancellablePromise<string>}
+ */
+export function RadioStationName() {
+    return $Call.ByID(2576550642);
 }
 
 /**
@@ -319,6 +355,14 @@ export function State() {
  */
 export function Stop() {
     return $Call.ByID(2311398648);
+}
+
+/**
+ * StopRadio stops the current radio stream and restores the library queue.
+ * @returns {$CancellablePromise<void>}
+ */
+export function StopRadio() {
+    return $Call.ByID(3776601259);
 }
 
 /**

--- a/frontend/src/NowPlayingBar.svelte
+++ b/frontend/src/NowPlayingBar.svelte
@@ -15,6 +15,9 @@
   let repeatMode = $state('off');
   let muted = $state(false);
   let volumeBeforeMute = $state(100);
+  let radioMode = $state(false);
+  let radioStation = $state('');
+  let radioArtwork = $state('');
   let pollTimer: ReturnType<typeof setInterval> | null = null;
 
   function startPolling() {
@@ -29,6 +32,11 @@
       album = await PlayerService.MediaAlbum();
       shuffleOn = await PlayerService.GetShuffle();
       repeatMode = await PlayerService.GetRepeat();
+      radioMode = await PlayerService.IsRadioMode();
+      if (radioMode) {
+        radioStation = await PlayerService.RadioStationName();
+        radioArtwork = await PlayerService.RadioArtworkURL();
+      }
     }, 250);
   }
 
@@ -76,7 +84,14 @@
   }
 
   async function stop() {
-    await PlayerService.Stop();
+    if (radioMode) {
+      await PlayerService.StopRadio();
+      radioMode = false;
+      radioStation = '';
+      radioArtwork = '';
+    } else {
+      await PlayerService.Stop();
+    }
     artworkSrc = '';
     lastArtworkKey = '';
   }
@@ -130,13 +145,18 @@
 
 <footer class="bar">
   <div class="track-info">
-    {#if artworkSrc}
+    {#if radioMode && radioArtwork}
+      <img class="artwork" src={radioArtwork} alt="Station art" />
+    {:else if artworkSrc}
       <img class="artwork" src={artworkSrc} alt="Album art" />
     {:else}
       <div class="artwork-placeholder"></div>
     {/if}
     <div class="meta">
-      {#if !isStopped && title}
+      {#if radioMode && radioStation}
+        <span class="title">{radioStation}</span>
+        <span class="artist">Radio{#if title} - {title}{/if}</span>
+      {:else if !isStopped && title}
         <span class="title">{title}</span>
         <span class="artist">{artist}{album ? ` - ${album}` : ''}</span>
       {:else if !isStopped}
@@ -150,16 +170,18 @@
 
   <div class="controls">
     <div class="transport">
-      <button class="mode-btn" class:active={shuffleOn} onclick={toggleShuffle} aria-label="Shuffle">
-        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
-          <path d="M10.59 9.17 5.41 4 4 5.41l5.17 5.17 1.42-1.41zM14.5 4l2.04 2.04L4 18.59 5.41 20 17.96 7.46 20 9.5V4h-5.5zm.33 9.41-1.41 1.41 3.13 3.13L14.5 20H20v-5.5l-2.04 2.04-3.13-3.13z"/>
-        </svg>
-      </button>
-      <button onclick={previous} disabled={isStopped} aria-label="Previous">
-        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
-          <path d="M6 6h2v12H6zm3.5 6 8.5 6V6z"/>
-        </svg>
-      </button>
+      {#if !radioMode}
+        <button class="mode-btn" class:active={shuffleOn} onclick={toggleShuffle} aria-label="Shuffle">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+            <path d="M10.59 9.17 5.41 4 4 5.41l5.17 5.17 1.42-1.41zM14.5 4l2.04 2.04L4 18.59 5.41 20 17.96 7.46 20 9.5V4h-5.5zm.33 9.41-1.41 1.41 3.13 3.13L14.5 20H20v-5.5l-2.04 2.04-3.13-3.13z"/>
+          </svg>
+        </button>
+        <button onclick={previous} disabled={isStopped} aria-label="Previous">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+            <path d="M6 6h2v12H6zm3.5 6 8.5 6V6z"/>
+          </svg>
+        </button>
+      {/if}
       <button class="play-btn" onclick={togglePlayPause} disabled={isStopped} aria-label={playbackState === 'playing' ? 'Pause' : 'Play'}>
         {#if playbackState === 'playing'}
           <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
@@ -171,42 +193,52 @@
           </svg>
         {/if}
       </button>
-      <button onclick={next} disabled={isStopped} aria-label="Next">
-        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
-          <path d="M6 18l8.5-6L6 6zm10-12v12h2V6z"/>
-        </svg>
-      </button>
+      {#if !radioMode}
+        <button onclick={next} disabled={isStopped} aria-label="Next">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+            <path d="M6 18l8.5-6L6 6zm10-12v12h2V6z"/>
+          </svg>
+        </button>
+      {/if}
       <button onclick={stop} disabled={isStopped} aria-label="Stop">
         <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
           <path d="M6 6h12v12H6z"/>
         </svg>
       </button>
-      <button class="mode-btn" class:active={repeatMode !== 'off'} onclick={cycleRepeat} aria-label="Repeat: {repeatMode}">
-        {#if repeatMode === 'one'}
-          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
-            <path d="M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4zm-4-2V9h-1l-2 1v1h1.5v4H13z"/>
-          </svg>
-        {:else}
-          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
-            <path d="M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4z"/>
-          </svg>
-        {/if}
-      </button>
+      {#if !radioMode}
+        <button class="mode-btn" class:active={repeatMode !== 'off'} onclick={cycleRepeat} aria-label="Repeat: {repeatMode}">
+          {#if repeatMode === 'one'}
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+              <path d="M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4zm-4-2V9h-1l-2 1v1h1.5v4H13z"/>
+            </svg>
+          {:else}
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+              <path d="M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4z"/>
+            </svg>
+          {/if}
+        </button>
+      {/if}
     </div>
 
-    <div class="seek">
-      <span class="time">{formatTime(position)}</span>
-      <input
-        type="range"
-        min="0"
-        max={duration || 1}
-        value={position}
-        step="0.5"
-        oninput={handleSeek}
-        disabled={isStopped}
-      />
-      <span class="time">{formatTime(duration)}</span>
-    </div>
+    {#if !radioMode}
+      <div class="seek">
+        <span class="time">{formatTime(position)}</span>
+        <input
+          type="range"
+          min="0"
+          max={duration || 1}
+          value={position}
+          step="0.5"
+          oninput={handleSeek}
+          disabled={isStopped}
+        />
+        <span class="time">{formatTime(duration)}</span>
+      </div>
+    {:else}
+      <div class="seek radio-label">
+        <span class="radio-indicator">LIVE</span>
+      </div>
+    {/if}
   </div>
 
   <div class="volume-section">
@@ -389,6 +421,20 @@
 
   .time:last-child {
     text-align: right;
+  }
+
+  .radio-label {
+    justify-content: center;
+  }
+
+  .radio-indicator {
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    color: #e74c3c;
+    padding: 0.15rem 0.5rem;
+    border: 1px solid #e74c3c;
+    border-radius: 3px;
   }
 
   .volume-section {

--- a/frontend/src/RadioView.svelte
+++ b/frontend/src/RadioView.svelte
@@ -108,9 +108,9 @@
     loadFeatured();
   }
 
-  async function playStation(url: string) {
+  async function playStation(name: string, url: string, favicon: string) {
     try {
-      await PlayerService.Play(url);
+      await PlayerService.PlayRadio(name, url, favicon);
     } catch {
       // ignore play errors
     }
@@ -204,7 +204,7 @@
       <div class="station-list">
         {#each stations as station (station.uuid)}
           <div class="station-card">
-            <button class="station-play" onclick={() => playStation(station.streamUrl)} aria-label="Play {station.name}">
+            <button class="station-play" onclick={() => playStation(station.name, station.streamUrl, station.favicon)} aria-label="Play {station.name}">
               <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
                 <path d="M8 5v14l11-7z"/>
               </svg>
@@ -263,7 +263,7 @@
       <div class="station-list">
         {#each favourites as fav (fav.stationUuid)}
           <div class="station-card">
-            <button class="station-play" onclick={() => playStation(fav.streamUrl)} aria-label="Play {fav.name}">
+            <button class="station-play" onclick={() => playStation(fav.name, fav.streamUrl, fav.faviconUrl)} aria-label="Play {fav.name}">
               <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
                 <path d="M8 5v14l11-7z"/>
               </svg>

--- a/frontend/tests/mocks/wails-runtime.ts
+++ b/frontend/tests/mocks/wails-runtime.ts
@@ -141,6 +141,16 @@ const fixtures: Record<number, (...args: any[]) => any> = {
   // --- PlayerService ---
   // State
   2570357237: () => "stopped",
+  // PlayRadio
+  1236378929: () => undefined,
+  // StopRadio
+  3776601259: () => undefined,
+  // IsRadioMode
+  2964685828: () => false,
+  // RadioStationName
+  2576550642: () => "",
+  // RadioArtworkURL
+  1282363134: () => "",
   // Play
   1808111650: () => undefined,
   // Pause

--- a/playerservice.go
+++ b/playerservice.go
@@ -38,6 +38,14 @@ type PlayerService struct {
 	scrobbleTrackID int64
 	scrobbleElapsed time.Duration
 	scrobbled       bool
+
+	// Radio mode state.
+	radioMode       bool
+	radioName       string
+	radioStreamURL  string
+	radioArtworkURL string
+	savedQueue      []player.QueueTrack
+	savedPosition   int
 }
 
 // ServiceStartup initialises the mpv engine when the application starts.
@@ -1009,6 +1017,94 @@ func (p *PlayerService) flushListenBrainzQueue() {
 		_ = p.db.RemoveScrobble(e.ID)
 	}
 	log.Printf("scrobble queue: flushed %d listenbrainz scrobbles", len(entries))
+}
+
+// PlayRadio starts playback of a radio stream. It saves the current library
+// queue and enters radio mode where next/prev/shuffle/repeat are disabled.
+func (p *PlayerService) PlayRadio(stationName, streamURL, artworkURL string) error {
+	if p.engine == nil {
+		return fmt.Errorf("player not initialised")
+	}
+
+	// Save the library queue if not already in radio mode.
+	if !p.radioMode {
+		p.savedQueue = p.queue.Tracks()
+		p.savedPosition = p.queue.Position()
+	}
+
+	p.radioMode = true
+	p.radioName = stationName
+	p.radioStreamURL = streamURL
+	p.radioArtworkURL = artworkURL
+
+	// Clear the queue and play the stream directly.
+	p.queue.Clear()
+	if err := p.engine.Play(streamURL); err != nil {
+		return fmt.Errorf("play radio: %w", err)
+	}
+
+	if p.mpris != nil {
+		p.mpris.UpdateMetadata(stationName, "Radio", "", streamURL, 0, 0)
+		p.mpris.UpdatePlaybackStatus("playing")
+	}
+	if p.onTrayUpdate != nil {
+		p.onTrayUpdate(stationName, "Radio")
+	}
+	if p.notifier != nil {
+		p.notifier.Notify(stationName, "Radio", nil)
+	}
+
+	return nil
+}
+
+// StopRadio stops the current radio stream and restores the library queue.
+func (p *PlayerService) StopRadio() {
+	if !p.radioMode {
+		return
+	}
+
+	p.radioMode = false
+	p.radioName = ""
+	p.radioStreamURL = ""
+	p.radioArtworkURL = ""
+
+	if p.engine != nil {
+		p.engine.Stop()
+	}
+
+	// Restore the library queue.
+	if len(p.savedQueue) > 0 {
+		pos := p.savedPosition
+		if pos < 0 || pos >= len(p.savedQueue) {
+			pos = 0
+		}
+		p.queue.Replace(p.savedQueue, pos)
+	}
+	p.savedQueue = nil
+	p.savedPosition = 0
+
+	if p.mpris != nil {
+		p.mpris.UpdatePlaybackStatus("stopped")
+		p.mpris.ClearMetadata()
+	}
+	if p.onTrayUpdate != nil {
+		p.onTrayUpdate("", "")
+	}
+}
+
+// IsRadioMode returns whether the player is currently in radio mode.
+func (p *PlayerService) IsRadioMode() bool {
+	return p.radioMode
+}
+
+// RadioStationName returns the name of the currently playing radio station.
+func (p *PlayerService) RadioStationName() string {
+	return p.radioName
+}
+
+// RadioArtworkURL returns the artwork URL of the currently playing radio station.
+func (p *PlayerService) RadioArtworkURL() string {
+	return p.radioArtworkURL
 }
 
 // SetReplayGain sets the ReplayGain mode: "track", "album", or "no" (off).


### PR DESCRIPTION
## Summary
- Adds `PlayRadio`/`StopRadio`/`IsRadioMode`/`RadioStationName`/`RadioArtworkURL` to PlayerService
- PlayRadio saves the library queue, plays the stream URL via mpv, and updates MPRIS/tray/notifications
- StopRadio stops the stream and restores the saved library queue
- Now-playing bar shows station name, artwork, and LIVE indicator in radio mode
- Hides shuffle/repeat/seek/next/prev controls when playing radio
- RadioView uses PlayRadio instead of raw Play

## Test plan
- [x] `go vet` passes
- [x] `golangci-lint` passes (0 issues)
- [x] `svelte-check` passes (0 errors)
- [x] Frontend builds
- [x] All 37 e2e tests pass

Closes #83