### PR TITLE
BAU: Enable Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

- Enable Dependabot version updates for Go modules, frontend npm dependencies, and GitHub Actions.
- Schedule each ecosystem weekly on Monday morning in `Europe/London`.
- Add a 7-day Dependabot cooldown before normal package version updates are opened.

## Notes

GitHub's `cooldown` option applies to Dependabot version updates, not security updates, so urgent security updates are not intentionally delayed by this setting.

## Verification

- `ruby -e 'require "yaml"; data=YAML.load_file(".github/dependabot.yml"); abort "missing version" unless data["version"] == 2; abort "missing updates" unless data["updates"].size == 3; data["updates"].each { |u| abort "bad cooldown" unless u.dig("cooldown", "default-days") == 7 }; puts "dependabot.yml parsed with 3 ecosystems and 7-day cooldowns"'`
- `git diff --check`
- `gh api -H 'Accept: application/vnd.github+json' /repos/willfish/forte/dependabot/alerts?state=open --paginate --jq 'length'` returns `0`
