### PR TITLE
Fix Linux tray menu click handling

### DIFF
--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -68,7 +68,8 @@ tasks:
 
         for patch_file in \
           '{{.ROOT_DIR}}/patches/wails-status-notifier-icon-name.patch' \
-          '{{.ROOT_DIR}}/patches/wails-gtk4-transparent-window.patch'
+          '{{.ROOT_DIR}}/patches/wails-gtk4-transparent-window.patch' \
+          '{{.ROOT_DIR}}/patches/wails-status-notifier-click-menu-split.patch'
         do
           if patch -p1 -d "$module_dir" --forward --dry-run < "$patch_file" >/dev/null 2>&1; then
             patch -p1 -d "$module_dir" < "$patch_file"

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
             if pkgs.stdenv.isDarwin then
               "sha256-M356Dg/QaaeitWx7srKTH+Hpht+c/HfHLdSfwaGwJus="
             else
-              "sha256-PgFI1Kw2jw47OARij8R0LXGthSa/LItw5rNdOJCwb3k=";
+              "sha256-XFQDb6cS4pihGShGm1bNCrrfftZOUVjQLcNRrtn5gOY=";
           modBuildPhase = ''
             runHook preBuild
 

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,7 @@
             ${lib.optionalString pkgs.stdenv.isLinux ''
               patch -p1 -d vendor/github.com/wailsapp/wails/v3 < ${./patches/wails-status-notifier-icon-name.patch}
               patch -p1 -d vendor/github.com/wailsapp/wails/v3 < ${./patches/wails-gtk4-transparent-window.patch}
+              patch -p1 -d vendor/github.com/wailsapp/wails/v3 < ${./patches/wails-status-notifier-click-menu-split.patch}
             ''}
 
             mkdir -p vendor

--- a/patches/wails-status-notifier-click-menu-split.patch
+++ b/patches/wails-status-notifier-click-menu-split.patch
@@ -1,0 +1,12 @@
+--- a/pkg/application/systemtray_linux.go
++++ b/pkg/application/systemtray_linux.go
+@@ -719,9 +719,6 @@ func (s *linuxSystemTray) Event(id int32, eventID string, data dbus.Variant, tim
+ 			gtkDispatch(item.menuItem.handleClick)
+ 		}
+ 	case "opened":
+-		if s.parent.clickHandler != nil {
+-			s.parent.clickHandler()
+-		}
+ 		if s.parent.onMenuOpen != nil {
+ 			s.parent.onMenuOpen()
+ 		}

--- a/wails_patches_test.go
+++ b/wails_patches_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestWailsLinuxTrayMenuOpenDoesNotInvokeClickHandlerPatch(t *testing.T) {
+	patch, err := os.ReadFile("patches/wails-status-notifier-click-menu-split.patch")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Contains(patch, []byte("-\t\tif s.parent.clickHandler != nil {")) ||
+		!bytes.Contains(patch, []byte("-\t\t\ts.parent.clickHandler()")) {
+		t.Fatal("patch must remove the left-click handler from the DBus menu opened event")
+	}
+
+	if !bytes.Contains(patch, []byte("case \"opened\":")) ||
+		!bytes.Contains(patch, []byte("s.parent.onMenuOpen")) {
+		t.Fatal("patch must preserve the DBus menu opened callback path")
+	}
+}


### PR DESCRIPTION
## Summary
- add a Wails Linux StatusNotifier patch so DBus menu-open events no longer invoke the tray left-click handler
- wire the patch into both local Taskfile builds and the Nix build
- add a regression test that guards the local Wails patch contract

## Root cause
On Linux, Wails handled the DBus menu `opened` event by calling `s.parent.clickHandler()`. On COSMIC, opening the exported StatusNotifier menu can emit that menu-open event, so one tray interaction could both toggle Forte and open the menu. The menu-open event should only notify menu-open callbacks; left-click toggle remains handled by StatusNotifier `Activate`.

## Validation
- watched the new regression test fail before the patch
- go test -tags nocgo ./... -run TestWailsLinuxTrayMenuOpenDoesNotInvokeClickHandlerPatch
- go test -tags nocgo ./...
- task build
- git diff --check
- nix build .#forte