### PR TITLE
Add tag and source filters to radio browse view

### DIFF
--- a/frontend/bindings/github.com/willfish/forte/libraryservice.js
+++ b/frontend/bindings/github.com/willfish/forte/libraryservice.js
@@ -278,6 +278,16 @@ export function GetServers() {
 }
 
 /**
+ * GetSomaFMStations returns all SomaFM channels.
+ * @returns {$CancellablePromise<$models.RadioStationJSON[]>}
+ */
+export function GetSomaFMStations() {
+    return $Call.ByID(3406641218).then(/** @type {($result: any) => any} */(($result) => {
+        return $$createType13($result);
+    }));
+}
+
+/**
  * GetTopAlbums returns the most-played albums for the given period.
  * @param {string} period
  * @param {number} limit

--- a/frontend/src/RadioView.svelte
+++ b/frontend/src/RadioView.svelte
@@ -31,12 +31,41 @@
   let loading = $state(false);
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // Active filters.
+  let activeTag = $state('');
+  let activeSource = $state<'all' | 'somafm'>('all');
+
   const isSearchActive = $derived(searchQuery.trim().length > 0);
+  const hasFilter = $derived(activeTag !== '' || activeSource !== 'all');
 
   async function loadFeatured() {
     loading = true;
     try {
       const result = await LibraryService.GetTopVotedRadioStations(50);
+      stations = (result || []).map(mapStation);
+    } catch {
+      stations = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadByTag(tag: string) {
+    loading = true;
+    try {
+      const result = await LibraryService.GetRadioStationsByTag(tag, 50);
+      stations = (result || []).map(mapStation);
+    } catch {
+      stations = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadSomaFM() {
+    loading = true;
+    try {
+      const result = await LibraryService.GetSomaFMStations();
       stations = (result || []).map(mapStation);
     } catch {
       stations = [];
@@ -81,6 +110,8 @@
   function handleSearchInput(e: Event) {
     const value = (e.target as HTMLInputElement).value;
     searchQuery = value;
+    activeTag = '';
+    activeSource = 'all';
 
     if (debounceTimer) clearTimeout(debounceTimer);
 
@@ -106,6 +137,34 @@
     searchQuery = '';
     if (debounceTimer) clearTimeout(debounceTimer);
     loadFeatured();
+  }
+
+  function clearFilters() {
+    activeTag = '';
+    activeSource = 'all';
+    searchQuery = '';
+    if (debounceTimer) clearTimeout(debounceTimer);
+    loadFeatured();
+  }
+
+  function filterByTag(tag: string) {
+    searchQuery = '';
+    if (debounceTimer) clearTimeout(debounceTimer);
+    activeSource = 'all';
+    activeTag = tag;
+    loadByTag(tag);
+  }
+
+  function filterBySource(source: 'all' | 'somafm') {
+    searchQuery = '';
+    if (debounceTimer) clearTimeout(debounceTimer);
+    activeTag = '';
+    activeSource = source;
+    if (source === 'somafm') {
+      loadSomaFM();
+    } else {
+      loadFeatured();
+    }
   }
 
   async function playStation(name: string, url: string, favicon: string) {
@@ -190,12 +249,43 @@
       {/if}
     </div>
 
+    <div class="filter-bar">
+      <div class="source-filters">
+        <button
+          class="filter-pill"
+          class:active={activeSource === 'all' && activeTag === ''}
+          onclick={() => filterBySource('all')}
+        >All</button>
+        <button
+          class="filter-pill"
+          class:active={activeSource === 'somafm'}
+          onclick={() => filterBySource('somafm')}
+        >SomaFM</button>
+      </div>
+      {#if hasFilter}
+        <div class="active-filter">
+          {#if activeTag}
+            <span class="filter-label">Tag: {activeTag}</span>
+          {:else if activeSource === 'somafm'}
+            <span class="filter-label">Source: SomaFM</span>
+          {/if}
+          <button class="filter-clear" onclick={clearFilters} aria-label="Clear filter">
+            <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor">
+              <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+            </svg>
+          </button>
+        </div>
+      {/if}
+    </div>
+
     {#if loading}
       <div class="empty">Loading stations...</div>
     {:else if stations.length === 0}
       <div class="empty">
         {#if isSearchActive}
           No stations found for "{searchQuery.trim()}"
+        {:else if activeTag}
+          No stations found for tag "{activeTag}"
         {:else}
           No stations available
         {/if}
@@ -231,7 +321,7 @@
               {#if formatTags(station.tags).length > 0}
                 <div class="station-tags">
                   {#each formatTags(station.tags) as tag}
-                    <span class="tag">{tag}</span>
+                    <button class="tag" class:active={activeTag === tag} onclick={() => filterByTag(tag)}>{tag}</button>
                   {/each}
                 </div>
               {/if}
@@ -397,6 +487,71 @@
     color: var(--text-primary);
   }
 
+  .filter-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .source-filters {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .filter-pill {
+    padding: 0.25rem 0.6rem;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    cursor: pointer;
+  }
+
+  .filter-pill:hover {
+    color: var(--text-primary);
+    border-color: var(--text-secondary);
+  }
+
+  .filter-pill.active {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+
+  .active-filter {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 12px;
+    background: var(--bg-hover);
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+  }
+
+  .filter-label {
+    white-space: nowrap;
+  }
+
+  .filter-clear {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0.1rem;
+    border-radius: 50%;
+  }
+
+  .filter-clear:hover {
+    background: var(--bg-elevated, var(--bg-hover));
+    color: var(--text-primary);
+  }
+
   .station-list {
     display: flex;
     flex-direction: column;
@@ -486,6 +641,18 @@
     border-radius: 3px;
     background: var(--bg-hover);
     color: var(--text-secondary);
+    border: none;
+    cursor: pointer;
+  }
+
+  .tag:hover {
+    color: var(--text-primary);
+    background: var(--bg-elevated, var(--bg-hover));
+  }
+
+  .tag.active {
+    background: var(--accent);
+    color: white;
   }
 
   .fav-btn {

--- a/internal/radio/somafm.go
+++ b/internal/radio/somafm.go
@@ -10,35 +10,43 @@ import (
 	"time"
 )
 
+type somafmPlaylist struct {
+	URL    string `json:"url"`
+	Format string `json:"format"`
+}
+
 type somafmChannel struct {
-	ID      string `json:"id"`
-	Title   string `json:"title"`
-	Image   string `json:"xlimage"`
+	ID        string           `json:"id"`
+	Title     string           `json:"title"`
+	Genre     string           `json:"genre"`
+	Image     string           `json:"xlimage"`
+	Playlists []somafmPlaylist `json:"playlists"`
 }
 
 type somafmResponse struct {
 	Channels []somafmChannel `json:"channels"`
 }
 
-// SomaFMArtwork fetches and caches SomaFM channel artwork.
-// It provides a fallback for stations whose favicon is missing
-// in the RadioBrowser API.
-type SomaFMArtwork struct {
+// SomaFMClient fetches and caches SomaFM channel data.
+// It provides artwork fallback for RadioBrowser stations and
+// a curated channel listing for source filtering.
+type SomaFMClient struct {
 	mu        sync.Mutex
-	channels  map[string]string // channel id -> xlimage URL
+	channels  []somafmChannel
+	artIndex  map[string]string // channel id -> xlimage URL
 	fetchedAt time.Time
 }
 
-// NewSomaFMArtwork creates a new SomaFM artwork cache.
-func NewSomaFMArtwork() *SomaFMArtwork {
-	return &SomaFMArtwork{}
+// NewSomaFMClient creates a new SomaFM client.
+func NewSomaFMClient() *SomaFMClient {
+	return &SomaFMClient{}
 }
 
 const somafmCacheTTL = 24 * time.Hour
 
-// Lookup returns the artwork URL for a station if it's a SomaFM station
-// with a missing favicon. Returns empty string if not applicable.
-func (s *SomaFMArtwork) Lookup(homepage string) string {
+// LookupArtwork returns the artwork URL for a SomaFM station identified
+// by its homepage URL. Returns empty string if not applicable.
+func (s *SomaFMClient) LookupArtwork(homepage string) string {
 	if homepage == "" {
 		return ""
 	}
@@ -50,16 +58,54 @@ func (s *SomaFMArtwork) Lookup(homepage string) string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.channels == nil || time.Since(s.fetchedAt) > somafmCacheTTL {
-		if err := s.fetch(); err != nil {
-			return ""
-		}
+	if err := s.ensureFetched(); err != nil {
+		return ""
 	}
 
-	return s.channels[id]
+	return s.artIndex[id]
 }
 
-func (s *SomaFMArtwork) fetch() error {
+// Stations returns all SomaFM channels as Station values.
+func (s *SomaFMClient) Stations() ([]Station, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.ensureFetched(); err != nil {
+		return nil, err
+	}
+
+	stations := make([]Station, 0, len(s.channels))
+	for _, ch := range s.channels {
+		streamURL := ""
+		for _, pl := range ch.Playlists {
+			if pl.Format == "mp3" {
+				streamURL = pl.URL
+				break
+			}
+		}
+		if streamURL == "" {
+			continue
+		}
+		stations = append(stations, Station{
+			UUID:      "somafm-" + ch.ID,
+			Name:      ch.Title,
+			Homepage:  "https://somafm.com/" + ch.ID + "/",
+			StreamURL: streamURL,
+			Favicon:   ch.Image,
+			Tags:      ch.Genre,
+		})
+	}
+	return stations, nil
+}
+
+func (s *SomaFMClient) ensureFetched() error {
+	if s.channels != nil && time.Since(s.fetchedAt) <= somafmCacheTTL {
+		return nil
+	}
+	return s.fetch()
+}
+
+func (s *SomaFMClient) fetch() error {
 	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Get("https://somafm.com/channels.json")
 	if err != nil {
@@ -81,14 +127,15 @@ func (s *SomaFMArtwork) fetch() error {
 		return fmt.Errorf("somafm parse: %w", err)
 	}
 
-	channels := make(map[string]string, len(data.Channels))
+	artIndex := make(map[string]string, len(data.Channels))
 	for _, ch := range data.Channels {
 		if ch.Image != "" {
-			channels[ch.ID] = ch.Image
+			artIndex[ch.ID] = ch.Image
 		}
 	}
 
-	s.channels = channels
+	s.channels = data.Channels
+	s.artIndex = artIndex
 	s.fetchedAt = time.Now()
 	return nil
 }

--- a/internal/radio/somafm_test.go
+++ b/internal/radio/somafm_test.go
@@ -32,12 +32,17 @@ func TestExtractSomaFMID(t *testing.T) {
 	}
 }
 
-func TestSomaFMArtworkLookup(t *testing.T) {
-	s := NewSomaFMArtwork()
+func TestSomaFMClientLookupArtwork(t *testing.T) {
+	s := NewSomaFMClient()
 
 	// Pre-populate the cache to avoid hitting the network.
 	s.mu.Lock()
-	s.channels = map[string]string{
+	s.channels = []somafmChannel{
+		{ID: "groovesalad", Title: "Groove Salad", Image: "https://somafm.com/logos/512/groovesalad512.png"},
+		{ID: "dronezone", Title: "Drone Zone", Image: "https://somafm.com/logos/512/dronezone512.png"},
+		{ID: "insound", Title: "The In-Sound", Image: "https://somafm.com/logos/512/insound512.jpg"},
+	}
+	s.artIndex = map[string]string{
 		"groovesalad": "https://somafm.com/logos/512/groovesalad512.png",
 		"dronezone":   "https://somafm.com/logos/512/dronezone512.png",
 		"insound":     "https://somafm.com/logos/512/insound512.jpg",
@@ -60,10 +65,70 @@ func TestSomaFMArtworkLookup(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := s.Lookup(tt.homepage)
+			got := s.LookupArtwork(tt.homepage)
 			if got != tt.want {
-				t.Errorf("Lookup(%q) = %q, want %q", tt.homepage, got, tt.want)
+				t.Errorf("LookupArtwork(%q) = %q, want %q", tt.homepage, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSomaFMClientStations(t *testing.T) {
+	s := NewSomaFMClient()
+
+	s.mu.Lock()
+	s.channels = []somafmChannel{
+		{
+			ID: "groovesalad", Title: "Groove Salad", Genre: "ambient",
+			Image: "https://somafm.com/logos/512/groovesalad512.png",
+			Playlists: []somafmPlaylist{
+				{URL: "https://api.somafm.com/groovesalad.pls", Format: "mp3"},
+				{URL: "https://api.somafm.com/groovesalad130.pls", Format: "aac"},
+			},
+		},
+		{
+			ID: "dronezone", Title: "Drone Zone", Genre: "ambient|space",
+			Image: "https://somafm.com/logos/512/dronezone512.png",
+			Playlists: []somafmPlaylist{
+				{URL: "https://api.somafm.com/dronezone130.pls", Format: "aac"},
+				{URL: "https://api.somafm.com/dronezone.pls", Format: "mp3"},
+			},
+		},
+		{
+			ID: "nostream", Title: "No Stream", Genre: "test",
+			Image: "https://somafm.com/logos/512/nostream512.png",
+			Playlists: []somafmPlaylist{
+				{URL: "https://api.somafm.com/nostream130.pls", Format: "aac"},
+			},
+		},
+	}
+	s.artIndex = map[string]string{
+		"groovesalad": "https://somafm.com/logos/512/groovesalad512.png",
+		"dronezone":   "https://somafm.com/logos/512/dronezone512.png",
+	}
+	s.fetchedAt = time.Now()
+	s.mu.Unlock()
+
+	stations, err := s.Stations()
+	if err != nil {
+		t.Fatalf("Stations() error: %v", err)
+	}
+
+	// Should skip "nostream" (no mp3 playlist).
+	if len(stations) != 2 {
+		t.Fatalf("got %d stations, want 2", len(stations))
+	}
+
+	if stations[0].UUID != "somafm-groovesalad" {
+		t.Errorf("stations[0].UUID = %q, want %q", stations[0].UUID, "somafm-groovesalad")
+	}
+	if stations[0].StreamURL != "https://api.somafm.com/groovesalad.pls" {
+		t.Errorf("stations[0].StreamURL = %q, want mp3 URL", stations[0].StreamURL)
+	}
+	if stations[0].Tags != "ambient" {
+		t.Errorf("stations[0].Tags = %q, want %q", stations[0].Tags, "ambient")
+	}
+	if stations[1].StreamURL != "https://api.somafm.com/dronezone.pls" {
+		t.Errorf("stations[1].StreamURL = %q, want mp3 URL", stations[1].StreamURL)
 	}
 }

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -885,14 +885,14 @@ type RadioStationJSON struct {
 	Clicks    int    `json:"clicks"`
 }
 
-var somafmArtwork = radio.NewSomaFMArtwork()
+var somafmClient = radio.NewSomaFMClient()
 
 func stationsToJSON(stations []radio.Station) []RadioStationJSON {
 	result := make([]RadioStationJSON, len(stations))
 	for i, s := range stations {
 		favicon := s.Favicon
 		if favicon == "" {
-			if art := somafmArtwork.Lookup(s.Homepage); art != "" {
+			if art := somafmClient.LookupArtwork(s.Homepage); art != "" {
 				favicon = art
 			}
 		}
@@ -953,6 +953,15 @@ func (s *LibraryService) GetTopVotedRadioStations(limit int) ([]RadioStationJSON
 // GetTopClickedRadioStations returns the most clicked radio stations.
 func (s *LibraryService) GetTopClickedRadioStations(limit int) ([]RadioStationJSON, error) {
 	stations, err := radioClient.TopClicked(limit)
+	if err != nil {
+		return nil, err
+	}
+	return stationsToJSON(stations), nil
+}
+
+// GetSomaFMStations returns all SomaFM channels.
+func (s *LibraryService) GetSomaFMStations() ([]RadioStationJSON, error) {
+	stations, err := somafmClient.Stations()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Clickable tag chips on station cards filter the Browse tab by genre via the RadioBrowser API
- Source filter pills (All / SomaFM) above the station list let you browse curated SomaFM channels directly from their API
- Active filter indicator with a clear button to return to the default top-voted view
- Refactored `SomaFMArtwork` into `SomaFMClient` that caches full channel data (titles, genres, stream URLs, artwork) for both artwork fallback and source filtering

## Test plan

- [x] Go tests pass (`go test ./internal/radio/`)
- [x] Go vet clean
- [x] Frontend builds with 0 errors
- [x] `go build` succeeds
- [ ] CI green