### PR TITLE
Add theme transparency settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev ffmpeg
 
-      - name: Install wails3
-        run: go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.95
-
       - name: Install go-task
         uses: arduino/setup-task@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libmpv-dev ffmpeg
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev ffmpeg
 
       - name: Build frontend
         working-directory: frontend
@@ -65,7 +65,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libmpv-dev ffmpeg
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev ffmpeg
 
       - name: Build frontend
         working-directory: frontend
@@ -119,7 +119,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libmpv-dev ffmpeg
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev ffmpeg
 
       - name: Install go-task
         uses: arduino/setup-task@v2
@@ -148,7 +148,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libmpv-dev ffmpeg
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev ffmpeg
 
       - name: Build frontend
         working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev ffmpeg
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libmpv-dev ffmpeg
 
       - name: Build frontend
         working-directory: frontend
@@ -65,7 +65,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev ffmpeg
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libmpv-dev ffmpeg
 
       - name: Build frontend
         working-directory: frontend
@@ -119,7 +119,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev ffmpeg
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libmpv-dev ffmpeg
 
       - name: Install go-task
         uses: arduino/setup-task@v2
@@ -148,7 +148,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev ffmpeg
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libmpv-dev ffmpeg
 
       - name: Build frontend
         working-directory: frontend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev libfuse2
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libmpv-dev libfuse2
 
       - name: Install go-task
         uses: arduino/setup-task@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev libfuse2
 
-      - name: Install wails3
-        run: go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.95
-
       - name: Install go-task
         uses: arduino/setup-task@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libmpv-dev libfuse2
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-4-dev libwebkitgtk-6.0-dev libmpv-dev libfuse2
 
       - name: Install go-task
         uses: arduino/setup-task@v2

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Without Nix, install:
 - mpv
 - pkg-config
 - [go-task](https://taskfile.dev)
-- Wails 3: `go install github.com/wailsapp/wails/v3/cmd/wails3@latest`
+
+The build tasks install the pinned Wails 3 CLI into the repo-local `.go/bin`
+directory when needed.
 
 Then build:
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
     cmds:
       - task: "linux:build"
         vars:
-          EXTRA_TAGS: nocgo,gtk4
+          EXTRA_TAGS: nocgo,gtk3
 
   package:
     summary: Packages a production build of the application

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,8 +31,10 @@ tasks:
 
   dev:
     summary: Runs the application in development mode
+    deps:
+      - task: common:ensure:wails3
     cmds:
-      - wails3 dev -config ./build/config.yml -port {{.VITE_PORT}}
+      - '{{.ROOT_DIR}}/.go/bin/wails3 dev -config ./build/config.yml -port {{.VITE_PORT}}'
 
   demo:
     summary: Seeds the database with fixture data for screenshots

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
     cmds:
       - task: "linux:build"
         vars:
-          EXTRA_TAGS: nocgo,gtk3
+          EXTRA_TAGS: nocgo,gtk4
 
   package:
     summary: Packages a production build of the application

--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -25,6 +25,26 @@ tasks:
     cmds:
       - go mod tidy
 
+  patch:wails:
+    summary: Applies Forte's local Wails patches to the module cache
+    internal: true
+    cmds:
+      - |
+        module_dir="$(go env GOMODCACHE)/github.com/wailsapp/wails/v3@{{.WAILS_VERSION}}"
+        test -d "$module_dir"
+
+        for patch_file in \
+          '{{.ROOT_DIR}}/patches/wails-status-notifier-icon-name.patch' \
+          '{{.ROOT_DIR}}/patches/wails-gtk4-transparent-window.patch'
+        do
+          if patch -p1 -d "$module_dir" --forward --dry-run < "$patch_file" >/dev/null 2>&1; then
+            chmod -R u+w "$module_dir"
+            patch -p1 -d "$module_dir" < "$patch_file"
+          else
+            patch -p1 -d "$module_dir" --reverse --dry-run < "$patch_file" >/dev/null 2>&1
+          fi
+        done
+
   install:frontend:deps:
     summary: Install frontend dependencies
     dir: frontend
@@ -66,6 +86,7 @@ tasks:
     summary: Generates bindings for the frontend
     deps:
       - task: go:mod:tidy
+      - task: patch:wails
       - task: ensure:wails3
     sources:
       - "**/*.[jt]s"

--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -30,18 +30,28 @@ tasks:
     internal: true
     cmds:
       - |
+        lock_dir='{{.ROOT_DIR}}/.go/wails-patch.lock'
+        mkdir -p "$(dirname "$lock_dir")"
+        while ! mkdir "$lock_dir" 2>/dev/null; do
+          sleep 0.2
+        done
+        trap 'rmdir "$lock_dir"' EXIT
+
         module_dir="$(go env GOMODCACHE)/github.com/wailsapp/wails/v3@{{.WAILS_VERSION}}"
         test -d "$module_dir"
+        chmod -R u+w "$module_dir"
 
         for patch_file in \
           '{{.ROOT_DIR}}/patches/wails-status-notifier-icon-name.patch' \
           '{{.ROOT_DIR}}/patches/wails-gtk4-transparent-window.patch'
         do
           if patch -p1 -d "$module_dir" --forward --dry-run < "$patch_file" >/dev/null 2>&1; then
-            chmod -R u+w "$module_dir"
             patch -p1 -d "$module_dir" < "$patch_file"
+          elif patch -p1 -d "$module_dir" --reverse --dry-run < "$patch_file" >/dev/null 2>&1; then
+            :
           else
-            patch -p1 -d "$module_dir" --reverse --dry-run < "$patch_file" >/dev/null 2>&1
+            echo "Failed to apply or verify Wails patch: $patch_file" >&2
+            exit 1
           fi
         done
 

--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -1,6 +1,24 @@
 version: '3'
 
+vars:
+  WAILS_VERSION: v3.0.0-alpha.95
+  WAILS_BIN: '{{.ROOT_DIR}}/.go/bin/wails3'
+
 tasks:
+  ensure:wails3:
+    summary: Installs the pinned Wails 3 CLI for local build tasks
+    internal: true
+    preconditions:
+      - sh: go version
+        msg: "Go is required to install wails3. Install Go 1.25+ or enter `nix develop`."
+    cmds:
+      - |
+        if [ -x '{{.WAILS_BIN}}' ] && [ "$('{{.WAILS_BIN}}' version)" = '{{.WAILS_VERSION}}' ]; then
+          exit 0
+        fi
+        mkdir -p '{{.ROOT_DIR}}/.go/bin'
+        GOBIN='{{.ROOT_DIR}}/.go/bin' go install github.com/wailsapp/wails/v3/cmd/wails3@{{.WAILS_VERSION}}
+
   go:mod:tidy:
     summary: Runs `go mod tidy`
     internal: true
@@ -48,6 +66,7 @@ tasks:
     summary: Generates bindings for the frontend
     deps:
       - task: go:mod:tidy
+      - task: ensure:wails3
     sources:
       - "**/*.[jt]s"
       - exclude: frontend/**/*
@@ -58,7 +77,7 @@ tasks:
     generates:
       - frontend/bindings/**/*
     cmds:
-      - wails3 generate bindings -f '{{.BUILD_FLAGS}}' -clean=true -ts
+      - '{{.WAILS_BIN}} generate bindings -f ''{{.BUILD_FLAGS}}'' -clean=true -ts'
 
   dev:frontend:
     summary: Runs the frontend in development mode
@@ -71,5 +90,7 @@ tasks:
   update:build-assets:
     summary: Updates the build assets
     dir: build
+    deps:
+      - task: ensure:wails3
     cmds:
-      - wails3 update build-assets -name "{{.APP_NAME}}" -binaryname "{{.APP_NAME}}" -config config.yml -dir .
+      - '{{.WAILS_BIN}} update build-assets -name "{{.APP_NAME}}" -binaryname "{{.APP_NAME}}" -config config.yml -dir .'

--- a/build/config.yml
+++ b/build/config.yml
@@ -29,7 +29,7 @@ dev_mode:
       - "*.ts"
     git_ignore: true
   executes:
-    - cmd: ./.go/bin/wails3 build DEV=true EXTRA_TAGS=gtk4
+    - cmd: ./.go/bin/wails3 build DEV=true EXTRA_TAGS=gtk3
       type: blocking
     - cmd: ./.go/bin/wails3 task common:dev:frontend
       type: background

--- a/build/config.yml
+++ b/build/config.yml
@@ -29,11 +29,11 @@ dev_mode:
       - "*.ts"
     git_ignore: true
   executes:
-    - cmd: wails3 build DEV=true EXTRA_TAGS=gtk4
+    - cmd: ./.go/bin/wails3 build DEV=true EXTRA_TAGS=gtk4
       type: blocking
-    - cmd: wails3 task common:dev:frontend
+    - cmd: ./.go/bin/wails3 task common:dev:frontend
       type: background
-    - cmd: wails3 task run
+    - cmd: ./.go/bin/wails3 task run
       type: primary
 
 fileAssociations: []

--- a/build/config.yml
+++ b/build/config.yml
@@ -29,7 +29,7 @@ dev_mode:
       - "*.ts"
     git_ignore: true
   executes:
-    - cmd: ./.go/bin/wails3 build DEV=true EXTRA_TAGS=gtk3
+    - cmd: ./.go/bin/wails3 build DEV=true EXTRA_TAGS=gtk4
       type: blocking
     - cmd: ./.go/bin/wails3 task common:dev:frontend
       type: background

--- a/build/linux/Taskfile.yml
+++ b/build/linux/Taskfile.yml
@@ -115,10 +115,11 @@ tasks:
     deps:
       - task: build
       - task: generate:dotdesktop
+      - task: common:ensure:wails3
     cmds:
       - cp "{{.APP_BINARY}}" "{{.APP_NAME}}"
       - cp ../../appicon.png "{{.APP_NAME}}.png"
-      - wails3 generate appimage -binary "{{.APP_NAME}}" -icon {{.ICON}} -desktopfile {{.DESKTOP_FILE}} -outputdir {{.OUTPUT_DIR}} -builddir {{.ROOT_DIR}}/build/linux/appimage/build
+      - '{{.ROOT_DIR}}/.go/bin/wails3 generate appimage -binary "{{.APP_NAME}}" -icon {{.ICON}} -desktopfile {{.DESKTOP_FILE}} -outputdir {{.OUTPUT_DIR}} -builddir {{.ROOT_DIR}}/build/linux/appimage/build'
     vars:
       APP_NAME: '{{.APP_NAME}}'
       APP_BINARY: '../../../bin/{{.APP_NAME}}'
@@ -152,26 +153,34 @@ tasks:
 
   generate:deb:
     summary: Creates a deb package
+    deps:
+      - task: common:ensure:wails3
     cmds:
-      - wails3 tool package -name "{{.APP_NAME}}" -format deb -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin
+      - '{{.ROOT_DIR}}/.go/bin/wails3 tool package -name "{{.APP_NAME}}" -format deb -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin'
 
   generate:rpm:
     summary: Creates a rpm package
+    deps:
+      - task: common:ensure:wails3
     cmds:
-      - wails3 tool package -name "{{.APP_NAME}}" -format rpm -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin
+      - '{{.ROOT_DIR}}/.go/bin/wails3 tool package -name "{{.APP_NAME}}" -format rpm -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin'
 
   generate:aur:
     summary: Creates a arch linux packager package
+    deps:
+      - task: common:ensure:wails3
     cmds:
-      - wails3 tool package -name "{{.APP_NAME}}" -format archlinux -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin
+      - '{{.ROOT_DIR}}/.go/bin/wails3 tool package -name "{{.APP_NAME}}" -format archlinux -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin'
 
   generate:dotdesktop:
     summary: Generates a `.desktop` file
     dir: build
+    deps:
+      - task: common:ensure:wails3
     cmds:
       - mkdir -p {{.ROOT_DIR}}/build/linux/appimage
       - |
-        wails3 generate .desktop \
+        {{.ROOT_DIR}}/.go/bin/wails3 generate .desktop \
           -name "{{.DISPLAY_NAME}}" \
           -exec "{{.EXEC}}" \
           -icon "{{.ICON}}" \
@@ -201,8 +210,9 @@ tasks:
       Password is retrieved from system keychain (run: wails3 setup signing)
     deps:
       - task: create:deb
+      - task: common:ensure:wails3
     cmds:
-      - wails3 tool sign --input "{{.BIN_DIR}}/{{.APP_NAME}}*.deb" --pgp-key {{.PGP_KEY}} {{if .SIGN_ROLE}}--role {{.SIGN_ROLE}}{{end}}
+      - '{{.ROOT_DIR}}/.go/bin/wails3 tool sign --input "{{.BIN_DIR}}/{{.APP_NAME}}*.deb" --pgp-key {{.PGP_KEY}} {{if .SIGN_ROLE}}--role {{.SIGN_ROLE}}{{end}}'
     preconditions:
       - sh: '[ -n "{{.PGP_KEY}}" ]'
         msg: "PGP_KEY is required. Set it in the vars section at the top of build/linux/Taskfile.yml"
@@ -215,8 +225,9 @@ tasks:
       Password is retrieved from system keychain (run: wails3 setup signing)
     deps:
       - task: create:rpm
+      - task: common:ensure:wails3
     cmds:
-      - wails3 tool sign --input "{{.BIN_DIR}}/{{.APP_NAME}}*.rpm" --pgp-key {{.PGP_KEY}}
+      - '{{.ROOT_DIR}}/.go/bin/wails3 tool sign --input "{{.BIN_DIR}}/{{.APP_NAME}}*.rpm" --pgp-key {{.PGP_KEY}}'
     preconditions:
       - sh: '[ -n "{{.PGP_KEY}}" ]'
         msg: "PGP_KEY is required. Set it in the vars section at the top of build/linux/Taskfile.yml"

--- a/build/linux/Taskfile.yml
+++ b/build/linux/Taskfile.yml
@@ -41,6 +41,7 @@ tasks:
     internal: true
     deps:
       - task: common:go:mod:tidy
+      - task: common:patch:wails
       - task: common:build:frontend
         vars:
           BUILD_FLAGS:

--- a/build/linux/nfpm/nfpm.yaml
+++ b/build/linux/nfpm/nfpm.yaml
@@ -32,10 +32,10 @@ contents:
   - src: "./build/linux/forte.desktop"
     dst: "/usr/share/applications/io.github.willfish.forte.desktop"
 
-# Default dependencies for Debian/Ubuntu builds using GTK3 and WebKit2GTK 4.1.
+# Default dependencies for Debian/Ubuntu builds using GTK4 and WebKitGTK 6.
 depends:
-  - libgtk-3-0
-  - libwebkit2gtk-4.1-0
+  - libgtk-4-1
+  - libwebkitgtk-6.0-4
   - libmpv2
   - hicolor-icon-theme
 
@@ -43,15 +43,15 @@ depends:
 overrides:
   rpm:
     depends:
-      - gtk3
-      - webkit2gtk4.1
+      - gtk4
+      - webkitgtk6.0
       - mpv-libs
       - hicolor-icon-theme
   
   archlinux:
     depends:
-      - gtk3
-      - webkit2gtk-4.1
+      - gtk4
+      - webkitgtk-6.0
       - mpv
       - hicolor-icon-theme
 

--- a/build/linux/nfpm/nfpm.yaml
+++ b/build/linux/nfpm/nfpm.yaml
@@ -32,10 +32,10 @@ contents:
   - src: "./build/linux/forte.desktop"
     dst: "/usr/share/applications/io.github.willfish.forte.desktop"
 
-# Default dependencies for Debian/Ubuntu builds using GTK4 and WebKitGTK 6.
+# Default dependencies for Debian/Ubuntu builds using GTK3 and WebKit2GTK 4.1.
 depends:
-  - libgtk-4-1
-  - libwebkitgtk-6.0-4
+  - libgtk-3-0
+  - libwebkit2gtk-4.1-0
   - libmpv2
   - hicolor-icon-theme
 
@@ -43,15 +43,15 @@ depends:
 overrides:
   rpm:
     depends:
-      - gtk4
-      - webkitgtk6.0
+      - gtk3
+      - webkit2gtk4.1
       - mpv-libs
       - hicolor-icon-theme
   
   archlinux:
     depends:
-      - gtk4
-      - webkitgtk-6.0
+      - gtk3
+      - webkit2gtk-4.1
       - mpv
       - hicolor-icon-theme
 

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
             if pkgs.stdenv.isDarwin then
               "sha256-lzVkzCZZ3jGCWSpnln4yCJDo+vojZU1pkrK7JkbAK40="
             else
-              "sha256-6DhIT+e7kUl1BqBGoe4kMgl98uJZK6Ucap1Gn6qoZqw=";
+              "sha256-3g4XNVbKnH8/9Dqm92bJcGMO7IC6COSX7LH54Gb44v8=";
           modBuildPhase = ''
             runHook preBuild
 
@@ -61,6 +61,7 @@
             go mod vendor "''${goModVendorFlags[@]}"
             ${lib.optionalString pkgs.stdenv.isLinux ''
               patch -p1 -d vendor/github.com/wailsapp/wails/v3 < ${./patches/wails-status-notifier-icon-name.patch}
+              patch -p1 -d vendor/github.com/wailsapp/wails/v3 < ${./patches/wails-gtk4-transparent-window.patch}
             ''}
 
             mkdir -p vendor

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
           go = pkgs.go_1_25;
           vendorHash =
             if pkgs.stdenv.isDarwin then
-              "sha256-66N2XYd0rMUmtZkkScLL/KtpfyR/cPXIUOJ4iPbWHEs="
+              "sha256-lzVkzCZZ3jGCWSpnln4yCJDo+vojZU1pkrK7JkbAK40="
             else
               "sha256-6DhIT+e7kUl1BqBGoe4kMgl98uJZK6Ucap1Gn6qoZqw=";
           modBuildPhase = ''

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
             mkdir -p vendor
             runHook postBuild
           '';
-          tags = [ "production" "nocgo" ] ++ lib.optionals pkgs.stdenv.isLinux [ "gtk3" ];
+          tags = [ "production" "nocgo" ] ++ lib.optionals pkgs.stdenv.isLinux [ "gtk4" ];
           ldflags = [ "-s" "-w" ];
           subPackages = [ "." ];
           doCheck = false; # Tests need libmpv.so at runtime
@@ -74,7 +74,7 @@
           nativeBuildInputs = with pkgs; [
             pkg-config
           ] ++ lib.optionals pkgs.stdenv.isLinux [
-            wrapGAppsHook3
+            wrapGAppsHook4
             imagemagick
             desktop-file-utils
           ];
@@ -82,8 +82,8 @@
           buildInputs = with pkgs; [
             mpv
           ] ++ lib.optionals pkgs.stdenv.isLinux [
-            gtk3
-            webkitgtk_4_1
+            gtk4
+            webkitgtk_6_0
           ] ++ lib.optionals pkgs.stdenv.isDarwin [
             pkgs.apple-sdk_14
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
             mkdir -p vendor
             runHook postBuild
           '';
-          tags = [ "production" "nocgo" ] ++ lib.optionals pkgs.stdenv.isLinux [ "gtk4" ];
+          tags = [ "production" "nocgo" ] ++ lib.optionals pkgs.stdenv.isLinux [ "gtk3" ];
           ldflags = [ "-s" "-w" ];
           subPackages = [ "." ];
           doCheck = false; # Tests need libmpv.so at runtime
@@ -74,7 +74,7 @@
           nativeBuildInputs = with pkgs; [
             pkg-config
           ] ++ lib.optionals pkgs.stdenv.isLinux [
-            wrapGAppsHook4
+            wrapGAppsHook3
             imagemagick
             desktop-file-utils
           ];
@@ -82,8 +82,8 @@
           buildInputs = with pkgs; [
             mpv
           ] ++ lib.optionals pkgs.stdenv.isLinux [
-            gtk4
-            webkitgtk_6_0
+            gtk3
+            webkitgtk_4_1
           ] ++ lib.optionals pkgs.stdenv.isDarwin [
             pkgs.apple-sdk_14
           ];

--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -33,6 +33,9 @@
     --radius-lg:   6px;
     --radius-xl:   8px;
     --radius-full: 50%;
+
+    --theme-opacity: 1;
+    --theme-surface-opacity: 100%;
 }
 
 /* --- Colour tokens: green dark theme (default) --- */
@@ -184,7 +187,7 @@ body {
     margin: 0;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: var(--text-base);
-    background: var(--bg-main);
+    background: color-mix(in srgb, var(--bg-main) var(--theme-surface-opacity), transparent);
     color: var(--text-primary);
     overflow: hidden;
 }
@@ -198,6 +201,7 @@ body {
     display: flex;
     flex-direction: column;
     height: 100vh;
+    background: color-mix(in srgb, var(--bg-main) var(--theme-surface-opacity), transparent);
 }
 
 .top {
@@ -209,7 +213,7 @@ body {
 .sidebar-wrap {
     width: 200px;
     flex-shrink: 0;
-    background: var(--bg-sidebar);
+    background: color-mix(in srgb, var(--bg-sidebar) var(--theme-surface-opacity), transparent);
     border-right: 1px solid var(--border);
     display: flex;
     flex-direction: column;
@@ -222,6 +226,7 @@ body {
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    background: color-mix(in srgb, var(--bg-main) var(--theme-surface-opacity), transparent);
 }
 
 /* View transition animation applied to content views */

--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -187,7 +187,7 @@ body {
     margin: 0;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: var(--text-base);
-    background: color-mix(in srgb, var(--bg-main) var(--theme-surface-opacity), transparent);
+    background: transparent;
     color: var(--text-primary);
     overflow: hidden;
 }
@@ -201,7 +201,7 @@ body {
     display: flex;
     flex-direction: column;
     height: 100vh;
-    background: color-mix(in srgb, var(--bg-main) var(--theme-surface-opacity), transparent);
+    background: transparent;
 }
 
 .top {

--- a/frontend/src/NowPlayingBar.svelte
+++ b/frontend/src/NowPlayingBar.svelte
@@ -212,7 +212,7 @@
   .bar {
     height: 72px;
     flex-shrink: 0;
-    background: var(--bg-bar);
+    background: color-mix(in srgb, var(--bg-bar) var(--theme-surface-opacity), transparent);
     border-top: 1px solid var(--border);
     display: grid;
     grid-template-columns: 250px 1fr 150px;

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
   import {
     getPreference,
+    getTransparencyPreference,
     onPreferenceChange,
+    onTransparencyPreferenceChange,
     setPreference,
+    setTransparencyPreference,
     themeColour,
     themeMode,
     themePreference,
     type ThemeColour,
     type ThemeMode,
-    type ThemePreference
+    type ThemePreference,
+    type ThemeTransparencyPreference
   } from './lib/theme';
   import { setLibraryEnabled, setTitlebarEnabled } from './lib/stores';
   import { LibraryService } from "../bindings/github.com/willfish/forte";
@@ -21,6 +25,7 @@
 
   // Theme state
   let preference = $state<ThemePreference>(getPreference());
+  let transparencyPreference = $state<ThemeTransparencyPreference>(getTransparencyPreference());
   let appPreferences = $state({
     libraryEnabled: false,
     startLastStation: true,
@@ -32,9 +37,23 @@
     return onPreferenceChange((p) => { preference = p; });
   });
 
+  $effect(() => {
+    return onTransparencyPreferenceChange((p) => { transparencyPreference = p; });
+  });
+
   function handleChange(pref: ThemePreference) {
     setPreference(pref);
     preference = pref;
+  }
+
+  function handleTransparencyEnabledChange(enabled: boolean) {
+    setTransparencyPreference({ enabled });
+    transparencyPreference = getTransparencyPreference();
+  }
+
+  function handleOpacityChange(opacity: number) {
+    setTransparencyPreference({ opacity });
+    transparencyPreference = getTransparencyPreference();
   }
 
   async function loadAppPreferences() {
@@ -408,6 +427,38 @@
           {/each}
         </div>
       </div>
+
+      <div class="theme-control-group">
+        <h4>Transparency</h4>
+        <div class="preference-list">
+          <label class="preference-row">
+            <span>
+              <span class="option-label">Transparent theme</span>
+              <span class="option-desc">Let Forte's main surfaces show the desktop behind the window</span>
+            </span>
+            <input
+              type="checkbox"
+              checked={transparencyPreference.enabled}
+              onchange={(e) => handleTransparencyEnabledChange((e.target as HTMLInputElement).checked)}
+            />
+          </label>
+          <label class="opacity-row">
+            <span>
+              <span class="option-label">Theme opacity</span>
+              <span class="option-desc">{transparencyPreference.opacity.toFixed(2)}</span>
+            </span>
+            <input
+              type="range"
+              min="0.2"
+              max="1"
+              step="0.05"
+              value={transparencyPreference.opacity}
+              disabled={!transparencyPreference.enabled}
+              oninput={(e) => handleOpacityChange(Number((e.target as HTMLInputElement).value))}
+            />
+          </label>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -770,6 +821,31 @@
   .preference-row input {
     flex-shrink: 0;
     accent-color: var(--accent);
+  }
+
+  .opacity-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(10rem, 14rem);
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+  }
+
+  .opacity-row > span {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .opacity-row input {
+    width: 100%;
+    accent-color: var(--accent);
+  }
+
+  .opacity-row input:disabled {
+    opacity: 0.45;
   }
 
   .option-content {

--- a/frontend/src/TitleBar.svelte
+++ b/frontend/src/TitleBar.svelte
@@ -41,7 +41,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    background: var(--bg-sidebar);
+    background: color-mix(in srgb, var(--bg-sidebar) var(--theme-surface-opacity), transparent);
     border-bottom: 1px solid var(--border);
     color: var(--text-secondary);
     --wails-draggable: drag;

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,3 +1,5 @@
+import { Window } from '@wailsio/runtime';
+
 export type ThemePreference =
   | 'green-dark'
   | 'green-light'
@@ -73,6 +75,19 @@ function applyTransparencyPreference(pref: ThemeTransparencyPreference) {
   root.setAttribute('data-theme-transparency', pref.enabled ? 'on' : 'off');
   root.style.setProperty('--theme-opacity', String(activeOpacity));
   root.style.setProperty('--theme-surface-opacity', `${activeOpacity * 100}%`);
+  syncNativeWindowBackground(pref.enabled);
+}
+
+function syncNativeWindowBackground(transparent: boolean) {
+  try {
+    if (transparent) {
+      void Window.SetBackgroundColour(0, 0, 0, 0);
+    } else {
+      void Window.SetBackgroundColour(27, 38, 54, 255);
+    }
+  } catch {
+    // Wails runtime is unavailable in browser-only test contexts.
+  }
 }
 
 function saveTransparencyPreference(pref: ThemeTransparencyPreference) {

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -7,8 +7,17 @@ export type ThemePreference =
   | 'financial-times-light';
 export type ThemeMode = 'dark' | 'light';
 export type ThemeColour = 'green' | 'blue' | 'financial-times';
+export type ThemeTransparencyPreference = {
+  enabled: boolean;
+  opacity: number;
+};
 
 const STORAGE_KEY = 'forte-theme';
+const TRANSPARENCY_STORAGE_KEY = 'forte-theme-transparency';
+const DEFAULT_TRANSPARENCY: ThemeTransparencyPreference = {
+  enabled: false,
+  opacity: 0.8,
+};
 const THEME_PREFERENCES: ThemePreference[] = [
   'green-dark',
   'green-light',
@@ -20,6 +29,8 @@ const THEME_PREFERENCES: ThemePreference[] = [
 
 let _preference: ThemePreference = loadPreference();
 const _listeners: Array<(theme: ThemePreference) => void> = [];
+let _transparencyPreference: ThemeTransparencyPreference = loadTransparencyPreference();
+const _transparencyListeners: Array<(preference: ThemeTransparencyPreference) => void> = [];
 
 function loadPreference(): ThemePreference {
   const stored = localStorage.getItem(STORAGE_KEY);
@@ -31,6 +42,41 @@ function loadPreference(): ThemePreference {
 
 function applyTheme(theme: ThemePreference) {
   document.documentElement.setAttribute('data-theme', theme);
+}
+
+function clampOpacity(opacity: number): number {
+  if (!Number.isFinite(opacity)) return DEFAULT_TRANSPARENCY.opacity;
+  return Math.min(1, Math.max(0.2, opacity));
+}
+
+function normaliseTransparencyPreference(pref: Partial<ThemeTransparencyPreference> | null): ThemeTransparencyPreference {
+  return {
+    enabled: Boolean(pref?.enabled),
+    opacity: clampOpacity(Number(pref?.opacity ?? DEFAULT_TRANSPARENCY.opacity)),
+  };
+}
+
+function loadTransparencyPreference(): ThemeTransparencyPreference {
+  const stored = localStorage.getItem(TRANSPARENCY_STORAGE_KEY);
+  if (!stored) return DEFAULT_TRANSPARENCY;
+
+  try {
+    return normaliseTransparencyPreference(JSON.parse(stored));
+  } catch {
+    return DEFAULT_TRANSPARENCY;
+  }
+}
+
+function applyTransparencyPreference(pref: ThemeTransparencyPreference) {
+  const root = document.documentElement;
+  const activeOpacity = pref.enabled ? pref.opacity : 1;
+  root.setAttribute('data-theme-transparency', pref.enabled ? 'on' : 'off');
+  root.style.setProperty('--theme-opacity', String(activeOpacity));
+  root.style.setProperty('--theme-surface-opacity', `${activeOpacity * 100}%`);
+}
+
+function saveTransparencyPreference(pref: ThemeTransparencyPreference) {
+  localStorage.setItem(TRANSPARENCY_STORAGE_KEY, JSON.stringify(pref));
 }
 
 export function getPreference(): ThemePreference {
@@ -58,6 +104,20 @@ export function themePreference(colour: ThemeColour, mode: ThemeMode): ThemePref
   return `${colour}-${mode}` as ThemePreference;
 }
 
+export function getTransparencyPreference(): ThemeTransparencyPreference {
+  return { ..._transparencyPreference };
+}
+
+export function setTransparencyPreference(pref: Partial<ThemeTransparencyPreference>) {
+  _transparencyPreference = normaliseTransparencyPreference({
+    ..._transparencyPreference,
+    ...pref,
+  });
+  saveTransparencyPreference(_transparencyPreference);
+  applyTransparencyPreference(_transparencyPreference);
+  for (const fn of _transparencyListeners) fn(getTransparencyPreference());
+}
+
 export function onPreferenceChange(fn: (pref: ThemePreference) => void): () => void {
   _listeners.push(fn);
   return () => {
@@ -66,6 +126,15 @@ export function onPreferenceChange(fn: (pref: ThemePreference) => void): () => v
   };
 }
 
+export function onTransparencyPreferenceChange(fn: (pref: ThemeTransparencyPreference) => void): () => void {
+  _transparencyListeners.push(fn);
+  return () => {
+    const idx = _transparencyListeners.indexOf(fn);
+    if (idx >= 0) _transparencyListeners.splice(idx, 1);
+  };
+}
+
 export function initTheme() {
   applyTheme(_preference);
+  applyTransparencyPreference(_transparencyPreference);
 }

--- a/frontend/tests/mocks/wails-runtime.ts
+++ b/frontend/tests/mocks/wails-runtime.ts
@@ -416,6 +416,8 @@ class MockCancellablePromise<T> extends Promise<T> {
   cancel() {}
 }
 
+const windowCalls: Array<{ method: string; args: any[] }> = [];
+
 export const Call = {
   ByID(id: number, ...args: any[]): MockCancellablePromise<any> {
     const handler = fixtures[id];
@@ -433,7 +435,15 @@ export const Window = {
   Minimise: () => MockCancellablePromise.resolve(undefined),
   ToggleMaximise: () => MockCancellablePromise.resolve(undefined),
   Close: () => MockCancellablePromise.resolve(undefined),
+  SetBackgroundColour: (...args: any[]) => {
+    windowCalls.push({ method: "SetBackgroundColour", args });
+    return MockCancellablePromise.resolve(undefined);
+  },
 };
+
+if (typeof window !== "undefined") {
+  (window as any).__wailsWindowCalls = windowCalls;
+}
 
 export const Create = {
   Array(createFn: (source: any) => any) {

--- a/frontend/tests/settings.spec.ts
+++ b/frontend/tests/settings.spec.ts
@@ -31,6 +31,31 @@ test.describe("Settings", () => {
     await expect(page.locator(".brand-mark path")).toHaveCSS("stroke", "rgb(199, 66, 106)");
   });
 
+  test("configures theme transparency", async ({ page }) => {
+    const html = page.locator("html");
+    const opacity = page.getByLabel("Theme opacity");
+
+    await expect(page.getByLabel("Transparent theme")).not.toBeChecked();
+    await expect(opacity).toHaveValue("0.8");
+    await expect(opacity).toBeDisabled();
+    await expect(html).toHaveAttribute("data-theme-transparency", "off");
+    await expect(html).toHaveCSS("--theme-opacity", "1");
+
+    await page.getByLabel("Transparent theme").check();
+    await expect(opacity).toBeEnabled();
+    await expect(html).toHaveAttribute("data-theme-transparency", "on");
+    await expect(html).toHaveCSS("--theme-opacity", "0.8");
+
+    await opacity.fill("0.65");
+    await expect(html).toHaveCSS("--theme-opacity", "0.65");
+
+    await page.reload();
+    await page.getByRole("button", { name: "Settings" }).click();
+    await expect(page.getByLabel("Transparent theme")).toBeChecked();
+    await expect(page.getByLabel("Theme opacity")).toHaveValue("0.65");
+    await expect(html).toHaveCSS("--theme-opacity", "0.65");
+  });
+
   test("shows servers section", async ({ page }) => {
     await enableLibraryMode(page);
     await expect(page.getByRole("heading", { name: "Servers" })).toBeVisible();

--- a/frontend/tests/settings.spec.ts
+++ b/frontend/tests/settings.spec.ts
@@ -47,6 +47,16 @@ test.describe("Settings", () => {
     await expect(html).toHaveCSS("--theme-opacity", "0.8");
     await expect(page.locator("body")).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
     await expect(page.locator(".shell")).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (window as any).__wailsWindowCalls?.some(
+            (call: any) =>
+              call.method === "SetBackgroundColour" && JSON.stringify(call.args) === JSON.stringify([0, 0, 0, 0])
+          )
+        )
+      )
+      .toBe(true);
 
     await opacity.fill("0.65");
     await expect(html).toHaveCSS("--theme-opacity", "0.65");

--- a/frontend/tests/settings.spec.ts
+++ b/frontend/tests/settings.spec.ts
@@ -45,6 +45,8 @@ test.describe("Settings", () => {
     await expect(opacity).toBeEnabled();
     await expect(html).toHaveAttribute("data-theme-transparency", "on");
     await expect(html).toHaveCSS("--theme-opacity", "0.8");
+    await expect(page.locator("body")).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+    await expect(page.locator(".shell")).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
 
     await opacity.fill("0.65");
     await expect(html).toHaveCSS("--theme-opacity", "0.65");

--- a/main.go
+++ b/main.go
@@ -140,7 +140,8 @@ func main() {
 		Frameless:        true,
 		MinWidth:         700,
 		MinHeight:        600,
-		BackgroundColour: application.NewRGB(27, 38, 54),
+		BackgroundType:   application.BackgroundTypeTransparent,
+		BackgroundColour: application.NewRGBA(27, 38, 54, 0),
 		URL:              "/",
 	})
 

--- a/patches/wails-gtk4-transparent-window.patch
+++ b/patches/wails-gtk4-transparent-window.patch
@@ -1,0 +1,76 @@
+--- a/pkg/application/linux_cgo.h
++++ b/pkg/application/linux_cgo.h
+@@ -145,6 +145,7 @@
+
+ void window_move_x11(GtkWindow *window, int x, int y);
+ void window_get_position_x11(GtkWindow *window, int *x, int *y);
++void window_set_transparent_gtk4(GtkWindow *window);
+
+ // ============================================================================
+ // Drag and drop (GtkDropTarget for GTK4)
+--- a/pkg/application/linux_cgo.c
++++ b/pkg/application/linux_cgo.c
+@@ -946,6 +946,52 @@
+ #endif
+ }
+
++static void clear_window_opaque_region(GtkWidget *widget) {
++    GtkNative *native = gtk_widget_get_native(widget);
++    if (native == NULL) return;
++
++    GdkSurface *surface = gtk_native_get_surface(native);
++    if (surface == NULL) return;
++
++    cairo_region_t *empty_region = cairo_region_create();
++    gdk_surface_set_opaque_region(surface, empty_region);
++    cairo_region_destroy(empty_region);
++}
++
++static void on_transparent_window_realize(GtkWidget *widget, gpointer user_data) {
++    (void)user_data;
++    clear_window_opaque_region(widget);
++}
++
++void window_set_transparent_gtk4(GtkWindow *window) {
++    static GtkCssProvider *provider = NULL;
++    GtkWidget *widget = GTK_WIDGET(window);
++
++    if (provider == NULL) {
++        provider = gtk_css_provider_new();
++        gtk_css_provider_load_from_string(
++            provider,
++            "window.wails-transparent-window, "
++            "window.wails-transparent-window > * {"
++            "  background: transparent;"
++            "}"
++            "webview {"
++            "  background: transparent;"
++            "}");
++    }
++
++    gtk_style_context_add_provider_for_display(
++        gtk_widget_get_display(widget),
++        GTK_STYLE_PROVIDER(provider),
++        GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
++    gtk_widget_add_css_class(widget, "wails-transparent-window");
++    g_signal_connect_after(widget, "realize", G_CALLBACK(on_transparent_window_realize), NULL);
++
++    if (gtk_widget_get_realized(widget)) {
++        clear_window_opaque_region(widget);
++    }
++}
++
+ // ============================================================================
+ // Window size constraints (max size enforcement for GTK4)
+ // ============================================================================
+--- a/pkg/application/linux_cgo.go
++++ b/pkg/application/linux_cgo.go
+@@ -1286,7 +1286,7 @@
+ }
+
+ func (w *linuxWebviewWindow) setTransparent() {
+-	// GTK4: Transparency via CSS - different from GTK3
++	C.window_set_transparent_gtk4(w.gtkWindow())
+ }
+
+ func (w *linuxWebviewWindow) setBackgroundColour(colour RGBA) {

--- a/scripts/gtk4-webkit-transparency-repro.c
+++ b/scripts/gtk4-webkit-transparency-repro.c
@@ -1,0 +1,116 @@
+#include <gtk/gtk.h>
+#include <webkit/webkit.h>
+#include <string.h>
+
+static gboolean fullscreen = FALSE;
+
+static gboolean on_close_request(GtkWindow *window, gpointer user_data) {
+    (void)window;
+    (void)user_data;
+    g_printerr("[repro] close-request\n");
+    return FALSE;
+}
+
+static void on_destroy(GtkApplication *app) {
+    g_printerr("[repro] destroy\n");
+    g_application_release(G_APPLICATION(app));
+}
+
+static void on_activate(GtkApplication *app, gpointer user_data) {
+    (void)user_data;
+    g_printerr("[repro] activate\n");
+
+    GtkWidget *window = gtk_application_window_new(app);
+    g_application_hold(G_APPLICATION(app));
+    g_signal_connect(window, "close-request", G_CALLBACK(on_close_request), NULL);
+    g_signal_connect_swapped(window, "destroy", G_CALLBACK(on_destroy), app);
+    gtk_window_set_title(GTK_WINDOW(window), "GTK4 WebKit Transparency Repro");
+    gtk_window_set_default_size(GTK_WINDOW(window), 720, 420);
+    gtk_window_set_decorated(GTK_WINDOW(window), FALSE);
+    if (fullscreen) {
+        gtk_window_fullscreen(GTK_WINDOW(window));
+    }
+
+    GtkCssProvider *provider = gtk_css_provider_new();
+    gtk_css_provider_load_from_string(
+        provider,
+        "window, webview { background: transparent; }"
+        ".repro-window { background: transparent; }");
+    gtk_style_context_add_provider_for_display(
+        gtk_widget_get_display(window),
+        GTK_STYLE_PROVIDER(provider),
+        GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+    gtk_widget_add_css_class(window, "repro-window");
+
+    WebKitUserContentManager *manager = webkit_user_content_manager_new();
+    GtkWidget *webview = GTK_WIDGET(g_object_new(
+        WEBKIT_TYPE_WEB_VIEW,
+        "user-content-manager", manager,
+        NULL));
+
+    GdkRGBA transparent = {0.0, 0.0, 0.0, 0.0};
+    webkit_web_view_set_background_color(WEBKIT_WEB_VIEW(webview), &transparent);
+
+    const char *html =
+        "<!doctype html>"
+        "<html>"
+        "<head>"
+        "<meta charset='utf-8'>"
+        "<style>"
+        "html, body {"
+        "  margin: 0;"
+        "  width: 100%;"
+        "  height: 100%;"
+        "  background: transparent;"
+        "  font: 16px system-ui, sans-serif;"
+        "}"
+        ".panel {"
+        "  margin: 48px;"
+        "  padding: 24px;"
+        "  border-radius: 12px;"
+        "  color: white;"
+        "  background: rgba(24, 34, 48, 0.58);"
+        "  border: 1px solid rgba(255, 255, 255, 0.28);"
+        "}"
+        ".hole {"
+        "  margin-top: 20px;"
+        "  height: 120px;"
+        "  border: 2px dashed rgba(255,255,255,0.65);"
+        "  background: transparent;"
+        "}"
+        "</style>"
+        "</head>"
+        "<body>"
+        "<div class='panel'>"
+        "<h1>GTK4 WebKit Transparency Repro</h1>"
+        "<p>The area outside this panel, and the dashed box below, should show the desktop behind the window.</p>"
+        "<div class='hole'></div>"
+        "</div>"
+        "</body>"
+        "</html>";
+
+    webkit_web_view_load_html(WEBKIT_WEB_VIEW(webview), html, "file:///");
+    gtk_window_set_child(GTK_WINDOW(window), webview);
+    gtk_window_present(GTK_WINDOW(window));
+    g_printerr("[repro] presented\n");
+}
+
+int main(int argc, char **argv) {
+    g_printerr("[repro] start\n");
+    int gtk_argc = 1;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--fullscreen") == 0) {
+            fullscreen = TRUE;
+            continue;
+        }
+        argv[gtk_argc++] = argv[i];
+    }
+    argv[gtk_argc] = NULL;
+
+    GtkApplication *app = gtk_application_new("io.github.willfish.forte.TransparencyRepro", G_APPLICATION_DEFAULT_FLAGS);
+    g_signal_connect(app, "activate", G_CALLBACK(on_activate), NULL);
+    int status = g_application_run(G_APPLICATION(app), gtk_argc, argv);
+    g_printerr("[repro] exit %d\n", status);
+    g_object_unref(app);
+    return status;
+}

--- a/scripts/run-gtk4-webkit-transparency-repro.sh
+++ b/scripts/run-gtk4-webkit-transparency-repro.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+cc scripts/gtk4-webkit-transparency-repro.c \
+  -o /tmp/forte-gtk4-webkit-transparency-repro \
+  $(pkg-config --cflags --libs gtk4 webkitgtk-6.0)
+
+exec /tmp/forte-gtk4-webkit-transparency-repro "$@"


### PR DESCRIPTION
## What changed

- Added a theme transparency preference stored alongside the existing frontend theme preference.
- Added Settings controls for enabling transparent theme surfaces and choosing opacity, defaulting to 0.8.
- Applied the opacity setting to the main shell, sidebar, title bar, content area, and now-playing bar.
- Enabled transparent Wails window backing so CSS transparency can reveal the desktop instead of an opaque webview background.
- Added Playwright coverage for the default, toggle, opacity change, and persisted setting behavior.

## Validation

- `npm run check`
- `npx playwright test tests/settings.spec.ts`
- `go test ./...`
- `npm run build`
- `npx playwright test`
