### PR TITLE
Add desktop VM validation checks

### DIFF
--- a/.github/workflows/vm-validation.yml
+++ b/.github/workflows/vm-validation.yml
@@ -1,0 +1,51 @@
+name: VM Validation
+
+on:
+  schedule:
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  desktop-smoke:
+    name: ${{ matrix.desktop }} desktop smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        desktop:
+          - gnome
+          - plasma
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Run VM smoke test
+        run: nix build ".#checks.x86_64-linux.forte-vm-smoke-${{ matrix.desktop }}" -L --no-write-lock-file
+
+      - name: Collect VM artifacts
+        if: always()
+        run: |
+          mkdir -p "vm-artifacts/${{ matrix.desktop }}"
+          if [ -e result ]; then
+            cp -Lr result/* "vm-artifacts/${{ matrix.desktop }}/" || true
+          fi
+
+      - uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: vm-validation-${{ matrix.desktop }}
+          path: vm-artifacts/${{ matrix.desktop }}
+          if-no-files-found: ignore

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
+        lib = pkgs.lib;
 
         frontend = pkgs.buildNpmPackage {
           pname = "forte-frontend";
@@ -121,12 +122,152 @@
             mainProgram = "forte";
           };
         };
+
+        vmUser = "forte";
+
+        mkDesktopVmModule = desktop: { pkgs, ... }: {
+          networking.hostName = "forte-${desktop}";
+          system.stateVersion = "26.05";
+
+          virtualisation.vmVariant.virtualisation = {
+            cores = 2;
+            memorySize = 4096;
+            diskSize = 8192;
+          };
+
+          users.users.${vmUser} = {
+            isNormalUser = true;
+            description = "Forte VM validation user";
+            extraGroups = [ "audio" "video" "wheel" ];
+            password = "";
+          };
+
+          security.polkit.enable = true;
+          services.dbus.enable = true;
+
+          services.pipewire = {
+            enable = true;
+            alsa.enable = true;
+            pulse.enable = true;
+          };
+
+          hardware.graphics.enable = true;
+          xdg.portal.enable = true;
+
+          services.xserver.enable = true;
+          services.displayManager.autoLogin = {
+            enable = true;
+            user = vmUser;
+          };
+
+          services.desktopManager.gnome.enable = desktop == "gnome";
+          services.displayManager.gdm = lib.mkIf (desktop == "gnome") {
+            enable = true;
+          };
+
+          services.desktopManager.plasma6.enable = desktop == "plasma";
+          services.displayManager.sddm = lib.mkIf (desktop == "plasma") {
+            enable = true;
+            wayland.enable = false;
+          };
+
+          environment.systemPackages = with pkgs; [
+            forte
+            dbus
+            desktop-file-utils
+            hicolor-icon-theme
+            playerctl
+            xdg-utils
+          ];
+        };
+
+        mkDesktopVm = desktop:
+          nixpkgs.lib.nixosSystem {
+            inherit system;
+            modules = [ (mkDesktopVmModule desktop) ];
+          };
+
+        mkDesktopVmApp = desktop:
+          let
+            vm = mkDesktopVm desktop;
+            runner = pkgs.writeShellApplication {
+              name = "forte-vm-${desktop}";
+              text = ''
+                export QEMU_OPTS="''${QEMU_OPTS:-} -m 4096"
+                exec ${vm.config.system.build.vm}/bin/run-*-vm "$@"
+              '';
+            };
+          in
+          {
+            type = "app";
+            program = "${runner}/bin/forte-vm-${desktop}";
+            meta.description = "Launch Forte in an interactive ${desktop} validation VM";
+          };
+
+        mkDesktopVmSmoke = desktop:
+          pkgs.testers.nixosTest {
+            name = "forte-${desktop}-desktop-smoke";
+
+            nodes.machine = { ... }: {
+              imports = [ (mkDesktopVmModule desktop) ];
+
+              virtualisation = {
+                cores = 2;
+                memorySize = 4096;
+                diskSize = 8192;
+              };
+            };
+
+            testScript = ''
+              machine.start()
+              machine.wait_for_unit("display-manager.service")
+              machine.wait_for_file("/run/user/1000/bus")
+              machine.wait_for_x()
+
+              machine.succeed("test -x /run/current-system/sw/bin/forte")
+              machine.succeed("desktop-file-validate /run/current-system/sw/share/applications/io.github.willfish.forte.desktop")
+              machine.succeed("test -e /run/current-system/sw/share/icons/hicolor/scalable/apps/io.github.willfish.forte.svg")
+              machine.succeed("test -e /run/current-system/sw/share/icons/hicolor/scalable/apps/io.github.willfish.forte-tray-idle.svg")
+
+              base_env = "XDG_RUNTIME_DIR=/run/user/1000 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus"
+              machine.succeed(
+                  f"runuser -u ${vmUser} -- sh -lc '{base_env} systemctl --user show-environment > /tmp/forte-session.env'"
+              )
+              machine.succeed("grep -Eq '^(DISPLAY|WAYLAND_DISPLAY)=' /tmp/forte-session.env")
+
+              env = "set -a; . /tmp/forte-session.env; set +a; export XDG_RUNTIME_DIR=/run/user/1000 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus"
+              machine.succeed(
+                  f"runuser -u ${vmUser} -- sh -lc '{env}; nohup forte >/tmp/forte.log 2>&1 &'"
+              )
+              machine.succeed(
+                  "for i in $(seq 1 30); do pgrep -u ${vmUser} -af '[f]orte' && exit 0; sleep 1; done; cat /tmp/forte.log >&2 || true; exit 1"
+              )
+              machine.succeed(
+                  f"for i in $(seq 1 30); do runuser -u ${vmUser} -- sh -lc '{env}; busctl --user --list | grep -q org.mpris.MediaPlayer2.forte' && exit 0; sleep 1; done; cat /tmp/forte.log >&2 || true; exit 1"
+              )
+              machine.screenshot("forte-${desktop}-launched")
+              machine.succeed(
+                  f"runuser -u ${vmUser} -- sh -lc '{env}; playerctl -p forte status >/tmp/forte-playerctl-status'"
+              )
+              machine.succeed("pkill -TERM -u ${vmUser} -f '[f]orte' || true")
+            '';
+          };
       in
       {
         packages = {
           default = forte;
           forte = forte;
           frontend = frontend;
+        };
+
+        apps = lib.optionalAttrs pkgs.stdenv.isLinux {
+          forte-vm-gnome = mkDesktopVmApp "gnome";
+          forte-vm-plasma = mkDesktopVmApp "plasma";
+        };
+
+        checks = lib.optionalAttrs pkgs.stdenv.isLinux {
+          forte-vm-smoke-gnome = mkDesktopVmSmoke "gnome";
+          forte-vm-smoke-plasma = mkDesktopVmSmoke "plasma";
         };
 
         devShells.default = pkgs.mkShell {


### PR DESCRIPTION
## Summary

Adds NixOS desktop VM validation for Forte across GNOME and KDE Plasma.

The flake now exposes interactive VM apps for local investigation and smoke-test checks that boot a desktop session, validate the installed desktop metadata and icons, launch Forte inside the logged-in user session, verify the MPRIS player appears on D-Bus, exercise `playerctl -p forte status`, and capture a screenshot artifact.

A new GitHub Actions workflow runs these checks weekly and on demand, with separate matrix jobs for GNOME and Plasma.

## Validation

- `nix build .#checks.x86_64-linux.forte-vm-smoke-plasma -L --no-write-lock-file`
- `nix build .#checks.x86_64-linux.forte-vm-smoke-gnome -L --no-write-lock-file`
- `nix flake check --no-build --no-write-lock-file --option eval-cache false`
- `git diff --check`

## Notes

The derivation-size work has been parked separately in `stash@{0}: wip derivation size plan` and is not part of this PR.
