### PR TITLE
feat: automated release pipeline with binary uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev libfuse2
+
+      - name: Install wails3
+        run: go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+
+      - name: Install go-task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+
+      - name: Set version from tag
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+
+      - name: Build and package
+        run: task package
+
+      - name: Generate checksums
+        working-directory: bin
+        run: |
+          sha256sum * > checksums-sha256.txt
+          cat checksums-sha256.txt
+
+      - name: Create release
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            bin/* \
+            --generate-notes \
+            --title "$GITHUB_REF_NAME"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,6 +19,8 @@ tasks:
 
   package:
     summary: Packages a production build of the application
+    env:
+      VERSION: '{{.VERSION | default "0.0.0-dev"}}'
     cmds:
       - task: "linux:package"
 

--- a/build/linux/nfpm/nfpm.yaml
+++ b/build/linux/nfpm/nfpm.yaml
@@ -6,7 +6,7 @@
 name: "forte"
 arch: ${GOARCH}
 platform: "linux"
-version: "0.1.0"
+version: "${VERSION}"
 section: "default"
 priority: "extra"
 maintainer: ${GIT_COMMITTER_NAME} <${GIT_COMMITTER_EMAIL}>


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` triggered on `v*` tag push
- Builds binary, creates deb/rpm/AppImage/archlinux packages via `task package`
- Generates SHA256 checksums for all artifacts
- Creates GitHub release with auto-generated notes from commit history
- Update nfpm.yaml to use `VERSION` env var from tag (strips `v` prefix)
- Default version for local `task package` is `0.0.0-dev`

## Test plan
- [x] Workflow YAML syntax validated
- [x] nfpm.yaml already uses env var expansion (`${GOARCH}` etc), `${VERSION}` follows same pattern
- [ ] Push a `v0.3.0` tag after merge to trigger the first release

Closes #98