### PR TITLE
BAU: Keep radio history as a tab

### DIFF
--- a/frontend/src/Content.svelte
+++ b/frontend/src/Content.svelte
@@ -206,8 +206,6 @@
     {/if}
   {:else if currentView === 'radio'}
     <RadioView />
-  {:else if currentView === 'history'}
-    <RadioView initialTab="history" />
   {:else if currentView === 'playlists' && libraryEnabled}
     <PlaylistView />
   {:else if currentView === 'stats' && libraryEnabled}

--- a/frontend/src/Sidebar.svelte
+++ b/frontend/src/Sidebar.svelte
@@ -26,7 +26,6 @@
 
   const navItems: { view: View; label: string; icon: string }[] = [
     { view: 'radio', label: 'Radio', icon: '\u25CE' },
-    { view: 'history', label: 'History', icon: '\u25F7' },
     { view: 'library', label: 'Library', icon: '\u266B' },
     { view: 'playlists', label: 'Playlists', icon: '\u2630' },
     { view: 'stats', label: 'Stats', icon: '\u2584' },

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -1,7 +1,7 @@
 // Reactive stores for application state.
 
 // Current view shown in the content area.
-export type View = 'library' | 'playlists' | 'radio' | 'history' | 'stats' | 'settings';
+export type View = 'library' | 'playlists' | 'radio' | 'stats' | 'settings';
 
 // Simple store using Svelte 5 module-level state is not possible
 // in a .ts file, so we use a plain object with getter/setter callbacks.

--- a/frontend/tests/radio.spec.ts
+++ b/frontend/tests/radio.spec.ts
@@ -14,6 +14,7 @@ test('shows Radio in sidebar navigation', async ({ page }) => {
 
 test('opens on radio and hides library-first navigation by default', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Radio' })).toBeVisible();
+  await expect(page.locator('nav.sidebar button', { hasText: 'History' })).toHaveCount(0);
   await expect(page.locator('nav.sidebar button', { hasText: 'Library' })).toHaveCount(0);
   await expect(page.locator('nav.sidebar button', { hasText: 'Playlists' })).toHaveCount(0);
   await expect(page.locator('nav.sidebar button', { hasText: 'Stats' })).toHaveCount(0);
@@ -69,8 +70,9 @@ test('adds and plays a custom station', async ({ page }) => {
   await expect(page.getByText('My Stream')).toBeVisible();
 });
 
-test('shows radio history from sidebar', async ({ page }) => {
-  await page.locator('nav.sidebar button', { hasText: 'History' }).click();
+test('shows radio history from the Radio tab', async ({ page }) => {
+  await radioNavButton(page).click();
+  await page.locator('.tabs').getByRole('button', { name: 'History', exact: true }).click();
   await expect(page.getByRole('heading', { name: 'Radio' })).toBeVisible();
   await expect(page.getByText('Classical 24')).toBeVisible();
   await expect(page.getByText('Morning Concert')).toBeVisible();


### PR DESCRIPTION
## Summary

- Remove History as a top-level sidebar item.
- Keep radio history available inside the Radio view as a tab.
- Update the radio e2e coverage to assert there is no duplicate History navigation item.

## Verification

- `npm run check`
- `npm run build`
- `nix develop --command bash -lc 'cd frontend && npm run test:e2e -- tests/radio.spec.ts'`
