### PR TITLE
Prove distro package installs

### DIFF
--- a/.github/workflows/vm-validation.yml
+++ b/.github/workflows/vm-validation.yml
@@ -49,3 +49,27 @@ jobs:
           name: vm-validation-${{ matrix.desktop }}
           path: vm-artifacts/${{ matrix.desktop }}
           if-no-files-found: ignore
+
+  distro-install:
+    name: ${{ matrix.distro }} package install
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - ubuntu
+          - arch
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Prove package install
+        run: scripts/prove-distro-install.sh "${{ matrix.distro }}"
+
+      - uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: distro-install-${{ matrix.distro }}
+          path: /tmp/forte-distro-proof
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Forte is a Linux desktop music player built with Go, Wails, Svelte, mpv, and SQL
 
 ## Installation
 
+### Linux Installer
+
+Install Forte on Ubuntu, Debian, or Arch:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/willfish/forte/master/scripts/install.sh | sh
+```
+
 ### Nix
 
 Build and run the current release from GitHub:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,3 +38,8 @@ tasks:
     summary: Seeds the database with fixture data for screenshots
     cmds:
       - go run -tags nocgo ./cmd/demo
+
+  prove:distro-install:
+    summary: Proves Ubuntu and Arch packages install and launch
+    cmds:
+      - scripts/prove-distro-install.sh {{.CLI_ARGS}}

--- a/build/linux/Taskfile.yml
+++ b/build/linux/Taskfile.yml
@@ -170,12 +170,23 @@ tasks:
     dir: build
     cmds:
       - mkdir -p {{.ROOT_DIR}}/build/linux/appimage
-      - wails3 generate .desktop -name "{{.APP_NAME}}" -exec "{{.EXEC}}" -icon "{{.ICON}}" -outputfile "{{.ROOT_DIR}}/build/linux/{{.APP_NAME}}.desktop" -categories "{{.CATEGORIES}}"
+      - |
+        wails3 generate .desktop \
+          -name "{{.DISPLAY_NAME}}" \
+          -exec "{{.EXEC}}" \
+          -icon "{{.ICON}}" \
+          -outputfile "{{.ROOT_DIR}}/build/linux/{{.APP_NAME}}.desktop" \
+          -categories "{{.CATEGORIES}}" \
+          -keywords "{{.KEYWORDS}}"
+        printf 'StartupWMClass=%s\n' "{{.STARTUP_WM_CLASS}}" >> "{{.ROOT_DIR}}/build/linux/{{.APP_NAME}}.desktop"
     vars:
       APP_NAME: '{{.APP_NAME}}'
+      DISPLAY_NAME: 'Forte'
       EXEC: '{{.APP_NAME}}'
-      ICON: '{{.APP_NAME}}'
-      CATEGORIES: 'Audio;Music;Player;'
+      ICON: 'io.github.willfish.forte'
+      CATEGORIES: 'AudioVideo;Audio;Music;Player;'
+      KEYWORDS: 'music;audio;player;radio;'
+      STARTUP_WM_CLASS: 'io.github.willfish.forte'
       OUTPUTFILE: '{{.ROOT_DIR}}/build/linux/{{.APP_NAME}}.desktop'
 
   run:

--- a/build/linux/nfpm/nfpm.yaml
+++ b/build/linux/nfpm/nfpm.yaml
@@ -11,37 +11,49 @@ section: "default"
 priority: "extra"
 maintainer: ${GIT_COMMITTER_NAME} <${GIT_COMMITTER_EMAIL}>
 description: "A forte application"
-vendor: "My Company"
-homepage: "https://wails.io"
+vendor: "willfish"
+homepage: "https://github.com/willfish/forte"
 license: "MIT"
 release: "1"
 
 contents:
   - src: "./bin/forte"
     dst: "/usr/local/bin/forte"
+  - src: "./build/logo.svg"
+    dst: "/usr/share/icons/hicolor/scalable/apps/io.github.willfish.forte.svg"
+  - src: "./build/logo.svg"
+    dst: "/usr/share/icons/hicolor/scalable/apps/forte.svg"
+  - src: "./build/tray-idle.svg"
+    dst: "/usr/share/icons/hicolor/scalable/apps/io.github.willfish.forte-tray-idle.svg"
+  - src: "./build/tray-playing.svg"
+    dst: "/usr/share/icons/hicolor/scalable/apps/io.github.willfish.forte-tray-playing.svg"
   - src: "./build/appicon.png"
     dst: "/usr/share/icons/hicolor/128x128/apps/io.github.willfish.forte.png"
   - src: "./build/linux/forte.desktop"
     dst: "/usr/share/applications/io.github.willfish.forte.desktop"
 
-# Default dependencies for Debian 12/Ubuntu 22.04+ with WebKit 4.1
+# Default dependencies for Debian/Ubuntu builds using GTK4 and WebKitGTK 6.
 depends:
-  - libgtk-3-0
-  - libwebkit2gtk-4.1-0
+  - libgtk-4-1
+  - libwebkitgtk-6.0-4
+  - libmpv2
+  - hicolor-icon-theme
 
-# Distribution-specific overrides for different package formats and WebKit versions
+# Distribution-specific overrides for different package formats.
 overrides:
-  # RPM packages for RHEL/CentOS/AlmaLinux/Rocky Linux (WebKit 4.0)
   rpm:
     depends:
-      - gtk3
-      - webkit2gtk4.1
+      - gtk4
+      - webkitgtk6.0
+      - mpv-libs
+      - hicolor-icon-theme
   
-  # Arch Linux packages (WebKit 4.1)  
   archlinux:
     depends:
-      - gtk3
-      - webkit2gtk-4.1
+      - gtk4
+      - webkitgtk-6.0
+      - mpv
+      - hicolor-icon-theme
 
 # scripts section to ensure desktop database is updated after install
 scripts:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env sh
+set -eu
+
+repo="${FORTE_REPO:-willfish/forte}"
+version="${FORTE_VERSION:-latest}"
+package_url="${FORTE_PACKAGE_URL:-}"
+
+log() {
+  printf '%s\n' "$*"
+}
+
+die() {
+  printf 'forte installer: %s\n' "$*" >&2
+  exit 1
+}
+
+as_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    die "this installer needs root privileges; rerun as root or install sudo"
+  fi
+}
+
+download() {
+  url="$1"
+  output="$2"
+
+  case "$url" in
+    file://*)
+      cp "${url#file://}" "$output"
+      ;;
+    *)
+      if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$output"
+      elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$output" "$url"
+      else
+        die "curl or wget is required to download Forte"
+      fi
+      ;;
+  esac
+}
+
+release_asset_url() {
+  asset="$1"
+
+  if [ "$version" = "latest" ]; then
+    printf 'https://github.com/%s/releases/latest/download/%s\n' "$repo" "$asset"
+  else
+    printf 'https://github.com/%s/releases/download/%s/%s\n' "$repo" "$version" "$asset"
+  fi
+}
+
+install_debian() {
+  package="$1"
+
+  export DEBIAN_FRONTEND=noninteractive
+  as_root apt-get update
+  as_root apt-get install -y "$package"
+}
+
+install_arch() {
+  package="$1"
+
+  as_root pacman -Syu --noconfirm
+  as_root pacman -U --noconfirm "$package"
+}
+
+detect_distro() {
+  if [ -r /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    distro_id="${ID:-}"
+    distro_like="${ID_LIKE:-}"
+  else
+    distro_id=""
+    distro_like=""
+  fi
+
+  case " $distro_id $distro_like " in
+    *" debian "*|*" ubuntu "*)
+      printf 'debian\n'
+      ;;
+    *" arch "*)
+      printf 'arch\n'
+      ;;
+    *)
+      die "unsupported Linux distribution; expected Debian, Ubuntu, or Arch"
+      ;;
+  esac
+}
+
+distro="$(detect_distro)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+case "$distro" in
+  debian)
+    asset="forte.deb"
+    package="$tmpdir/$asset"
+    ;;
+  arch)
+    asset="forte.pkg.tar.zst"
+    package="$tmpdir/$asset"
+    ;;
+  *)
+    die "unsupported distro: $distro"
+    ;;
+esac
+
+if [ -z "$package_url" ]; then
+  package_url="$(release_asset_url "$asset")"
+fi
+
+log "Downloading Forte from $package_url"
+download "$package_url" "$package"
+
+case "$distro" in
+  debian)
+    log "Installing Forte with apt"
+    install_debian "$package"
+    ;;
+  arch)
+    log "Installing Forte with pacman"
+    install_arch "$package"
+    ;;
+esac
+
+log "Forte installed successfully"

--- a/scripts/prove-distro-install.sh
+++ b/scripts/prove-distro-install.sh
@@ -4,14 +4,16 @@ set -euo pipefail
 artifact_dir="${ARTIFACT_DIR:-/tmp/forte-distro-proof}"
 host_uid="$(id -u)"
 host_gid="$(id -g)"
+repo_root="$(git rev-parse --show-toplevel)"
 
 usage() {
   cat <<'USAGE'
 Usage: scripts/prove-distro-install.sh [ubuntu|arch|all]
 
-Builds Forte inside fresh distro containers, installs the resulting package
-inside fresh containers, validates desktop integration, and proves the app can
-launch under Xvfb without relying on Nix-linked host artifacts.
+Builds Forte packages inside fresh distro containers, installs them through the
+same installer entrypoint users run, validates desktop integration, and proves
+the installed app can launch under Xvfb without relying on Nix-linked host
+artifacts.
 USAGE
 }
 
@@ -19,7 +21,7 @@ prepare_source() {
   local source_dir
   source_dir="$(mktemp -d)"
 
-  git ls-files -z | tar --null -T - -cf - | tar -x -C "$source_dir"
+  git -C "$repo_root" ls-files -z | tar -C "$repo_root" --null -T - -cf - | tar -x -C "$source_dir"
   printf '%s\n' "$source_dir"
 }
 
@@ -80,13 +82,15 @@ EOF
 prove_ubuntu() {
   docker run --rm --privileged -i \
     -v "$artifact_dir:/artifacts:ro" \
+    -v "$repo_root/scripts/install.sh:/install-forte.sh:ro" \
     ubuntu:latest \
     bash -s <<'EOF'
 set -euxo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y /artifacts/forte-ubuntu.deb desktop-file-utils xvfb dbus-x11 procps
+apt-get install -y ca-certificates desktop-file-utils xvfb dbus-x11 procps
+FORTE_PACKAGE_URL=file:///artifacts/forte-ubuntu.deb sh /install-forte.sh
 
 command -v forte
 desktop-file-validate /usr/share/applications/io.github.willfish.forte.desktop
@@ -95,12 +99,20 @@ test -e /usr/share/icons/hicolor/scalable/apps/io.github.willfish.forte-tray-idl
 ldd /usr/local/bin/forte | tee /tmp/forte-ldd.txt >/dev/null
 ! grep -q /nix/store /tmp/forte-ldd.txt
 
+xvfb-run -a dbus-run-session sh -s <<'LAUNCH'
+set -eu
+env WEBKIT_DISABLE_DMABUF_RENDERER=1 forte >/tmp/forte.log 2>&1 &
+forte_pid="$!"
+sleep 10
+kill -0 "$forte_pid"
+kill "$forte_pid"
 set +e
-timeout 15s xvfb-run -a dbus-run-session env WEBKIT_DISABLE_DMABUF_RENDERER=1 forte >/tmp/forte.log 2>&1
-status=$?
+wait "$forte_pid"
+status="$?"
 set -e
-cat /tmp/forte.log
-test "$status" -eq 124
+test "$status" -eq 0 || test "$status" -eq 143
+LAUNCH
+sed -n '1,160p' /tmp/forte.log
 EOF
 }
 
@@ -151,13 +163,14 @@ EOF
 prove_arch() {
   docker run --rm --privileged -i \
     -v "$artifact_dir:/artifacts:ro" \
+    -v "$repo_root/scripts/install.sh:/install-forte.sh:ro" \
     archlinux:latest \
     bash -s <<'EOF'
 set -euxo pipefail
 
 pacman -Syu --noconfirm
-pacman -U --noconfirm /artifacts/forte-arch.pkg.tar.zst
-pacman -S --noconfirm --needed desktop-file-utils xorg-server-xvfb xorg-xauth dbus procps-ng
+pacman -S --noconfirm --needed ca-certificates desktop-file-utils xorg-server-xvfb xorg-xauth dbus procps-ng
+FORTE_PACKAGE_URL=file:///artifacts/forte-arch.pkg.tar.zst sh /install-forte.sh
 
 command -v forte
 desktop-file-validate /usr/share/applications/io.github.willfish.forte.desktop
@@ -166,12 +179,20 @@ test -e /usr/share/icons/hicolor/scalable/apps/io.github.willfish.forte-tray-idl
 ldd /usr/local/bin/forte | tee /tmp/forte-ldd.txt >/dev/null
 ! grep -q /nix/store /tmp/forte-ldd.txt
 
+xvfb-run -a dbus-run-session sh -s <<'LAUNCH'
+set -eu
+env WEBKIT_DISABLE_DMABUF_RENDERER=1 forte >/tmp/forte.log 2>&1 &
+forte_pid="$!"
+sleep 10
+kill -0 "$forte_pid"
+kill "$forte_pid"
 set +e
-timeout 15s xvfb-run -a dbus-run-session env WEBKIT_DISABLE_DMABUF_RENDERER=1 forte >/tmp/forte.log 2>&1
-status=$?
+wait "$forte_pid"
+status="$?"
 set -e
-cat /tmp/forte.log
-test "$status" -eq 124
+test "$status" -eq 0 || test "$status" -eq 143
+LAUNCH
+sed -n '1,160p' /tmp/forte.log
 EOF
 }
 

--- a/scripts/prove-distro-install.sh
+++ b/scripts/prove-distro-install.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact_dir="${ARTIFACT_DIR:-/tmp/forte-distro-proof}"
+host_uid="$(id -u)"
+host_gid="$(id -g)"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/prove-distro-install.sh [ubuntu|arch|all]
+
+Builds Forte inside fresh distro containers, installs the resulting package
+inside fresh containers, validates desktop integration, and proves the app can
+launch under Xvfb without relying on Nix-linked host artifacts.
+USAGE
+}
+
+prepare_source() {
+  local source_dir
+  source_dir="$(mktemp -d)"
+
+  git ls-files -z | tar --null -T - -cf - | tar -x -C "$source_dir"
+  printf '%s\n' "$source_dir"
+}
+
+cleanup_source() {
+  local source_dir="$1"
+
+  docker run --rm -v "$source_dir:/src" ubuntu:latest \
+    bash -lc 'rm -rf /src/* /src/.[!.]* /src/..?* 2>/dev/null || true' >/dev/null
+  rmdir "$source_dir"
+}
+
+build_ubuntu() {
+  local source_dir="$1"
+
+  docker run --rm -i \
+    -e HOST_UID="$host_uid" \
+    -e HOST_GID="$host_gid" \
+    -v "$source_dir:/src" \
+    -v "$artifact_dir:/artifacts" \
+    -w /src \
+    ubuntu:latest \
+    bash -s <<'EOF'
+set -euxo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y \
+  build-essential \
+  ca-certificates \
+  git \
+  golang-go \
+  libgtk-4-dev \
+  libmpv-dev \
+  libwebkitgtk-6.0-dev \
+  nodejs \
+  npm \
+  pkg-config
+
+export PATH="$HOME/go/bin:$PATH"
+go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.95
+go install github.com/go-task/task/v3/cmd/task@v3.51.1
+
+export VERSION=0.1.0-test
+export GIT_COMMITTER_NAME=Forte
+export GIT_COMMITTER_EMAIL=forte@example.invalid
+task linux:create:deb
+
+ldd bin/forte | tee /tmp/forte-ldd.txt
+! grep -q /nix/store /tmp/forte-ldd.txt
+test -f bin/forte.deb
+
+install -m644 bin/forte.deb /artifacts/forte-ubuntu.deb
+chown "$HOST_UID:$HOST_GID" /artifacts/forte-ubuntu.deb
+chown -R "$HOST_UID:$HOST_GID" /src
+EOF
+}
+
+prove_ubuntu() {
+  docker run --rm --privileged -i \
+    -v "$artifact_dir:/artifacts:ro" \
+    ubuntu:latest \
+    bash -s <<'EOF'
+set -euxo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y /artifacts/forte-ubuntu.deb desktop-file-utils xvfb dbus-x11 procps
+
+command -v forte
+desktop-file-validate /usr/share/applications/io.github.willfish.forte.desktop
+test -e /usr/share/icons/hicolor/scalable/apps/io.github.willfish.forte.svg
+test -e /usr/share/icons/hicolor/scalable/apps/io.github.willfish.forte-tray-idle.svg
+ldd /usr/local/bin/forte | tee /tmp/forte-ldd.txt >/dev/null
+! grep -q /nix/store /tmp/forte-ldd.txt
+
+set +e
+timeout 15s xvfb-run -a dbus-run-session env WEBKIT_DISABLE_DMABUF_RENDERER=1 forte >/tmp/forte.log 2>&1
+status=$?
+set -e
+cat /tmp/forte.log
+test "$status" -eq 124
+EOF
+}
+
+build_arch() {
+  local source_dir="$1"
+
+  docker run --rm -i \
+    -e HOST_UID="$host_uid" \
+    -e HOST_GID="$host_gid" \
+    -v "$source_dir:/src" \
+    -v "$artifact_dir:/artifacts" \
+    -w /src \
+    archlinux:latest \
+    bash -s <<'EOF'
+set -euxo pipefail
+
+pacman -Syu --noconfirm
+pacman -S --noconfirm --needed \
+  base-devel \
+  git \
+  go \
+  gtk4 \
+  mpv \
+  nodejs \
+  npm \
+  pkgconf \
+  webkitgtk-6.0
+
+export PATH="$HOME/go/bin:$PATH"
+go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.95
+go install github.com/go-task/task/v3/cmd/task@v3.51.1
+
+export VERSION=0.1.0-test
+export GIT_COMMITTER_NAME=Forte
+export GIT_COMMITTER_EMAIL=forte@example.invalid
+task linux:create:aur
+
+ldd bin/forte | tee /tmp/forte-ldd.txt
+! grep -q /nix/store /tmp/forte-ldd.txt
+test -f bin/forte.pkg.tar.zst
+
+install -m644 bin/forte.pkg.tar.zst /artifacts/forte-arch.pkg.tar.zst
+chown "$HOST_UID:$HOST_GID" /artifacts/forte-arch.pkg.tar.zst
+chown -R "$HOST_UID:$HOST_GID" /src
+EOF
+}
+
+prove_arch() {
+  docker run --rm --privileged -i \
+    -v "$artifact_dir:/artifacts:ro" \
+    archlinux:latest \
+    bash -s <<'EOF'
+set -euxo pipefail
+
+pacman -Syu --noconfirm
+pacman -U --noconfirm /artifacts/forte-arch.pkg.tar.zst
+pacman -S --noconfirm --needed desktop-file-utils xorg-server-xvfb xorg-xauth dbus procps-ng
+
+command -v forte
+desktop-file-validate /usr/share/applications/io.github.willfish.forte.desktop
+test -e /usr/share/icons/hicolor/scalable/apps/io.github.willfish.forte.svg
+test -e /usr/share/icons/hicolor/scalable/apps/io.github.willfish.forte-tray-idle.svg
+ldd /usr/local/bin/forte | tee /tmp/forte-ldd.txt >/dev/null
+! grep -q /nix/store /tmp/forte-ldd.txt
+
+set +e
+timeout 15s xvfb-run -a dbus-run-session env WEBKIT_DISABLE_DMABUF_RENDERER=1 forte >/tmp/forte.log 2>&1
+status=$?
+set -e
+cat /tmp/forte.log
+test "$status" -eq 124
+EOF
+}
+
+prove_distro() {
+  local distro="$1"
+  local source_dir
+
+  source_dir="$(prepare_source)"
+  trap 'cleanup_source "$source_dir"' RETURN
+  mkdir -p "$artifact_dir"
+
+  case "$distro" in
+    ubuntu)
+      build_ubuntu "$source_dir"
+      prove_ubuntu
+      ;;
+    arch)
+      build_arch "$source_dir"
+      prove_arch
+      ;;
+    *)
+      printf 'Unknown distro: %s\n' "$distro" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+
+  trap - RETURN
+  cleanup_source "$source_dir"
+}
+
+target="${1:-all}"
+
+case "$target" in
+  ubuntu|arch)
+    prove_distro "$target"
+    ;;
+  all)
+    prove_distro ubuntu
+    prove_distro arch
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    printf 'Unknown target: %s\n' "$target" >&2
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Adds a hosted-style Linux installer at `scripts/install.sh` for Ubuntu/Debian and Arch.
- Updates the distro proof so Forte itself is installed only through that installer, using `FORTE_PACKAGE_URL` to point at the freshly built package artifact.
- Keeps extra container packages limited to build/validation harness tools such as Docker build dependencies, `desktop-file-validate`, Xvfb, D-Bus, and process checks.
- Wires the proof into the weekly/manual VM validation workflow as an Ubuntu and Arch matrix.
- Fixes non-Nix package metadata for GTK4/WebKitGTK 6/mpv runtime dependencies, launcher/tray icons, app name, categories, keywords, and startup WM class.

## Validation

- `scripts/prove-distro-install.sh ubuntu`
- `scripts/prove-distro-install.sh arch`
- `sh -n scripts/install.sh`
- `bash -n scripts/prove-distro-install.sh`
- `git diff --check`
- `task linux:generate:dotdesktop`
