### PR TITLE
BAU: Fix security dependency warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,12 +116,12 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev
 
       - name: Install wails3
-        run: go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+        run: go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.74
 
       - name: Install go-task
         uses: arduino/setup-task@v2
         with:
-          version: 3.x
+          version: 3.51.1
 
       - run: task build
 
@@ -151,14 +151,15 @@ jobs:
         working-directory: frontend
         run: |
           npm ci
+          npm audit signatures
           npm run build
 
       - name: govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
           govulncheck -tags nocgo ./...
 
       - name: trufflehog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.95.3
         with:
           extra_args: --only-verified

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.8"
+          go-version: "1.25.10"
 
       - uses: actions/setup-node@v4
         with:
@@ -33,12 +33,12 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev libfuse2
 
       - name: Install wails3
-        run: go install github.com/wailsapp/wails/v3/cmd/wails3@latest
+        run: go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.74
 
       - name: Install go-task
         uses: arduino/setup-task@v2
         with:
-          version: 3.x
+          version: 3.51.1
 
       - name: Set version from tag
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV

--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -19,7 +19,7 @@ tasks:
       - sh: npm version
         msg: "Looks like npm isn't installed. Npm is part of the Node installer: https://nodejs.org/en/download/"
     cmds:
-      - npm install
+      - npm ci
 
   build:frontend:
     label: build:frontend (DEV={{.DEV}})

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772479524,
-        "narHash": "sha256-u7nCaNiMjqvKpE+uZz9hE7pgXXTmm5yvdtFaqzSzUQI=",
+        "lastModified": 1779414690,
+        "narHash": "sha256-gOTcX/9MZVMUE0Xvb4IEcv+0TQJkZFNEnL757ljU360=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4215e62dc2cd3bc705b0a423b9719ff6be378a43",
+        "rev": "6dedf69f94d03cbe7bdde106f2d4c23ae2a853bf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,8 @@
           pname = "forte-frontend";
           version = "0.1.0";
           src = ./frontend;
-          npmDepsHash = "sha256-zCzHDKFSowfaPyKi2fUEvXkpotx0koK30OjQWBZ/RX8=";
+          nodejs = pkgs.nodejs_22;
+          npmDepsHash = "sha256-TWuww6q2PVFmoDqjkgGw67ZUometknyPtBOLARdcEfU=";
           buildPhase = ''
             npm run build
           '';
@@ -29,7 +30,8 @@
           pname = "forte";
           version = "0.1.0";
           src = ./.;
-          vendorHash = "sha256-ZaGM6mtQHojsnXJmyEzMPVF5dmt29kUkfJx2wQmOSDw=";
+          go = pkgs.go_1_25;
+          vendorHash = "sha256-l/iMbtl+O1X4N8Wdbn1ohNd9AIgs4kyyeqGPZxGCfhE=";
           tags = [ "production" "nocgo" "gtk4" ];
           ldflags = [ "-s" "-w" ];
           subPackages = [ "." ];
@@ -82,7 +84,7 @@
 
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            go
+            go_1_25
             nodejs_22
             go-task
             golangci-lint

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,13 +11,13 @@
         "@wailsio/runtime": "3.0.0-alpha.79"
       },
       "devDependencies": {
-        "@playwright/test": "^1.58.2",
-        "@sveltejs/vite-plugin-svelte": "^5.0.0",
-        "@tsconfig/svelte": "^5.0.4",
-        "svelte": "^5.0.0",
-        "svelte-check": "^4.0.0",
-        "typescript": "^5.7.0",
-        "vite": "^6.0.0"
+        "@playwright/test": "1.58.2",
+        "@sveltejs/vite-plugin-svelte": "5.1.1",
+        "@tsconfig/svelte": "5.0.8",
+        "svelte": "5.55.9",
+        "svelte-check": "4.4.4",
+        "typescript": "5.9.3",
+        "vite": "6.4.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "packageManager": "npm@10.9.4",
   "scripts": {
     "dev": "vite",
     "build:dev": "vite build --minify false --mode development",
@@ -15,12 +16,12 @@
     "@wailsio/runtime": "3.0.0-alpha.79"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2",
-    "@sveltejs/vite-plugin-svelte": "^5.0.0",
-    "@tsconfig/svelte": "^5.0.4",
-    "svelte": "^5.0.0",
-    "svelte-check": "^4.0.0",
-    "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "@playwright/test": "1.58.2",
+    "@sveltejs/vite-plugin-svelte": "5.1.1",
+    "@tsconfig/svelte": "5.0.8",
+    "svelte": "5.55.9",
+    "svelte-check": "4.4.4",
+    "typescript": "5.9.3",
+    "vite": "6.4.2"
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
-	github.com/go-git/go-git/v5 v5.17.1 // indirect
+	github.com/go-git/go-git/v5 v5.19.1 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -40,7 +40,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/pjbgf/sha1cd v0.5.0 // indirect
+	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/samber/lo v1.52.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.17.1 h1:WnljyxIzSj9BRRUlnmAU35ohDsjRK0EKmL0evDqi5Jk=
-github.com/go-git/go-git/v5 v5.17.1/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
+github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
+github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/go-json-experiment/json v0.0.0-20251027170946-4849db3c2f7e h1:Lf/gRkoycfOBPa42vU2bbgPurFong6zXeFtPoxholzU=
 github.com/go-json-experiment/json v0.0.0-20251027170946-4849db3c2f7e/go.mod h1:uNVvRXArCGbZ508SxYYTC5v1JWoz2voff5pm25jU1Ok=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
@@ -92,8 +92,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/pjbgf/sha1cd v0.5.0 h1:a+UkboSi1znleCDUNT3M5YxjOnN1fz2FhN48FlwCxs0=
-github.com/pjbgf/sha1cd v0.5.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
+github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=
+github.com/pjbgf/sha1cd v0.6.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
## Summary
- Upgrade `go-git` to `v5.19.1` and refresh Go/Nix hashes for the patched dependency set.
- Pin frontend dev dependency versions to the audited lockfile versions that satisfy the Dependabot advisories.
- Tighten CI/release supply-chain posture by removing moving refs for Wails, go-task, govulncheck, and TruffleHog, plus adding npm registry signature verification in the security job.
- Pin Nix builds/dev shell to Go 1.25 and Node 22 so local and CI toolchains stay aligned.

## Validation
- `npm ci`
- `npm audit --audit-level=moderate`
- `npm audit signatures`
- `npm run check`
- `npm run build`
- `nix develop --command go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 -tags 'nocgo gtk4' ./...`
- `nix develop --command go test -tags 'nocgo gtk4' ./...`
- `nix develop --command golangci-lint run --build-tags 'nocgo,gtk4'`
- `nix build .#frontend`
- `nix build .#forte`
- `git diff --check`
