### PR TITLE
BAU: Clear go-git dependency alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev ffmpeg
 
       - name: Install wails3
-        run: go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.74
+        run: go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.95
 
       - name: Install go-task
         uses: arduino/setup-task@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev libfuse2
 
       - name: Install wails3
-        run: go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.74
+        run: go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.95
 
       - name: Install go-task
         uses: arduino/setup-task@v2

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,33 @@
           version = "0.1.0";
           src = ./.;
           go = pkgs.go_1_25;
-          vendorHash = "sha256-l/iMbtl+O1X4N8Wdbn1ohNd9AIgs4kyyeqGPZxGCfhE=";
+          vendorHash = "sha256-jzLbGazcgpDCT6bjqfnwVcZWs4e3201mdOeKVtPMhlE=";
+          modBuildPhase = ''
+            runHook preBuild
+
+            if [ -d vendor ]; then
+              echo "vendor folder exists, please set 'vendorHash = null;' in your expression"
+              exit 10
+            fi
+
+            export GIT_SSL_CAINFO=$NIX_SSL_CERT_FILE
+            go mod download
+
+            webview2Loader="$GOPATH/pkg/mod/github.com/wailsapp/wails/webview2@v1.0.24/webviewloader"
+            chmod -R u+w "$GOPATH/pkg/mod/github.com/wailsapp/wails/webview2@v1.0.24"
+            mkdir -p "$webview2Loader/x86" "$webview2Loader/x64" "$webview2Loader/arm64"
+            : > "$webview2Loader/x86/WebView2Loader.dll"
+            : > "$webview2Loader/x64/WebView2Loader.dll"
+            : > "$webview2Loader/arm64/WebView2Loader.dll"
+
+            if (( "''${NIX_DEBUG:-0}" >= 1 )); then
+              goModVendorFlags+=(-v)
+            fi
+            go mod vendor "''${goModVendorFlags[@]}"
+
+            mkdir -p vendor
+            runHook postBuild
+          '';
           tags = [ "production" "nocgo" "gtk4" ];
           ldflags = [ "-s" "-w" ];
           subPackages = [ "." ];

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gen2brain/go-mpv v0.2.3
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/wailsapp/wails/v3 v3.0.0-alpha.74
+	github.com/wailsapp/wails/v3 v3.0.0-alpha.95
 	go.senan.xyz/taglib v0.11.1
 	modernc.org/sqlite v1.46.1
 )
@@ -47,13 +47,13 @@ require (
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/tetratelabs/wazero v1.10.1 // indirect
-	github.com/wailsapp/go-webview2 v1.0.23 // indirect
+	github.com/wailsapp/wails/webview2 v1.0.24 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,10 +121,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tetratelabs/wazero v1.10.1 h1:2DugeJf6VVk58KTPszlNfeeN8AhhpwcZqkJj2wwFuH8=
 github.com/tetratelabs/wazero v1.10.1/go.mod h1:DRm5twOQ5Gr1AoEdSi0CLjDQF1J9ZAuyqFIjl1KKfQU=
-github.com/wailsapp/go-webview2 v1.0.23 h1:jmv8qhz1lHibCc79bMM/a/FqOnnzOGEisLav+a0b9P0=
-github.com/wailsapp/go-webview2 v1.0.23/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
-github.com/wailsapp/wails/v3 v3.0.0-alpha.74 h1:wRm1EiDQtxDisXk46NtpiBH90STwfKp36NrTDwOEdxw=
-github.com/wailsapp/wails/v3 v3.0.0-alpha.74/go.mod h1:4saK4A4K9970X+X7RkMwP2lyGbLogcUz54wVeq4C/V8=
+github.com/wailsapp/wails/v3 v3.0.0-alpha.95 h1:Rve8djRSldn6381q2l8gw8XEnzPX/4So6VsRM6bc7Vs=
+github.com/wailsapp/wails/v3 v3.0.0-alpha.95/go.mod h1:3euiK0wb6vnXvxiHysRYYbukCa060bLSsfrvN7sZg4k=
+github.com/wailsapp/wails/webview2 v1.0.24 h1:uULnjCSaRfMlU84mS3kjLgPsRosEOIusVK1nFOHZHzs=
+github.com/wailsapp/wails/webview2 v1.0.24/go.mod h1:sdf+s0nAdxlzVWf9SCxC15XaxnQPJeY+uU1Ucn3jHQM=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 go.senan.xyz/taglib v0.11.1 h1:S3mO5e3HRRG0Ehw1jLUodYbAJK8TtqdOoNgqkC0D3uU=
@@ -156,8 +156,8 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
 golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
-golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
 golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=


### PR DESCRIPTION
## Summary

- Upgrade Wails from `v3.0.0-alpha.74` to `v3.0.0-alpha.95` so Wails' own module metadata now declares patched `github.com/go-git/go-git/v5 v5.19.1` and `github.com/go-git/go-billy/v5 v5.9.0`.
- Pin CI and release Wails CLI installs to the same alpha.95 version.
- Refresh the Nix Go vendor hash and patch the Nix vendoring phase for Wails' Windows-only WebView2 embed placeholders.

## Root Cause

The project already selected patched `go-git` and `go-billy` versions directly, but Wails alpha.74 still declared vulnerable transitive module requirements in its own `go.mod`. Dependabot was alerting against that transitive Wails edge. Wails alpha.95 updates those edges to the patched versions.

Wails alpha.95 also introduces `github.com/wailsapp/wails/webview2 v1.0.24`, whose module zip lacks Windows DLL files referenced by embed patterns. The Linux app build does not use those DLLs, but Nix's vendoring scan validates module embed patterns while building the vendor tree, so the Nix module phase now creates deterministic empty placeholders before `go mod vendor`.

## Verification

- `go mod graph | rg 'wailsapp/wails/v3@v3.0.0-alpha.95 github.com/go-git'`
  - `github.com/go-git/go-git/v5@v5.19.1`
  - `github.com/go-git/go-billy/v5@v5.9.0`
- `go test ./...`
- `govulncheck -tags nocgo ./...` reports code affected by 0 vulnerabilities
- `npm audit --json` reports 0 vulnerabilities
- `npm run check`
- `npm run build`
- `npm run test:e2e` reports 52 passed
- `go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.95 && wails3 version && task build`
- `nix build .#forte --extra-experimental-features 'nix-command flakes'`
