### PR TITLE
Add radio station double-click toggle

### DIFF
--- a/frontend/src/RadioView.svelte
+++ b/frontend/src/RadioView.svelte
@@ -408,6 +408,21 @@
     }
   }
 
+  async function handleStationDoubleClick(
+    event: MouseEvent,
+    stationUuid: string,
+    name: string,
+    url: string,
+    favicon: string,
+    tags: string
+  ) {
+    const target = event.target as HTMLElement;
+    if (target.closest('button, input, a, select, textarea')) {
+      return;
+    }
+    await playStation(stationUuid, name, url, favicon, tags);
+  }
+
   function isPlayingStation(stationUuid: string): boolean {
     return isCurrentStation(stationUuid) && playbackState === 'playing';
   }
@@ -615,9 +630,14 @@
         {/if}
       </div>
     {:else}
-      <div class="station-list">
+      <div class="station-list" role="list">
         {#each stations as station (station.uuid)}
-          <div class="station-card" class:playing={isCurrentStation(station.uuid)}>
+          <div
+            class="station-card"
+            role="listitem"
+            class:playing={isCurrentStation(station.uuid)}
+            ondblclick={(event) => handleStationDoubleClick(event, station.uuid, station.name, station.streamUrl, station.favicon, station.tags)}
+          >
             <button class="station-play" class:playing={isCurrentStation(station.uuid)} onclick={() => playStation(station.uuid, station.name, station.streamUrl, station.favicon, station.tags)} aria-label={isPlayingStation(station.uuid) ? `Pause ${station.name}` : `Play ${station.name}`}>
               {#if isPlayingStation(station.uuid)}
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
@@ -682,9 +702,14 @@
     {#if favourites.length === 0}
       <div class="empty">No favourite stations yet. Browse and add some!</div>
     {:else}
-      <div class="station-list">
+      <div class="station-list" role="list">
         {#each favourites as fav (fav.stationUuid)}
-          <div class="station-card" class:playing={isCurrentStation(fav.stationUuid)}>
+          <div
+            class="station-card"
+            role="listitem"
+            class:playing={isCurrentStation(fav.stationUuid)}
+            ondblclick={(event) => handleStationDoubleClick(event, fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.tags)}
+          >
             <button class="station-play" class:playing={isCurrentStation(fav.stationUuid)} onclick={() => playStation(fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.tags)} aria-label={isPlayingStation(fav.stationUuid) ? `Pause ${fav.name}` : `Play ${fav.name}`}>
               {#if isPlayingStation(fav.stationUuid)}
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
@@ -766,9 +791,14 @@
     {#if customStations.length === 0}
       <div class="empty">No custom stations yet.</div>
     {:else}
-      <div class="station-list">
+      <div class="station-list" role="list">
         {#each customStations as station (station.stationUuid)}
-          <div class="station-card" class:playing={isCurrentStation(station.stationUuid)}>
+          <div
+            class="station-card"
+            role="listitem"
+            class:playing={isCurrentStation(station.stationUuid)}
+            ondblclick={(event) => handleStationDoubleClick(event, station.stationUuid, station.name, station.streamUrl, station.faviconUrl, station.tags)}
+          >
             <button class="station-play" class:playing={isCurrentStation(station.stationUuid)} onclick={() => playStation(station.stationUuid, station.name, station.streamUrl, station.faviconUrl, station.tags)} aria-label={isPlayingStation(station.stationUuid) ? `Pause ${station.name}` : `Play ${station.name}`}>
               {#if isPlayingStation(station.stationUuid)}
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
@@ -823,9 +853,14 @@
     {#if history.length === 0}
       <div class="empty">No radio history yet.</div>
     {:else}
-      <div class="station-list">
+      <div class="station-list" role="list">
         {#each history as item (item.stationUuid)}
-          <div class="station-card" class:playing={isCurrentStation(item.stationUuid)}>
+          <div
+            class="station-card"
+            role="listitem"
+            class:playing={isCurrentStation(item.stationUuid)}
+            ondblclick={(event) => handleStationDoubleClick(event, item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.tags)}
+          >
             <button class="station-play" class:playing={isCurrentStation(item.stationUuid)} onclick={() => playStation(item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.tags)} aria-label={isPlayingStation(item.stationUuid) ? `Pause ${item.name}` : `Play ${item.name}`}>
               {#if isPlayingStation(item.stationUuid)}
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">

--- a/frontend/tests/mocks/wails-runtime.ts
+++ b/frontend/tests/mocks/wails-runtime.ts
@@ -30,6 +30,7 @@ let playbackStatus = {
   repeat: "off",
   mediaPath: "",
   radioMode: false,
+  radioUuid: "",
   radioStation: "",
   radioArtwork: "",
 };
@@ -259,19 +260,18 @@ const fixtures: Record<number, (...args: any[]) => any> = {
   // PlayRadioStation
   3331506535: (stationUuid: string, name: string, streamUrl: string, artworkUrl: string, tags: string) => {
     upsertHistory(stationUuid, name, streamUrl, artworkUrl, tags);
-    if (stationUuid === "somafm-missioncontrol") {
-      playbackStatus = {
-        ...playbackStatus,
-        state: "playing",
-        title: name,
-        artist: "SomaFM Mission Control (128k MP3)",
-        album: "",
-        mediaPath: streamUrl,
-        radioMode: true,
-        radioStation: "SomaFM Mission Control (128k MP3)",
-        radioArtwork: artworkUrl,
-      };
-    }
+    playbackStatus = {
+      ...playbackStatus,
+      state: "playing",
+      title: name,
+      artist: stationUuid === "somafm-missioncontrol" ? "SomaFM Mission Control (128k MP3)" : "Radio",
+      album: "",
+      mediaPath: streamUrl,
+      radioMode: true,
+      radioUuid: stationUuid,
+      radioStation: stationUuid === "somafm-missioncontrol" ? "SomaFM Mission Control (128k MP3)" : name,
+      radioArtwork: artworkUrl,
+    };
   },
   // StopRadio
   3776601259: () => undefined,
@@ -284,12 +284,20 @@ const fixtures: Record<number, (...args: any[]) => any> = {
   // Play
   1808111650: () => undefined,
   // Pause
-  191671602: () => undefined,
+  191671602: () => {
+    if (playbackStatus.state === "playing") {
+      playbackStatus = { ...playbackStatus, state: "paused" };
+    }
+  },
   // Resume
-  4192344979: () => undefined,
+  4192344979: () => {
+    if (playbackStatus.state === "paused") {
+      playbackStatus = { ...playbackStatus, state: "playing" };
+    }
+  },
   // Stop
   2311398648: () => {
-    playbackStatus = { ...playbackStatus, state: "stopped", title: "", artist: "", album: "", mediaPath: "" };
+    playbackStatus = { ...playbackStatus, state: "stopped", title: "", artist: "", album: "", mediaPath: "", radioMode: false, radioUuid: "" };
   },
   // Seek
   1479346536: () => undefined,

--- a/frontend/tests/radio.spec.ts
+++ b/frontend/tests/radio.spec.ts
@@ -64,10 +64,10 @@ test('adds and plays a custom station', async ({ page }) => {
   await page.getByLabel('Stream URL').fill('https://stream.example.com/mine');
   await page.getByLabel('Tags').fill('ambient');
   await page.getByRole('button', { name: 'Add Station' }).click();
-  await expect(page.getByText('My Stream')).toBeVisible();
+  await expect(page.getByRole('listitem').filter({ hasText: 'My Stream' })).toBeVisible();
 
   await page.locator('.tabs').getByRole('button', { name: 'History', exact: true }).click();
-  await expect(page.getByText('My Stream')).toBeVisible();
+  await expect(page.getByRole('listitem').filter({ hasText: 'My Stream' })).toBeVisible();
 });
 
 test('shows radio history from the Radio tab', async ({ page }) => {
@@ -96,4 +96,18 @@ test('shows play buttons for stations', async ({ page }) => {
   await radioNavButton(page).click();
   const playButtons = page.getByRole('button', { name: /Play / });
   await expect(playButtons.first()).toBeVisible();
+});
+
+test('double-clicking the current radio station toggles play and pause', async ({ page }) => {
+  await radioNavButton(page).click();
+
+  const station = page.getByRole('listitem').filter({ hasText: 'Ishq - Iqqoa' });
+  await station.dblclick();
+  await expect(station.getByText('Playing')).toBeVisible();
+
+  await station.dblclick();
+  await expect(station.getByText('Paused')).toBeVisible();
+
+  await station.dblclick();
+  await expect(station.getByText('Playing')).toBeVisible();
 });


### PR DESCRIPTION
## Summary

Adds double-click support to radio station rows so double-clicking a station starts it, pauses the currently playing station, or resumes the currently paused station.

The explicit row controls keep their existing behavior: double-clicks on play, favourite, pin, delete, tag, and form controls are ignored by the row-level handler so those controls do not accidentally toggle playback.

## Validation

- `cd frontend && npm run check`
