### PR TITLE
BAU: Improve radio station artwork fallbacks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
           version = "0.1.0";
           src = ./.;
           go = pkgs.go_1_25;
-          vendorHash = "sha256-SX43UbVi1YEC323j/rvE6OgjA8G/RfaXoNACVhL7B44=";
+          vendorHash = "sha256-xsXFHzJMAMCvSg47FL3HV7uHsb1ttuFdxBTmywZHDJg=";
           modBuildPhase = ''
             runHook preBuild
 

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
           version = "0.1.0";
           src = ./.;
           go = pkgs.go_1_25;
-          vendorHash = "sha256-xsXFHzJMAMCvSg47FL3HV7uHsb1ttuFdxBTmywZHDJg=";
+          vendorHash = "sha256-0pJQ5R54CwSn+f1wSt3Y5zPzV2A5WA2EC5flOAdhBd0=";
           modBuildPhase = ''
             runHook preBuild
 
@@ -101,6 +101,12 @@
                 "$out/share/icons/hicolor/''${size}x''${size}/apps/io.github.willfish.forte-tray-idle.png"
               install -Dm644 "build/tray-playing-''${size}.png" \
                 "$out/share/icons/hicolor/''${size}x''${size}/apps/io.github.willfish.forte-tray-playing.png"
+            done
+            for theme in green-dark green-light blue-dark blue-light financial-times-dark financial-times-light; do
+              install -Dm644 "build/tray-''${theme}-idle-32.png" \
+                "$out/share/icons/hicolor/32x32/apps/io.github.willfish.forte-tray-''${theme}-idle.png"
+              install -Dm644 "build/tray-''${theme}-playing-32.png" \
+                "$out/share/icons/hicolor/32x32/apps/io.github.willfish.forte-tray-''${theme}-playing.png"
             done
             install -Dm644 build/appicon.png $out/share/pixmaps/forte.png
             install -Dm644 build/linux/forte.desktop $out/share/applications/io.github.willfish.forte.desktop
@@ -228,6 +234,7 @@
               machine.succeed("desktop-file-validate /run/current-system/sw/share/applications/io.github.willfish.forte.desktop")
               machine.succeed("test -e /run/current-system/sw/share/icons/hicolor/scalable/apps/io.github.willfish.forte.svg")
               machine.succeed("test -e /run/current-system/sw/share/icons/hicolor/scalable/apps/io.github.willfish.forte-tray-idle.svg")
+              machine.succeed("test -e /run/current-system/sw/share/icons/hicolor/32x32/apps/io.github.willfish.forte-tray-financial-times-light-playing.png")
 
               base_env = "XDG_RUNTIME_DIR=/run/user/1000 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus"
               machine.succeed(

--- a/frontend/src/RadioView.svelte
+++ b/frontend/src/RadioView.svelte
@@ -155,6 +155,18 @@
     return proxiedIcons[url] || '';
   }
 
+  function stationInitials(name: string): string {
+    const cleaned = name
+      .replace(/\([^)]*\)/g, ' ')
+      .replace(/[^a-zA-Z0-9]+/g, ' ')
+      .trim();
+    if (!cleaned) return 'R';
+    const words = cleaned.split(/\s+/).filter(word => !/^\d+$/.test(word));
+    const source = words.length > 0 ? words : cleaned.split(/\s+/);
+    if (source.length === 1) return source[0].slice(0, 2).toUpperCase();
+    return `${source[0][0]}${source[1][0]}`.toUpperCase();
+  }
+
   const isSearchActive = $derived(searchQuery.trim().length > 0);
   const hasFilter = $derived(
     activeTags.length > 0 || activeSource !== 'all' ||
@@ -838,9 +850,7 @@
               <img class="station-icon" src={resolvedIcon(station.favicon)} alt="" />
             {:else}
               <div class="station-icon placeholder">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
-                  <path d="M3.24 6.15C2.51 6.43 2 7.17 2 8v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8c0-.83-.49-1.57-1.24-1.85L12 2 3.24 6.15zM12 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z"/>
-                </svg>
+                <span>{stationInitials(station.name)}</span>
               </div>
             {/if}
             <div class="station-info">
@@ -922,9 +932,7 @@
               <img class="station-icon" src={resolvedIcon(fav.faviconUrl)} alt="" />
             {:else}
               <div class="station-icon placeholder">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
-                  <path d="M3.24 6.15C2.51 6.43 2 7.17 2 8v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8c0-.83-.49-1.57-1.24-1.85L12 2 3.24 6.15zM12 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z"/>
-                </svg>
+                <span>{stationInitials(fav.name)}</span>
               </div>
             {/if}
             <div class="station-info">
@@ -1023,9 +1031,7 @@
               <img class="station-icon" src={resolvedIcon(station.faviconUrl)} alt="" />
             {:else}
               <div class="station-icon placeholder">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
-                  <path d="M3.24 6.15C2.51 6.43 2 7.17 2 8v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8c0-.83-.49-1.57-1.24-1.85L12 2 3.24 6.15zM12 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z"/>
-                </svg>
+                <span>{stationInitials(station.name)}</span>
               </div>
             {/if}
             <div class="station-info">
@@ -1097,9 +1103,7 @@
               <img class="station-icon" src={resolvedIcon(item.faviconUrl)} alt="" />
             {:else}
               <div class="station-icon placeholder">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
-                  <path d="M3.24 6.15C2.51 6.43 2 7.17 2 8v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8c0-.83-.49-1.57-1.24-1.85L12 2 3.24 6.15zM12 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z"/>
-                </svg>
+                <span>{stationInitials(item.name)}</span>
               </div>
             {/if}
             <div class="station-info">
@@ -1427,8 +1431,13 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--bg-hover);
-    color: var(--text-secondary);
+    background:
+      linear-gradient(135deg, color-mix(in srgb, var(--accent) 18%, var(--bg-elevated)) 0%, var(--bg-hover) 100%);
+    color: var(--accent);
+    border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--border));
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0;
   }
 
   .station-info {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/wailsapp/wails/v3 v3.0.0-alpha.95
 	go.senan.xyz/taglib v0.12.0
+	golang.org/x/net v0.53.0
 	modernc.org/sqlite v1.50.1
 )
 
@@ -50,7 +51,6 @@ require (
 	github.com/wailsapp/wails/webview2 v1.0.24 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
-	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -940,18 +940,13 @@ var somafmClient = radio.NewSomaFMClient()
 
 func stationsToJSON(stations []radio.Station) []RadioStationJSON {
 	result := make([]RadioStationJSON, len(stations))
+	favicons := resolveStationFavicons(stations)
 	for i, s := range stations {
-		favicon := s.Favicon
-		if favicon == "" {
-			if art := somafmClient.LookupArtwork(s.Homepage); art != "" {
-				favicon = art
-			}
-		}
 		result[i] = RadioStationJSON{
 			UUID:      s.UUID,
 			Name:      s.Name,
 			StreamURL: normalizeRadioStreamURL(s.StreamURL),
-			Favicon:   favicon,
+			Favicon:   favicons[i],
 			Country:   s.Country,
 			Tags:      s.Tags,
 			Bitrate:   s.Bitrate,
@@ -961,6 +956,24 @@ func stationsToJSON(stations []radio.Station) []RadioStationJSON {
 		}
 	}
 	return result
+}
+
+func resolveStationFavicons(stations []radio.Station) []string {
+	favicons := make([]string, len(stations))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 8)
+	for i, station := range stations {
+		i, station := i, station
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			favicons[i] = resolveRadioArtwork(station.Favicon, station.Homepage)
+		}()
+	}
+	wg.Wait()
+	return favicons
 }
 
 func normalizeRadioStreamURL(streamURL string) string {

--- a/patches/wails-status-notifier-icon-name.patch
+++ b/patches/wails-status-notifier-icon-name.patch
@@ -29,7 +29,7 @@
  
  		"IconName": {
 -			Value:    "",
-+			Value:    "io.github.willfish.forte-tray-idle",
++			Value:    "",
  			Writable: false,
  			Emit:     prop.EmitTrue,
  			Callback: nil,

--- a/radio_artwork.go
+++ b/radio_artwork.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+var radioArtworkClient = &http.Client{Timeout: 2 * time.Second}
+
+var radioArtworkCache struct {
+	sync.Mutex
+	m map[string]string
+}
+
+func resolveRadioArtwork(favicon, homepage string) string {
+	if isHTTPURL(favicon) {
+		return strings.TrimSpace(favicon)
+	}
+	if art := somafmClient.LookupArtwork(homepage); art != "" {
+		return art
+	}
+	if !isHTTPURL(homepage) {
+		return ""
+	}
+
+	key := strings.TrimSpace(homepage)
+	radioArtworkCache.Lock()
+	if radioArtworkCache.m == nil {
+		radioArtworkCache.m = make(map[string]string)
+	}
+	if cached, ok := radioArtworkCache.m[key]; ok {
+		radioArtworkCache.Unlock()
+		return cached
+	}
+	radioArtworkCache.Unlock()
+
+	resolved := resolveArtworkFromHomepage(key)
+
+	radioArtworkCache.Lock()
+	radioArtworkCache.m[key] = resolved
+	radioArtworkCache.Unlock()
+	return resolved
+}
+
+func resolveArtworkFromHomepage(homepage string) string {
+	req, err := http.NewRequest(http.MethodGet, homepage, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("User-Agent", "Forte/0.1 radio artwork resolver")
+
+	resp, err := radioArtworkClient.Do(req)
+	if err != nil {
+		return fallbackFaviconURL(homepage)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fallbackFaviconURL(homepage)
+	}
+
+	base := resp.Request.URL
+	doc, err := html.Parse(io.LimitReader(resp.Body, 512*1024))
+	if err != nil {
+		return fallbackFaviconURL(homepage)
+	}
+	if art := firstHomepageArtwork(doc, base); art != "" {
+		return art
+	}
+	return fallbackFaviconURL(homepage)
+}
+
+func firstHomepageArtwork(n *html.Node, base *url.URL) string {
+	var icons []string
+	var walk func(*html.Node) string
+	walk = func(node *html.Node) string {
+		if node.Type == html.ElementNode {
+			switch strings.ToLower(node.Data) {
+			case "meta":
+				if isImageMeta(node) {
+					if v := attr(node, "content"); v != "" {
+						if resolved := resolveURL(base, v); resolved != "" {
+							return resolved
+						}
+					}
+				}
+			case "link":
+				if isIconLink(node) {
+					if v := attr(node, "href"); v != "" {
+						if resolved := resolveURL(base, v); resolved != "" {
+							icons = append(icons, resolved)
+						}
+					}
+				}
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			if resolved := walk(child); resolved != "" {
+				return resolved
+			}
+		}
+		return ""
+	}
+	if resolved := walk(n); resolved != "" {
+		return resolved
+	}
+	if len(icons) > 0 {
+		return icons[0]
+	}
+	return ""
+}
+
+func isImageMeta(n *html.Node) bool {
+	property := strings.ToLower(attr(n, "property"))
+	name := strings.ToLower(attr(n, "name"))
+	return property == "og:image" ||
+		property == "og:image:url" ||
+		name == "twitter:image" ||
+		name == "twitter:image:src"
+}
+
+func isIconLink(n *html.Node) bool {
+	rel := strings.ToLower(attr(n, "rel"))
+	if rel == "" {
+		return false
+	}
+	for _, part := range strings.Fields(rel) {
+		if part == "icon" || part == "apple-touch-icon" || part == "apple-touch-icon-precomposed" {
+			return true
+		}
+	}
+	return strings.Contains(rel, " icon")
+}
+
+func attr(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if strings.EqualFold(a.Key, key) {
+			return strings.TrimSpace(a.Val)
+		}
+	}
+	return ""
+}
+
+func resolveURL(base *url.URL, value string) string {
+	if value == "" || base == nil {
+		return ""
+	}
+	u, err := url.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return ""
+	}
+	resolved := base.ResolveReference(u)
+	if resolved.Scheme != "http" && resolved.Scheme != "https" {
+		return ""
+	}
+	return resolved.String()
+}
+
+func fallbackFaviconURL(homepage string) string {
+	u, err := url.Parse(homepage)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return ""
+	}
+	u.Path = "/favicon.ico"
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+func isHTTPURL(value string) bool {
+	u, err := url.Parse(strings.TrimSpace(value))
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+}

--- a/radio_artwork_test.go
+++ b/radio_artwork_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func resetRadioArtworkTestState(t *testing.T) {
+	t.Helper()
+	oldClient := radioArtworkClient
+	radioArtworkClient = &http.Client{Timeout: time.Second}
+	radioArtworkCache.Lock()
+	radioArtworkCache.m = nil
+	radioArtworkCache.Unlock()
+	t.Cleanup(func() {
+		radioArtworkClient = oldClient
+		radioArtworkCache.Lock()
+		radioArtworkCache.m = nil
+		radioArtworkCache.Unlock()
+	})
+}
+
+func TestResolveRadioArtworkKeepsExistingFavicon(t *testing.T) {
+	resetRadioArtworkTestState(t)
+
+	got := resolveRadioArtwork("https://example.com/icon.png", "https://example.com")
+	if got != "https://example.com/icon.png" {
+		t.Fatalf("resolveRadioArtwork = %q, want existing favicon", got)
+	}
+}
+
+func TestResolveRadioArtworkUsesHomepageMetadata(t *testing.T) {
+	resetRadioArtworkTestState(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><head><meta property="og:image" content="/station.png"></head></html>`))
+	}))
+	defer server.Close()
+
+	got := resolveRadioArtwork("", server.URL)
+	want := server.URL + "/station.png"
+	if got != want {
+		t.Fatalf("resolveRadioArtwork = %q, want %q", got, want)
+	}
+}
+
+func TestResolveRadioArtworkUsesIconWhenMetadataMissing(t *testing.T) {
+	resetRadioArtworkTestState(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><head><link rel="apple-touch-icon" href="touch.png"></head></html>`))
+	}))
+	defer server.Close()
+
+	got := resolveRadioArtwork("", server.URL+"/listen")
+	want := server.URL + "/touch.png"
+	if got != want {
+		t.Fatalf("resolveRadioArtwork = %q, want %q", got, want)
+	}
+}
+
+func TestResolveRadioArtworkFallsBackToFaviconPath(t *testing.T) {
+	resetRadioArtworkTestState(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><head><title>Station</title></head></html>`))
+	}))
+	defer server.Close()
+
+	got := resolveRadioArtwork("", server.URL+"/radio")
+	want := server.URL + "/favicon.ico"
+	if got != want {
+		t.Fatalf("resolveRadioArtwork = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What changed

- Resolves missing radio artwork from station homepage metadata, icon links, and `/favicon.ico` when Radio Browser does not provide a usable favicon.
- Caches homepage artwork resolution in memory and resolves station artwork concurrently with a small limit.
- Replaces the generic missing-artwork glyph with a theme-aware initials tile for stations that still have no usable image.
- Installs the theme-specific tray PNG assets in the Nix derivation for green, blue, and Financial Times light/dark variants.
- Stops the Nix StatusNotifier patch from pinning `IconName` to the generic tray icon, so tray hosts can reflect runtime theme/playback icon updates.

## Impact

Radio lists should show fewer generic placeholders, especially for stations where Radio Browser has no favicon. Stations that still cannot provide artwork now have a cleaner fallback that reflects the station name and selected theme.

The Nix-built app now ships the themed tray assets and no longer forces the generic tray icon name, so the installed derivation can follow theme changes in the tray as well as in the app UI.

## Verification

- `go test ./...`
- `npm run check` from `frontend/`
- `npm run test:e2e -- tests/radio.spec.ts tests/search.spec.ts tests/settings.spec.ts` - 38 passed
- `npm run build`
- `nix build .#forte`
- `find result/share/icons -iname *forte*tray* -printf %P\n | sort` confirmed themed tray PNG assets are installed\n