### PR TITLE
BAU: Add macOS build validation path

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,82 @@
+name: macOS
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.10"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install system dependencies
+        run: |
+          brew update
+          brew install ffmpeg mpv pkg-config
+          mkdir -p "$RUNNER_TEMP/lib"
+          mpv_lib="$(
+            find "$(brew --prefix mpv)/lib" "$(brew --prefix)/lib" \
+              -maxdepth 1 \
+              \( -name 'libmpv.dylib' -o -name 'libmpv.*.dylib' \) \
+              -print \
+              | head -n 1
+          )"
+          test -n "$mpv_lib"
+          ln -sf "$mpv_lib" "$RUNNER_TEMP/lib/libmpv.dylib"
+          printf 'PATH=%s/opt/ffmpeg/bin:%s/bin:%s\n' "$(brew --prefix)" "$(brew --prefix)" "$PATH" >> "$GITHUB_ENV"
+          printf 'DYLD_LIBRARY_PATH=%s/lib:%s/lib:%s\n' "$RUNNER_TEMP" "$(brew --prefix mpv)" "${DYLD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+          printf 'PKG_CONFIG_PATH=%s/lib/pkgconfig:%s\n' "$(brew --prefix mpv)" "${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
+
+      - name: Verify system dependencies
+        run: |
+          test -f "$RUNNER_TEMP/lib/libmpv.dylib"
+          ffmpeg -hide_banner -encoders | grep -q vorbis
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run check
+          npm run build
+
+      - name: Run Go tests
+        run: go test -tags nocgo ./...
+
+      - name: Build macOS binary
+        run: |
+          mkdir -p bin
+          go build -tags production,nocgo -trimpath -buildvcs=false -ldflags="-w -s" -o bin/forte
+          test -f bin/forte
+          file bin/forte | grep -q "Mach-O.*arm64"
+
+  nix:
+    name: Nix package
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: DeterminateSystems/nix-installer-action@v20
+
+      - name: Build Darwin package
+        run: nix build .#packages.aarch64-darwin.default -L --no-write-lock-file

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,11 @@
           version = "0.1.0";
           src = ./.;
           go = pkgs.go_1_25;
-          vendorHash = "sha256-0pJQ5R54CwSn+f1wSt3Y5zPzV2A5WA2EC5flOAdhBd0=";
+          vendorHash =
+            if pkgs.stdenv.isDarwin then
+              "sha256-66N2XYd0rMUmtZkkScLL/KtpfyR/cPXIUOJ4iPbWHEs="
+            else
+              "sha256-0pJQ5R54CwSn+f1wSt3Y5zPzV2A5WA2EC5flOAdhBd0=";
           modBuildPhase = ''
             runHook preBuild
 
@@ -55,27 +59,33 @@
               goModVendorFlags+=(-v)
             fi
             go mod vendor "''${goModVendorFlags[@]}"
-            patch -p1 -d vendor/github.com/wailsapp/wails/v3 < ${./patches/wails-status-notifier-icon-name.patch}
+            ${lib.optionalString pkgs.stdenv.isLinux ''
+              patch -p1 -d vendor/github.com/wailsapp/wails/v3 < ${./patches/wails-status-notifier-icon-name.patch}
+            ''}
 
             mkdir -p vendor
             runHook postBuild
           '';
-          tags = [ "production" "nocgo" "gtk4" ];
+          tags = [ "production" "nocgo" ] ++ lib.optionals pkgs.stdenv.isLinux [ "gtk4" ];
           ldflags = [ "-s" "-w" ];
           subPackages = [ "." ];
           doCheck = false; # Tests need libmpv.so at runtime
 
           nativeBuildInputs = with pkgs; [
             pkg-config
+          ] ++ lib.optionals pkgs.stdenv.isLinux [
             wrapGAppsHook4
             imagemagick
             desktop-file-utils
           ];
 
           buildInputs = with pkgs; [
+            mpv
+          ] ++ lib.optionals pkgs.stdenv.isLinux [
             gtk4
             webkitgtk_6_0
-            mpv
+          ] ++ lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.apple-sdk_14
           ];
 
           preBuild = ''
@@ -84,7 +94,7 @@
             cp -r ${frontend}/* frontend/dist/
           '';
 
-          postInstall = ''
+          postInstall = lib.optionalString pkgs.stdenv.isLinux ''
             for size in 16 24 32 48 64 128 256 512; do
               install -d "$out/share/icons/hicolor/''${size}x''${size}/apps"
               magick build/appicon.png -resize "''${size}x''${size}" \
@@ -113,7 +123,7 @@
             desktop-file-validate $out/share/applications/io.github.willfish.forte.desktop
           '';
 
-          preFixup = ''
+          preFixup = lib.optionalString pkgs.stdenv.isLinux ''
             gappsWrapperArgs+=(
               --prefix LD_LIBRARY_PATH : "${pkgs.lib.makeLibraryPath [ pkgs.mpv ]}"
             )
@@ -124,7 +134,7 @@
             homepage = "https://github.com/willfish/forte";
             license = licenses.gpl3Only;
             maintainers = [ ];
-            platforms = platforms.linux;
+            platforms = platforms.linux ++ platforms.darwin;
             mainProgram = "forte";
           };
         };
@@ -284,22 +294,26 @@
           buildInputs = with pkgs; [
             go_1_25
             nodejs_22
-            playwright-driver
             go-task
             golangci-lint
             govulncheck
             ffmpeg
             pkg-config
+            mpv
+          ] ++ lib.optionals pkgs.stdenv.isLinux [
+            playwright-driver
             gtk3
             webkitgtk_4_1
             gtk4
             webkitgtk_6_0
-            mpv
+          ] ++ lib.optionals pkgs.stdenv.isDarwin [
+            apple-sdk_14
           ];
 
           shellHook = ''
             export GOPATH="$PWD/.go"
             export PATH="$GOPATH/bin:$PATH"
+          '' + lib.optionalString pkgs.stdenv.isLinux ''
             export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [ pkgs.mpv ]}:$LD_LIBRARY_PATH"
             export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
             export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1

--- a/internal/library/scanner_test.go
+++ b/internal/library/scanner_test.go
@@ -117,7 +117,7 @@ func TestScanRealAudioFilesAcrossSupportedFormats(t *testing.T) {
 	}{
 		{"01 Forte FLAC.flac", "FLAC", "flac"},
 		{"02 Forte MP3.mp3", "MP3", "libmp3lame"},
-		{"03 Forte OGG.ogg", "OGG", "libvorbis"},
+		{"03 Forte OGG.ogg", "OGG", "vorbis"},
 		{"04 Forte M4A.m4a", "M4A", "aac"},
 		{"05 Forte WAV.wav", "WAV", "pcm_s16le"},
 	}
@@ -280,6 +280,9 @@ func generateTaggedAudio(t *testing.T, ffmpeg, path, codec, title, artist, album
 	}
 	if codec == "aac" {
 		args = append(args, "-b:a", "96k")
+	}
+	if codec == "vorbis" {
+		args = append(args, "-ac", "2", "-strict", "-2")
 	}
 	args = append(args, path)
 	if out, err := exec.Command(ffmpeg, args...).CombinedOutput(); err != nil {

--- a/internal/system/mpris_linux.go
+++ b/internal/system/mpris_linux.go
@@ -1,4 +1,5 @@
-// Package system provides Linux desktop integration (MPRIS2, notifications, tray).
+//go:build linux
+
 package system
 
 import (
@@ -20,35 +21,6 @@ const (
 	ifaceRoot   = "org.mpris.MediaPlayer2"
 	ifacePlayer = "org.mpris.MediaPlayer2.Player"
 )
-
-// readArtworkFn reads album artwork from a media file.
-// Set via SetReadArtworkFn to avoid a direct dependency on the metadata package.
-var readArtworkFn = func(path string) ([]byte, string, error) { return nil, "", nil }
-
-// SetReadArtworkFn sets the function used to read artwork from media files.
-func SetReadArtworkFn(fn func(string) ([]byte, string, error)) {
-	readArtworkFn = fn
-}
-
-// PlayerControl is the interface that the MPRIS provider uses to control the player.
-type PlayerControl interface {
-	Pause()
-	Resume()
-	Stop()
-	Next()
-	Previous()
-	Seek(seconds float64)
-	SetVolume(percent int)
-	Volume() int
-	Position() float64
-	Duration() float64
-	State() string // "playing", "paused", "stopped"
-	MediaPath() string
-	SetShuffle(enabled bool)
-	GetShuffle() bool
-	SetRepeat(mode string) // "off", "all", "one"
-	GetRepeat() string
-}
 
 // MPRIS provides MPRIS2 D-Bus integration for Forte.
 type MPRIS struct {

--- a/internal/system/mpris_linux_test.go
+++ b/internal/system/mpris_linux_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package system
 
 import (
@@ -189,22 +191,22 @@ type mockPlayer struct {
 	duration       float64
 }
 
-func (m *mockPlayer) Pause()                    { m.pauseCalled = true }
-func (m *mockPlayer) Resume()                   { m.resumeCalled = true }
-func (m *mockPlayer) Stop()                     { m.stopCalled = true }
-func (m *mockPlayer) Next()                     { m.nextCalled = true }
-func (m *mockPlayer) Previous()                 { m.previousCalled = true }
-func (m *mockPlayer) Seek(s float64)            { m.seekPos = s }
-func (m *mockPlayer) SetVolume(p int)           { m.volumeSet = p }
-func (m *mockPlayer) Volume() int               { return 50 }
-func (m *mockPlayer) Position() float64         { return m.position }
-func (m *mockPlayer) Duration() float64         { return m.duration }
-func (m *mockPlayer) State() string             { return m.state }
-func (m *mockPlayer) MediaPath() string         { return "" }
-func (m *mockPlayer) SetShuffle(e bool)         { m.shuffleSet = &e }
-func (m *mockPlayer) GetShuffle() bool          { return false }
-func (m *mockPlayer) SetRepeat(mode string)     { m.repeatSet = mode }
-func (m *mockPlayer) GetRepeat() string         { return "off" }
+func (m *mockPlayer) Pause()                { m.pauseCalled = true }
+func (m *mockPlayer) Resume()               { m.resumeCalled = true }
+func (m *mockPlayer) Stop()                 { m.stopCalled = true }
+func (m *mockPlayer) Next()                 { m.nextCalled = true }
+func (m *mockPlayer) Previous()             { m.previousCalled = true }
+func (m *mockPlayer) Seek(s float64)        { m.seekPos = s }
+func (m *mockPlayer) SetVolume(p int)       { m.volumeSet = p }
+func (m *mockPlayer) Volume() int           { return 50 }
+func (m *mockPlayer) Position() float64     { return m.position }
+func (m *mockPlayer) Duration() float64     { return m.duration }
+func (m *mockPlayer) State() string         { return m.state }
+func (m *mockPlayer) MediaPath() string     { return "" }
+func (m *mockPlayer) SetShuffle(e bool)     { m.shuffleSet = &e }
+func (m *mockPlayer) GetShuffle() bool      { return false }
+func (m *mockPlayer) SetRepeat(mode string) { m.repeatSet = mode }
+func (m *mockPlayer) GetRepeat() string     { return "off" }
 
 func TestMprisPlayerPlay(t *testing.T) {
 	mock := &mockPlayer{}

--- a/internal/system/mpris_unsupported.go
+++ b/internal/system/mpris_unsupported.go
@@ -1,0 +1,35 @@
+//go:build !linux
+
+package system
+
+// MPRIS is a no-op media-control integration on platforms without MPRIS2.
+type MPRIS struct{}
+
+// NewMPRIS returns a no-op MPRIS integration.
+func NewMPRIS(_ PlayerControl) (*MPRIS, error) {
+	return &MPRIS{}, nil
+}
+
+// Close releases the no-op integration.
+func (m *MPRIS) Close() {}
+
+// UpdatePlaybackStatus records no platform state on unsupported platforms.
+func (m *MPRIS) UpdatePlaybackStatus(_ string) {}
+
+// UpdateMetadata records no platform state on unsupported platforms.
+func (m *MPRIS) UpdateMetadata(_, _, _, _ string, _ int, _ int64) {}
+
+// UpdateVolume records no platform state on unsupported platforms.
+func (m *MPRIS) UpdateVolume(_ int) {}
+
+// UpdateShuffle records no platform state on unsupported platforms.
+func (m *MPRIS) UpdateShuffle(_ bool) {}
+
+// UpdateLoopStatus records no platform state on unsupported platforms.
+func (m *MPRIS) UpdateLoopStatus(_ string) {}
+
+// UpdatePosition records no platform state on unsupported platforms.
+func (m *MPRIS) UpdatePosition(_ float64) {}
+
+// ClearMetadata records no platform state on unsupported platforms.
+func (m *MPRIS) ClearMetadata() {}

--- a/internal/system/notify_linux.go
+++ b/internal/system/notify_linux.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package system
 
 import (
@@ -67,14 +69,14 @@ func (n *Notifier) Notify(title, body string, artwork []byte) {
 	obj := n.conn.Object(notifyDest, notifyPath)
 	call := obj.Call(
 		notifyMethod, 0,
-		"Forte",          // app_name
-		n.replacesID,     // replaces_id
-		icon,             // app_icon
-		title,            // summary
-		body,             // body
-		[]string{},       // actions
+		"Forte",                   // app_name
+		n.replacesID,              // replaces_id
+		icon,                      // app_icon
+		title,                     // summary
+		body,                      // body
+		[]string{},                // actions
 		map[string]dbus.Variant{}, // hints
-		int32(5000),      // expire_timeout ms
+		int32(5000),               // expire_timeout ms
 	)
 	if call.Err != nil {
 		return

--- a/internal/system/notify_linux_test.go
+++ b/internal/system/notify_linux_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package system
 
 import "testing"

--- a/internal/system/notify_unsupported.go
+++ b/internal/system/notify_unsupported.go
@@ -1,0 +1,30 @@
+//go:build !linux
+
+package system
+
+// Notifier is a no-op desktop notification integration on platforms without
+// Freedesktop notifications.
+type Notifier struct {
+	enabled bool
+}
+
+// NewNotifier returns a no-op notifier.
+func NewNotifier() (*Notifier, error) {
+	return &Notifier{enabled: true}, nil
+}
+
+// Notify records no platform state on unsupported platforms.
+func (n *Notifier) Notify(_, _ string, _ []byte) {}
+
+// SetEnabled enables or disables notifications.
+func (n *Notifier) SetEnabled(enabled bool) {
+	n.enabled = enabled
+}
+
+// Enabled returns whether notifications are enabled.
+func (n *Notifier) Enabled() bool {
+	return n.enabled
+}
+
+// Close releases the no-op notifier.
+func (n *Notifier) Close() {}

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -1,0 +1,32 @@
+// Package system provides desktop integration for media controls and notifications.
+package system
+
+// PlayerControl is the interface that desktop media integrations use to control
+// the player.
+type PlayerControl interface {
+	Pause()
+	Resume()
+	Stop()
+	Next()
+	Previous()
+	Seek(seconds float64)
+	SetVolume(percent int)
+	Volume() int
+	Position() float64
+	Duration() float64
+	State() string
+	MediaPath() string
+	SetShuffle(enabled bool)
+	GetShuffle() bool
+	SetRepeat(mode string)
+	GetRepeat() string
+}
+
+// readArtworkFn reads album artwork from a media file.
+// Set via SetReadArtworkFn to avoid a direct dependency on the metadata package.
+var readArtworkFn = func(path string) ([]byte, string, error) { return nil, "", nil }
+
+// SetReadArtworkFn sets the function used to read artwork from media files.
+func SetReadArtworkFn(fn func(string) ([]byte, string, error)) {
+	readArtworkFn = fn
+}

--- a/internal/system/unsupported_test.go
+++ b/internal/system/unsupported_test.go
@@ -1,0 +1,58 @@
+//go:build !linux
+
+package system
+
+import "testing"
+
+type unsupportedPlayer struct{}
+
+func (unsupportedPlayer) Pause()            {}
+func (unsupportedPlayer) Resume()           {}
+func (unsupportedPlayer) Stop()             {}
+func (unsupportedPlayer) Next()             {}
+func (unsupportedPlayer) Previous()         {}
+func (unsupportedPlayer) Seek(float64)      {}
+func (unsupportedPlayer) SetVolume(int)     {}
+func (unsupportedPlayer) Volume() int       { return 50 }
+func (unsupportedPlayer) Position() float64 { return 0 }
+func (unsupportedPlayer) Duration() float64 { return 0 }
+func (unsupportedPlayer) State() string     { return "stopped" }
+func (unsupportedPlayer) MediaPath() string { return "" }
+func (unsupportedPlayer) SetShuffle(bool)   {}
+func (unsupportedPlayer) GetShuffle() bool  { return false }
+func (unsupportedPlayer) SetRepeat(string)  {}
+func (unsupportedPlayer) GetRepeat() string { return "off" }
+
+func TestUnsupportedMPRISNoOps(t *testing.T) {
+	m, err := NewMPRIS(unsupportedPlayer{})
+	if err != nil {
+		t.Fatalf("NewMPRIS() error = %v", err)
+	}
+
+	m.UpdatePlaybackStatus("playing")
+	m.UpdateMetadata("Title", "Artist", "Album", "/tmp/track.flac", 123, 1)
+	m.UpdateVolume(75)
+	m.UpdateShuffle(true)
+	m.UpdateLoopStatus("all")
+	m.UpdatePosition(10)
+	m.ClearMetadata()
+	m.Close()
+}
+
+func TestUnsupportedNotifierStateAndNoOps(t *testing.T) {
+	n, err := NewNotifier()
+	if err != nil {
+		t.Fatalf("NewNotifier() error = %v", err)
+	}
+	if !n.Enabled() {
+		t.Fatal("notifier should default to enabled")
+	}
+
+	n.Notify("Title", "Body", []byte{0xff, 0xd8})
+	n.SetEnabled(false)
+	if n.Enabled() {
+		t.Fatal("notifier should be disabled")
+	}
+	n.Notify("Title", "Body", nil)
+	n.Close()
+}


### PR DESCRIPTION
## What changed

- Split Linux MPRIS and desktop notification integrations behind Linux build tags.
- Added non-Linux no-op system integrations so Darwin builds do not pull in DBus/Freedesktop code.
- Added unit tests for the non-Linux no-op behavior.
- Made the Nix package and dev shell platform-aware so Darwin no longer evaluates Linux GTK/WebKit/icon packaging dependencies.
- Added an arm64 macOS GitHub Actions workflow that runs frontend checks, Go tests, a Mach-O arm64 binary build, and a Darwin Nix package build.

## Impact

This does not make the macOS app fully productized yet, but it creates the first validated macOS build/install path. Linux keeps the existing MPRIS, Freedesktop notification, GTK/WebKit, desktop file, and tray icon packaging behavior.

## Verification

Local Linux and cross-platform evaluation:

- `go test ./...`
- `go test -tags nocgo ./...`
- `npm run check` from `frontend/`
- `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go test -c ./internal/system -o /tmp/forte-system-darwin.test`
- `file /tmp/forte-system-darwin.test` confirmed `Mach-O 64-bit arm64 executable`
- `nix build .#forte`
- `nix build .#packages.aarch64-darwin.default --dry-run`
- `nix flake check --no-build --all-systems`

The draft PR is intentionally left for the macOS GitHub runner to prove the native Darwin build and Nix package build.
