### PR TITLE
BAU: Add configurable diagnostic logging

### DIFF
--- a/frontend/bindings/github.com/willfish/forte/models.ts
+++ b/frontend/bindings/github.com/willfish/forte/models.ts
@@ -117,6 +117,8 @@ export class AppPreferencesJSON {
     "startLastStation": boolean;
     "autoReconnect": boolean;
     "showTitlebar": boolean;
+    "logLevel": string;
+    "logFilePath": string;
 
     /** Creates a new AppPreferencesJSON instance. */
     constructor($$source: Partial<AppPreferencesJSON> = {}) {
@@ -131,6 +133,12 @@ export class AppPreferencesJSON {
         }
         if (!("showTitlebar" in $$source)) {
             this["showTitlebar"] = false;
+        }
+        if (!("logLevel" in $$source)) {
+            this["logLevel"] = "";
+        }
+        if (!("logFilePath" in $$source)) {
+            this["logFilePath"] = "";
         }
 
         Object.assign(this, $$source);

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -85,6 +85,7 @@
         autoReconnect: next.autoReconnect,
         showTitlebar: next.showTitlebar,
         logLevel: next.logLevel,
+        logFilePath: next.logFilePath,
       });
       await loadAppPreferences();
     } catch {

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -26,7 +26,17 @@
     startLastStation: true,
     autoReconnect: true,
     showTitlebar: false,
+    logLevel: 'warn',
+    logFilePath: '',
   });
+
+  const logLevelOptions: { value: string; label: string; description: string }[] = [
+    { value: 'error', label: 'Errors only', description: 'Log failures and critical issues' },
+    { value: 'warn', label: 'Normal', description: 'Default — warnings, errors, and legacy diagnostic lines' },
+    { value: 'info', label: 'Detailed', description: 'More library and sync messages' },
+    { value: 'debug', label: 'Verbose', description: 'Everything, including playback and tray debug lines' },
+    { value: 'off', label: 'Off', description: 'Disable file logging (crash.log is still written)' },
+  ];
 
   $effect(() => {
     return onPreferenceChange((p) => { preference = p; });
@@ -45,6 +55,8 @@
         startLastStation: Boolean(prefs?.startLastStation),
         autoReconnect: Boolean(prefs?.autoReconnect),
         showTitlebar: Boolean(prefs?.showTitlebar),
+        logLevel: prefs?.logLevel || 'warn',
+        logFilePath: prefs?.logFilePath || '',
       };
       setLibraryEnabled(appPreferences.libraryEnabled);
       setTitlebarEnabled(appPreferences.showTitlebar);
@@ -58,20 +70,34 @@
     loadAppPreferences();
   });
 
-  async function saveAppPreference(key: keyof typeof appPreferences, value: boolean) {
-    const next = { ...appPreferences, [key]: value };
+  async function saveAppPreferences(next: typeof appPreferences) {
     appPreferences = next;
-    if (key === 'libraryEnabled') {
-      setLibraryEnabled(value);
+    if ('libraryEnabled' in next) {
+      setLibraryEnabled(next.libraryEnabled);
     }
-    if (key === 'showTitlebar') {
-      setTitlebarEnabled(value);
+    if ('showTitlebar' in next) {
+      setTitlebarEnabled(next.showTitlebar);
     }
     try {
-      await LibraryService.SaveAppPreferences(next);
+      await LibraryService.SaveAppPreferences({
+        libraryEnabled: next.libraryEnabled,
+        startLastStation: next.startLastStation,
+        autoReconnect: next.autoReconnect,
+        showTitlebar: next.showTitlebar,
+        logLevel: next.logLevel,
+      });
+      await loadAppPreferences();
     } catch {
       await loadAppPreferences();
     }
+  }
+
+  async function saveAppPreference(key: 'libraryEnabled' | 'startLastStation' | 'autoReconnect' | 'showTitlebar', value: boolean) {
+    await saveAppPreferences({ ...appPreferences, [key]: value });
+  }
+
+  async function saveLogLevel(level: string) {
+    await saveAppPreferences({ ...appPreferences, logLevel: level });
   }
 
   const themeModeOptions: { value: ThemeMode; label: string; description: string }[] = [
@@ -458,6 +484,28 @@
           onchange={(e) => saveAppPreference('libraryEnabled', (e.target as HTMLInputElement).checked)}
         />
       </label>
+      <div class="preference-row log-level-row">
+        <span>
+          <span class="option-label">Diagnostic logging</span>
+          <span class="option-desc">
+            {#each logLevelOptions.filter((o) => o.value === appPreferences.logLevel) as opt}
+              {opt.description}
+            {/each}
+          </span>
+          {#if appPreferences.logFilePath}
+            <span class="log-path">{appPreferences.logFilePath}</span>
+          {/if}
+        </span>
+        <select
+          class="log-level-select"
+          value={appPreferences.logLevel}
+          onchange={(e) => saveLogLevel((e.target as HTMLSelectElement).value)}
+        >
+          {#each logLevelOptions as opt}
+            <option value={opt.value}>{opt.label}</option>
+          {/each}
+        </select>
+      </div>
     </div>
   </section>
 
@@ -765,6 +813,28 @@
     display: flex;
     flex-direction: column;
     min-width: 0;
+  }
+
+  .log-level-row {
+    align-items: flex-start;
+  }
+
+  .log-path {
+    display: block;
+    margin-top: 0.35rem;
+    font-size: 0.75rem;
+    color: var(--text-muted, #888);
+    font-family: ui-monospace, monospace;
+    word-break: break-all;
+  }
+
+  .log-level-select {
+    min-width: 9rem;
+    padding: 0.35rem 0.5rem;
+    border-radius: 6px;
+    border: 1px solid var(--border-subtle, #333);
+    background: var(--surface-raised, #1a1a1a);
+    color: inherit;
   }
 
   .preference-row input {

--- a/internal/library/db.go
+++ b/internal/library/db.go
@@ -101,4 +101,5 @@ var migrations = []migration{
 	{version: 11, sql: migration011},
 	{version: 12, sql: migration012},
 	{version: 13, sql: migration013},
+	{version: 14, sql: migration014},
 }

--- a/internal/library/radio_favourites.go
+++ b/internal/library/radio_favourites.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+
+	"github.com/willfish/forte/internal/logx"
 )
 
 // RadioFavourite represents a saved radio station.
@@ -47,6 +49,7 @@ type AppPreferences struct {
 	StartLastStation bool
 	AutoReconnect    bool
 	ShowTitlebar     bool
+	LogLevel         string
 }
 
 // AddRadioFavourite saves a radio station to favourites.
@@ -254,32 +257,38 @@ func (db *DB) ClearRadioHistory() error {
 // GetAppPreferences returns product-level preferences.
 func (db *DB) GetAppPreferences() (AppPreferences, error) {
 	var libraryEnabled, startLastStation, autoReconnect, showTitlebar int
+	var logLevel string
 	err := db.QueryRow(
-		`SELECT library_enabled, start_last_station, auto_reconnect, show_titlebar
+		`SELECT library_enabled, start_last_station, auto_reconnect, show_titlebar, log_level
 		 FROM app_preferences WHERE id = 1`,
-	).Scan(&libraryEnabled, &startLastStation, &autoReconnect, &showTitlebar)
+	).Scan(&libraryEnabled, &startLastStation, &autoReconnect, &showTitlebar, &logLevel)
 	if err != nil {
 		return AppPreferences{}, fmt.Errorf("get app preferences: %w", err)
+	}
+	if logLevel == "" {
+		logLevel = "warn"
 	}
 	return AppPreferences{
 		LibraryEnabled:   libraryEnabled != 0,
 		StartLastStation: startLastStation != 0,
 		AutoReconnect:    autoReconnect != 0,
 		ShowTitlebar:     showTitlebar != 0,
+		LogLevel:         logLevel,
 	}, nil
 }
 
 // SaveAppPreferences stores product-level preferences.
 func (db *DB) SaveAppPreferences(p AppPreferences) error {
 	_, err := db.Exec(
-		`INSERT INTO app_preferences (id, library_enabled, start_last_station, auto_reconnect, show_titlebar)
-		 VALUES (1, ?, ?, ?, ?)
+		`INSERT INTO app_preferences (id, library_enabled, start_last_station, auto_reconnect, show_titlebar, log_level)
+		 VALUES (1, ?, ?, ?, ?, ?)
 		 ON CONFLICT(id) DO UPDATE SET
 			library_enabled = excluded.library_enabled,
 			start_last_station = excluded.start_last_station,
 			auto_reconnect = excluded.auto_reconnect,
-			show_titlebar = excluded.show_titlebar`,
-		boolToInt(p.LibraryEnabled), boolToInt(p.StartLastStation), boolToInt(p.AutoReconnect), boolToInt(p.ShowTitlebar),
+			show_titlebar = excluded.show_titlebar,
+			log_level = excluded.log_level`,
+		boolToInt(p.LibraryEnabled), boolToInt(p.StartLastStation), boolToInt(p.AutoReconnect), boolToInt(p.ShowTitlebar), normalizeLogLevel(p.LogLevel),
 	)
 	if err != nil {
 		return fmt.Errorf("save app preferences: %w", err)
@@ -298,4 +307,8 @@ func boolToInt(v bool) int {
 		return 1
 	}
 	return 0
+}
+
+func normalizeLogLevel(v string) string {
+	return logx.LevelName(logx.ParseLevel(v))
 }

--- a/internal/library/radio_favourites_test.go
+++ b/internal/library/radio_favourites_test.go
@@ -298,7 +298,7 @@ func TestAppPreferencesRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAppPreferences: %v", err)
 	}
-	if prefs.LibraryEnabled || !prefs.StartLastStation || !prefs.AutoReconnect || prefs.ShowTitlebar {
+	if prefs.LibraryEnabled || !prefs.StartLastStation || !prefs.AutoReconnect || prefs.ShowTitlebar || prefs.LogLevel != "warn" {
 		t.Fatalf("unexpected default preferences: %#v", prefs)
 	}
 
@@ -307,6 +307,7 @@ func TestAppPreferencesRoundTrip(t *testing.T) {
 		StartLastStation: false,
 		AutoReconnect:    false,
 		ShowTitlebar:     true,
+		LogLevel:         "debug",
 	}
 	if err := db.SaveAppPreferences(want); err != nil {
 		t.Fatalf("SaveAppPreferences: %v", err)

--- a/internal/library/schema.go
+++ b/internal/library/schema.go
@@ -226,6 +226,10 @@ const migration012 = `
 ALTER TABLE app_preferences ADD COLUMN show_titlebar INTEGER NOT NULL DEFAULT 0;
 `
 
+const migration014 = `
+ALTER TABLE app_preferences ADD COLUMN log_level TEXT NOT NULL DEFAULT 'warn';
+`
+
 const migration013 = `
 DROP TABLE fts_tracks;
 

--- a/internal/logx/level.go
+++ b/internal/logx/level.go
@@ -1,0 +1,57 @@
+package logx
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Level names persisted in settings and FORTE_LOG_LEVEL.
+const (
+	LevelOff   = "off"
+	LevelError = "error"
+	LevelWarn  = "warn"
+	LevelInfo  = "info"
+	LevelDebug = "debug"
+)
+
+// ParseLevel maps a user-facing level string to slog.Level.
+// Unknown values default to warn.
+func ParseLevel(name string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case LevelOff:
+		return slog.LevelError + 4
+	case LevelError:
+		return slog.LevelError
+	case LevelInfo:
+		return slog.LevelInfo
+	case LevelDebug:
+		return slog.LevelDebug
+	default:
+		return slog.LevelWarn
+	}
+}
+
+// LevelName returns the canonical name for a slog level.
+func LevelName(level slog.Level) string {
+	switch {
+	case level >= slog.LevelError+4:
+		return LevelOff
+	case level >= slog.LevelError:
+		return LevelError
+	case level >= slog.LevelWarn:
+		return LevelWarn
+	case level >= slog.LevelInfo:
+		return LevelInfo
+	default:
+		return LevelDebug
+	}
+}
+
+// StartupLevel returns FORTE_LOG_LEVEL when set, otherwise warn.
+func StartupLevel() string {
+	if v := strings.TrimSpace(os.Getenv("FORTE_LOG_LEVEL")); v != "" {
+		return v
+	}
+	return LevelWarn
+}

--- a/internal/logx/level_test.go
+++ b/internal/logx/level_test.go
@@ -1,0 +1,26 @@
+package logx
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestParseLevel(t *testing.T) {
+	tests := []struct {
+		in   string
+		want slog.Level
+	}{
+		{LevelOff, slog.LevelError + 4},
+		{LevelError, slog.LevelError},
+		{LevelWarn, slog.LevelWarn},
+		{LevelInfo, slog.LevelInfo},
+		{LevelDebug, slog.LevelDebug},
+		{"", slog.LevelWarn},
+		{"LOUD", slog.LevelWarn},
+	}
+	for _, tc := range tests {
+		if got := ParseLevel(tc.in); got != tc.want {
+			t.Fatalf("ParseLevel(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -53,7 +53,7 @@ func Configure(levelName string) error {
 		writers = append(writers, os.Stderr)
 	}
 
-	var w io.Writer = io.Discard
+	var w = io.Discard
 	if len(writers) == 1 {
 		w = writers[0]
 	} else if len(writers) > 1 {

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -1,0 +1,117 @@
+package logx
+
+import (
+	"io"
+	"log"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var (
+	mu       sync.Mutex
+	logger   = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logFile  *os.File
+	logPath  string
+	level    = slog.LevelWarn
+	stderrOn = true
+)
+
+// Configure sets the global log level and writers.
+// Logs are appended to ~/.config/forte/forte.log (alongside crash.log).
+// When stderrOn, the same records are also written to stderr if the level allows.
+func Configure(levelName string) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	level = ParseLevel(levelName)
+
+	path, err := logFilePath()
+	if err != nil {
+		return err
+	}
+	logPath = path
+
+	if logFile != nil {
+		_ = logFile.Close()
+		logFile = nil
+	}
+
+	var writers []io.Writer
+	if level < slog.LevelError+4 {
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return err
+		}
+		logFile = f
+		writers = append(writers, f)
+	}
+
+	if stderrOn && level < slog.LevelError+4 {
+		writers = append(writers, os.Stderr)
+	}
+
+	var w io.Writer = io.Discard
+	if len(writers) == 1 {
+		w = writers[0]
+	} else if len(writers) > 1 {
+		w = io.MultiWriter(writers...)
+	}
+
+	handler := slog.NewTextHandler(w, &slog.HandlerOptions{Level: level})
+	logger = slog.New(handler)
+	slog.SetDefault(logger)
+	log.SetOutput(&legacyWriter{logger: logger})
+	log.SetFlags(0)
+
+	return nil
+}
+
+// Logger returns the configured application logger.
+func Logger() *slog.Logger {
+	mu.Lock()
+	defer mu.Unlock()
+	return logger
+}
+
+// SlogLevel returns the current minimum slog level.
+func SlogLevel() slog.Level {
+	mu.Lock()
+	defer mu.Unlock()
+	return level
+}
+
+// LevelString returns the canonical name of the active level.
+func LevelString() string {
+	return LevelName(SlogLevel())
+}
+
+// Path returns the log file path (empty until Configure succeeds).
+func Path() string {
+	mu.Lock()
+	defer mu.Unlock()
+	return logPath
+}
+
+func logFilePath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "forte", "forte.log"), nil
+}
+
+type legacyWriter struct {
+	logger *slog.Logger
+}
+
+func (w *legacyWriter) Write(p []byte) (int, error) {
+	msg := strings.TrimSpace(string(p))
+	if msg == "" {
+		return len(p), nil
+	}
+	w.logger.Warn(msg)
+	return len(p), nil
+}

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/browser"
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/willfish/forte/internal/artistinfo"
+	"github.com/willfish/forte/internal/logx"
 	"github.com/willfish/forte/internal/library"
 	"github.com/willfish/forte/internal/radio"
 	"github.com/willfish/forte/internal/scrobbling/lastfm"
@@ -58,6 +59,8 @@ func (s *LibraryService) ServiceStartup(_ context.Context, _ application.Service
 	if err != nil {
 		return fmt.Errorf("load preferences: %w", err)
 	}
+	applyLogging(prefs.LogLevel)
+	logx.Logger().Info("logging configured", "level", prefs.LogLevel, "path", logx.Path())
 
 	s.lifecycleMu.Lock()
 	if prefs.LibraryEnabled {
@@ -1091,10 +1094,12 @@ type RadioCustomStationJSON struct {
 
 // AppPreferencesJSON is the JSON-friendly app preference type exposed to the frontend.
 type AppPreferencesJSON struct {
-	LibraryEnabled   bool `json:"libraryEnabled"`
-	StartLastStation bool `json:"startLastStation"`
-	AutoReconnect    bool `json:"autoReconnect"`
-	ShowTitlebar     bool `json:"showTitlebar"`
+	LibraryEnabled   bool   `json:"libraryEnabled"`
+	StartLastStation bool   `json:"startLastStation"`
+	AutoReconnect    bool   `json:"autoReconnect"`
+	ShowTitlebar     bool   `json:"showTitlebar"`
+	LogLevel         string `json:"logLevel"`
+	LogFilePath      string `json:"logFilePath"`
 }
 
 // GetRadioFavourites returns all saved radio stations.
@@ -1254,6 +1259,8 @@ func (s *LibraryService) GetAppPreferences() (AppPreferencesJSON, error) {
 		StartLastStation: prefs.StartLastStation,
 		AutoReconnect:    prefs.AutoReconnect,
 		ShowTitlebar:     prefs.ShowTitlebar,
+		LogLevel:         prefs.LogLevel,
+		LogFilePath:      logx.Path(),
 	}, nil
 }
 
@@ -1268,15 +1275,21 @@ func (s *LibraryService) SaveAppPreferences(prefs AppPreferencesJSON) error {
 		return err
 	}
 
+	logLevel := prefs.LogLevel
+	if logLevel == "" {
+		logLevel = logx.LevelWarn
+	}
 	next := library.AppPreferences{
 		LibraryEnabled:   prefs.LibraryEnabled,
 		StartLastStation: prefs.StartLastStation,
 		AutoReconnect:    prefs.AutoReconnect,
 		ShowTitlebar:     prefs.ShowTitlebar,
+		LogLevel:         logLevel,
 	}
 	if err := s.db.SaveAppPreferences(next); err != nil {
 		return err
 	}
+	applyLogging(next.LogLevel)
 
 	s.lifecycleMu.Lock()
 	defer s.lifecycleMu.Unlock()

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"log/slog"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/willfish/forte/internal/logx"
+)
+
+var forteApp *application.App
+
+func initLogging(level string) {
+	if err := logx.Configure(level); err != nil {
+		// Last resort: stderr only via slog default.
+		slog.Error("configure logging", "err", err)
+	}
+}
+
+func applyLogging(level string) {
+	if err := logx.Configure(level); err != nil {
+		slog.Error("reconfigure logging", "err", err, "level", level)
+		return
+	}
+	if forteApp != nil {
+		forteApp.Logger = logx.Logger()
+	}
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/wailsapp/wails/v3/pkg/events"
+	"github.com/willfish/forte/internal/logx"
 )
 
 //go:embed all:frontend/dist
@@ -93,6 +94,8 @@ func main() {
 		defer func() { _ = f.Close() }()
 	}
 
+	initLogging(logx.StartupLevel())
+
 	ps := &PlayerService{}
 	ls := &LibraryService{}
 
@@ -107,6 +110,8 @@ func main() {
 	app := application.New(application.Options{
 		Name:        "Forte",
 		Description: "A modern music player",
+		Logger:      logx.Logger(),
+		LogLevel:    logx.SlogLevel(),
 		Linux: application.LinuxOptions{
 			ProgramName: appID,
 		},
@@ -118,6 +123,7 @@ func main() {
 			Handler: application.AssetFileServerFS(assets),
 		},
 	})
+	forteApp = app
 
 	app.SetIcon(appIcon)
 


### PR DESCRIPTION
### What?

- [x] Add `internal/logx` — file + stderr logging with off/error/warn/info/debug levels
- [x] Persist `log_level` in app preferences (migration 14)
- [x] Settings control under Application → Diagnostic logging (shows log file path)
- [x] Bridge legacy `log.Printf` to slog at warn level
- [x] Wire Wails `Logger` / `LogLevel` in production builds (no longer discarded)
- [x] Reload logging when preferences change; honour `FORTE_LOG_LEVEL` at startup

### Why?

Production builds discarded Wails logs and `log.Printf` only appeared when running from a terminal. Configurable file logging makes it possible to diagnose tray, playback, and library issues from `~/.config/forte/forte.log` without rebuilding.

### Risk

**Risk level:** 🟢

**Reason for rating:** Logging-only change; default level is warn; no playback or library behaviour changes.