### PR TITLE
#102: Animated transitions and micro-interactions

### DIFF
--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -9,10 +9,15 @@
     --bg-bar: #151e2b;
     --bg-hover: rgba(255, 255, 255, 0.06);
     --bg-active: rgba(51, 102, 170, 0.15);
+    --bg-elevated: #223040;
     --border: #2a3a4a;
     --text-primary: #e0e0e0;
     --text-secondary: #8899aa;
+    --text-on-accent: #ffffff;
     --accent: #3366aa;
+    --error: #ee5555;
+    --success: #44cc88;
+    --warning: #f59e0b;
 }
 
 [data-theme="light"] {
@@ -21,10 +26,15 @@
     --bg-bar: #eaeaea;
     --bg-hover: rgba(0, 0, 0, 0.05);
     --bg-active: rgba(51, 102, 170, 0.1);
+    --bg-elevated: #ffffff;
     --border: #d0d0d0;
     --text-primary: #1a1a1a;
     --text-secondary: #666666;
+    --text-on-accent: #ffffff;
     --accent: #2855a0;
+    --error: #dc2626;
+    --success: #16a34a;
+    --warning: #d97706;
 }
 
 body {
@@ -68,4 +78,19 @@ body {
     overflow: hidden;
     display: flex;
     flex-direction: column;
+}
+
+/* View transition animation applied to content views */
+@keyframes view-enter {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Respect user motion preferences */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
 }

--- a/frontend/src/AlbumGrid.svelte
+++ b/frontend/src/AlbumGrid.svelte
@@ -195,6 +195,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    animation: view-enter 0.2s ease-out;
   }
 
   .toolbar {

--- a/frontend/src/AlbumView.svelte
+++ b/frontend/src/AlbumView.svelte
@@ -220,6 +220,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    animation: view-enter 0.2s ease-out;
   }
 
   .back-btn {

--- a/frontend/src/ArtistView.svelte
+++ b/frontend/src/ArtistView.svelte
@@ -164,6 +164,7 @@
     flex-direction: column;
     height: 100%;
     gap: 1.5rem;
+    animation: view-enter 0.2s ease-out;
   }
 
   .back-btn {

--- a/frontend/src/NowPlayingBar.svelte
+++ b/frontend/src/NowPlayingBar.svelte
@@ -373,6 +373,7 @@
     align-items: center;
     justify-content: center;
     padding: 0;
+    transition: color 0.15s ease, background 0.15s ease, opacity 0.15s ease;
   }
 
   .transport button:hover:not(:disabled) {
@@ -390,12 +391,17 @@
     height: 32px;
     background: var(--accent);
     color: var(--text-on-accent);
+    transition: transform 0.1s ease;
   }
 
   .transport .play-btn:hover:not(:disabled) {
     background: var(--accent);
     color: var(--text-on-accent);
     filter: brightness(1.15);
+  }
+
+  .transport .play-btn:active:not(:disabled) {
+    transform: scale(0.9);
   }
 
   .transport .mode-btn {

--- a/frontend/src/QueuePanel.svelte
+++ b/frontend/src/QueuePanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { fly, fade } from 'svelte/transition';
   import { PlayerService } from "../bindings/github.com/willfish/forte";
 
   type QueueTrack = {
@@ -94,8 +95,8 @@
 
 {#if open}
   <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-  <div class="overlay" onclick={onclose}></div>
-  <aside class="panel" aria-label="Play queue">
+  <div class="overlay" onclick={onclose} transition:fade={{ duration: 150 }}></div>
+  <aside class="panel" aria-label="Play queue" transition:fly={{ x: 350, duration: 200 }}>
     <div class="panel-header">
       <h3>Queue</h3>
       <div class="header-actions">
@@ -163,12 +164,6 @@
     z-index: 101;
     display: flex;
     flex-direction: column;
-    animation: slide-in 0.2s ease-out;
-  }
-
-  @keyframes slide-in {
-    from { transform: translateX(100%); }
-    to { transform: translateX(0); }
   }
 
   .panel-header {

--- a/frontend/src/RadioView.svelte
+++ b/frontend/src/RadioView.svelte
@@ -308,6 +308,7 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    animation: view-enter 0.2s ease-out;
   }
 
   h2 {

--- a/frontend/src/SearchResults.svelte
+++ b/frontend/src/SearchResults.svelte
@@ -126,6 +126,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    animation: view-enter 0.2s ease-out;
   }
 
   .result-count {

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -526,6 +526,7 @@
 <style>
   .settings {
     max-width: 500px;
+    animation: view-enter 0.2s ease-out;
   }
 
   h2 {

--- a/frontend/src/Sidebar.svelte
+++ b/frontend/src/Sidebar.svelte
@@ -75,6 +75,7 @@
     font-size: 0.9rem;
     cursor: pointer;
     text-align: left;
+    transition: background 0.15s ease, color 0.15s ease;
   }
 
   .nav-btn:hover {

--- a/frontend/src/StatsView.svelte
+++ b/frontend/src/StatsView.svelte
@@ -206,6 +206,7 @@
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+    animation: view-enter 0.2s ease-out;
   }
 
   .toolbar {

--- a/frontend/src/Toast.svelte
+++ b/frontend/src/Toast.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { fly } from 'svelte/transition';
   import { PlayerService } from "../bindings/github.com/willfish/forte";
 
   type ToastItem = {
@@ -57,7 +58,7 @@
 {#if toasts.length > 0}
   <div class="toast-container">
     {#each toasts as toast (toast.id)}
-      <div class="toast toast-{toast.type}" role="alert">
+      <div class="toast toast-{toast.type}" role="alert" transition:fly={{ x: 50, duration: 200 }}>
         <span class="toast-message">{toast.message}</span>
         <button class="toast-close" onclick={() => dismiss(toast.id)} aria-label="Dismiss">
           <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor">
@@ -87,18 +88,17 @@
     gap: 0.5rem;
     padding: 0.6rem 0.75rem;
     border-radius: 6px;
-    background: var(--bg-secondary, #2a2a2a);
+    background: var(--bg-elevated, var(--bg-hover));
     border-left: 3px solid var(--accent);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-    animation: slide-in 0.2s ease-out;
   }
 
   .toast-warn {
-    border-left-color: #f59e0b;
+    border-left-color: var(--warning);
   }
 
   .toast-error {
-    border-left-color: #ef4444;
+    border-left-color: var(--error);
   }
 
   .toast-info {
@@ -129,14 +129,4 @@
     color: var(--text-primary);
   }
 
-  @keyframes slide-in {
-    from {
-      opacity: 0;
-      transform: translateX(1rem);
-    }
-    to {
-      opacity: 1;
-      transform: translateX(0);
-    }
-  }
 </style>


### PR DESCRIPTION
## Summary

- View enter animations (fade + translateY) on all main view components
- Play/pause button scale-on-press micro-interaction
- Queue panel slide in/out via Svelte `fly` transition (replaces CSS-only slide-in)
- Queue overlay fade in/out via Svelte `fade` transition
- Toast notifications slide in/out via Svelte `fly` transition (adds exit animation)
- Sidebar nav items gain smooth hover colour transitions
- Transport buttons have smooth colour/background/opacity transitions
- Global `prefers-reduced-motion` media query disables all animations
- Design system tokens added (--error, --warning, --success, --bg-elevated, --text-on-accent)
- Fixed remaining hardcoded colours in NowPlayingBar and Toast

## Test plan

- [x] All 37 e2e tests pass
- [x] `go vet` clean
- [x] Frontend build clean

Closes #102