### PR TITLE
Add radio station detail page with homepage links

### DIFF
--- a/frontend/bindings/github.com/willfish/forte/libraryservice.ts
+++ b/frontend/bindings/github.com/willfish/forte/libraryservice.ts
@@ -17,8 +17,8 @@ import * as $models from "./models.js";
 /**
  * AddCustomRadioStation saves a user-defined radio station.
  */
-export function AddCustomRadioStation(name: string, streamURL: string, faviconURL: string, tags: string): $CancellablePromise<$models.RadioCustomStationJSON> {
-    return $Call.ByID(3781401643, name, streamURL, faviconURL, tags).then(($result: any) => {
+export function AddCustomRadioStation(name: string, streamURL: string, faviconURL: string, homepage: string, tags: string): $CancellablePromise<$models.RadioCustomStationJSON> {
+    return $Call.ByID(3781401643, name, streamURL, faviconURL, homepage, tags).then(($result: any) => {
         return $$createType0($result);
     });
 }
@@ -26,8 +26,8 @@ export function AddCustomRadioStation(name: string, streamURL: string, faviconUR
 /**
  * AddRadioFavourite saves a radio station to favourites.
  */
-export function AddRadioFavourite(stationUUID: string, name: string, streamURL: string, faviconURL: string, homepage: string, tags: string): $CancellablePromise<void> {
-    return $Call.ByID(3744144887, stationUUID, name, streamURL, faviconURL, homepage, tags);
+export function AddRadioFavourite(stationUUID: string, name: string, streamURL: string, faviconURL: string, homepage: string, tags: string, country: string, codec: string, bitrate: number): $CancellablePromise<void> {
+    return $Call.ByID(3744144887, stationUUID, name, streamURL, faviconURL, homepage, tags, country, codec, bitrate);
 }
 
 /**
@@ -193,6 +193,13 @@ export function GetPlaylists(): $CancellablePromise<$models.Playlist[]> {
     return $Call.ByID(1524576557).then(($result: any) => {
         return $$createType12($result);
     });
+}
+
+/**
+ * GetRadioFavouritePinned reports whether a favourite station is pinned.
+ */
+export function GetRadioFavouritePinned(stationUUID: string): $CancellablePromise<boolean> {
+    return $Call.ByID(4094481906, stationUUID);
 }
 
 /**

--- a/frontend/bindings/github.com/willfish/forte/libraryservice.ts
+++ b/frontend/bindings/github.com/willfish/forte/libraryservice.ts
@@ -26,8 +26,8 @@ export function AddCustomRadioStation(name: string, streamURL: string, faviconUR
 /**
  * AddRadioFavourite saves a radio station to favourites.
  */
-export function AddRadioFavourite(stationUUID: string, name: string, streamURL: string, faviconURL: string, tags: string): $CancellablePromise<void> {
-    return $Call.ByID(3744144887, stationUUID, name, streamURL, faviconURL, tags);
+export function AddRadioFavourite(stationUUID: string, name: string, streamURL: string, faviconURL: string, homepage: string, tags: string): $CancellablePromise<void> {
+    return $Call.ByID(3744144887, stationUUID, name, streamURL, faviconURL, homepage, tags);
 }
 
 /**
@@ -214,6 +214,15 @@ export function GetRadioHistory(limit: number): $CancellablePromise<$models.Radi
 }
 
 /**
+ * GetRadioStationByUUID returns full station metadata, fetching from RadioBrowser when possible.
+ */
+export function GetRadioStationByUUID(stationUUID: string): $CancellablePromise<$models.RadioStationJSON> {
+    return $Call.ByID(4150278773, stationUUID).then(($result: any) => {
+        return $$createType17($result);
+    });
+}
+
+/**
  * GetRadioStationsByCountry returns radio stations matching a country.
  */
 export function GetRadioStationsByCountry(country: string, limit: number): $CancellablePromise<$models.RadioStationJSON[]> {
@@ -340,6 +349,13 @@ export function IsRadioFavourite(stationUUID: string): $CancellablePromise<boole
  */
 export function MoveTrackInPlaylist(playlistID: number, fromPos: number, toPos: number): $CancellablePromise<void> {
     return $Call.ByID(465154155, playlistID, fromPos, toPos);
+}
+
+/**
+ * OpenURL opens an http(s) URL in the system browser.
+ */
+export function OpenURL(rawURL: string): $CancellablePromise<void> {
+    return $Call.ByID(1380764543, rawURL);
 }
 
 /**

--- a/frontend/bindings/github.com/willfish/forte/models.ts
+++ b/frontend/bindings/github.com/willfish/forte/models.ts
@@ -407,6 +407,7 @@ export class RadioCustomStationJSON {
     "name": string;
     "streamUrl": string;
     "faviconUrl": string;
+    "homepage": string;
     "tags": string;
     "createdAt": string;
     "updatedAt": string;
@@ -424,6 +425,9 @@ export class RadioCustomStationJSON {
         }
         if (!("faviconUrl" in $$source)) {
             this["faviconUrl"] = "";
+        }
+        if (!("homepage" in $$source)) {
+            this["homepage"] = "";
         }
         if (!("tags" in $$source)) {
             this["tags"] = "";
@@ -455,6 +459,7 @@ export class RadioFavouriteJSON {
     "name": string;
     "streamUrl": string;
     "faviconUrl": string;
+    "homepage": string;
     "tags": string;
     "addedAt": string;
     "pinned": boolean;
@@ -472,6 +477,9 @@ export class RadioFavouriteJSON {
         }
         if (!("faviconUrl" in $$source)) {
             this["faviconUrl"] = "";
+        }
+        if (!("homepage" in $$source)) {
+            this["homepage"] = "";
         }
         if (!("tags" in $$source)) {
             this["tags"] = "";
@@ -503,6 +511,7 @@ export class RadioHistoryJSON {
     "name": string;
     "streamUrl": string;
     "faviconUrl": string;
+    "homepage": string;
     "tags": string;
     "trackTitle": string;
     "playCount": number;
@@ -522,6 +531,9 @@ export class RadioHistoryJSON {
         }
         if (!("faviconUrl" in $$source)) {
             this["faviconUrl"] = "";
+        }
+        if (!("homepage" in $$source)) {
+            this["homepage"] = "";
         }
         if (!("tags" in $$source)) {
             this["tags"] = "";
@@ -558,6 +570,7 @@ export class RadioStationJSON {
     "uuid": string;
     "name": string;
     "streamUrl": string;
+    "homepage": string;
     "favicon": string;
     "country": string;
     "tags": string;
@@ -576,6 +589,9 @@ export class RadioStationJSON {
         }
         if (!("streamUrl" in $$source)) {
             this["streamUrl"] = "";
+        }
+        if (!("homepage" in $$source)) {
+            this["homepage"] = "";
         }
         if (!("favicon" in $$source)) {
             this["favicon"] = "";

--- a/frontend/bindings/github.com/willfish/forte/models.ts
+++ b/frontend/bindings/github.com/willfish/forte/models.ts
@@ -408,6 +408,9 @@ export class RadioCustomStationJSON {
     "streamUrl": string;
     "faviconUrl": string;
     "homepage": string;
+    "country": string;
+    "codec": string;
+    "bitrate": number;
     "tags": string;
     "createdAt": string;
     "updatedAt": string;
@@ -428,6 +431,15 @@ export class RadioCustomStationJSON {
         }
         if (!("homepage" in $$source)) {
             this["homepage"] = "";
+        }
+        if (!("country" in $$source)) {
+            this["country"] = "";
+        }
+        if (!("codec" in $$source)) {
+            this["codec"] = "";
+        }
+        if (!("bitrate" in $$source)) {
+            this["bitrate"] = 0;
         }
         if (!("tags" in $$source)) {
             this["tags"] = "";
@@ -460,6 +472,9 @@ export class RadioFavouriteJSON {
     "streamUrl": string;
     "faviconUrl": string;
     "homepage": string;
+    "country": string;
+    "codec": string;
+    "bitrate": number;
     "tags": string;
     "addedAt": string;
     "pinned": boolean;
@@ -480,6 +495,15 @@ export class RadioFavouriteJSON {
         }
         if (!("homepage" in $$source)) {
             this["homepage"] = "";
+        }
+        if (!("country" in $$source)) {
+            this["country"] = "";
+        }
+        if (!("codec" in $$source)) {
+            this["codec"] = "";
+        }
+        if (!("bitrate" in $$source)) {
+            this["bitrate"] = 0;
         }
         if (!("tags" in $$source)) {
             this["tags"] = "";
@@ -512,6 +536,9 @@ export class RadioHistoryJSON {
     "streamUrl": string;
     "faviconUrl": string;
     "homepage": string;
+    "country": string;
+    "codec": string;
+    "bitrate": number;
     "tags": string;
     "trackTitle": string;
     "playCount": number;
@@ -534,6 +561,15 @@ export class RadioHistoryJSON {
         }
         if (!("homepage" in $$source)) {
             this["homepage"] = "";
+        }
+        if (!("country" in $$source)) {
+            this["country"] = "";
+        }
+        if (!("codec" in $$source)) {
+            this["codec"] = "";
+        }
+        if (!("bitrate" in $$source)) {
+            this["bitrate"] = 0;
         }
         if (!("tags" in $$source)) {
             this["tags"] = "";

--- a/frontend/bindings/github.com/willfish/forte/playerservice.ts
+++ b/frontend/bindings/github.com/willfish/forte/playerservice.ts
@@ -181,8 +181,8 @@ export function PlayRadio(stationName: string, streamURL: string, artworkURL: st
 /**
  * PlayRadioStation starts playback of a radio stream with stable station metadata.
  */
-export function PlayRadioStation(stationUUID: string, stationName: string, streamURL: string, artworkURL: string, homepage: string, tags: string): $CancellablePromise<void> {
-    return $Call.ByID(3331506535, stationUUID, stationName, streamURL, artworkURL, homepage, tags);
+export function PlayRadioStation(stationUUID: string, stationName: string, streamURL: string, artworkURL: string, homepage: string, tags: string, country: string, codec: string, bitrate: number): $CancellablePromise<void> {
+    return $Call.ByID(3331506535, stationUUID, stationName, streamURL, artworkURL, homepage, tags, country, codec, bitrate);
 }
 
 /**

--- a/frontend/bindings/github.com/willfish/forte/playerservice.ts
+++ b/frontend/bindings/github.com/willfish/forte/playerservice.ts
@@ -181,8 +181,8 @@ export function PlayRadio(stationName: string, streamURL: string, artworkURL: st
 /**
  * PlayRadioStation starts playback of a radio stream with stable station metadata.
  */
-export function PlayRadioStation(stationUUID: string, stationName: string, streamURL: string, artworkURL: string, tags: string): $CancellablePromise<void> {
-    return $Call.ByID(3331506535, stationUUID, stationName, streamURL, artworkURL, tags);
+export function PlayRadioStation(stationUUID: string, stationName: string, streamURL: string, artworkURL: string, homepage: string, tags: string): $CancellablePromise<void> {
+    return $Call.ByID(3331506535, stationUUID, stationName, streamURL, artworkURL, homepage, tags);
 }
 
 /**

--- a/frontend/src/NowPlayingBar.svelte
+++ b/frontend/src/NowPlayingBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { PlayerService } from "../bindings/github.com/willfish/forte";
   import { onPlaybackStatusChange, refreshPlaybackStatus } from './lib/playback';
+  import { openRadioStation } from './lib/stores';
   import type { PlaybackStatus, RepeatMode } from './lib/types';
   import Icon from './lib/Icon.svelte';
 
@@ -20,6 +21,7 @@
   let volumeBeforeMute = $state(100);
   let radioMode = $state(false);
   let radioStation = $state('');
+  let radioUuid = $state('');
   let radioArtwork = $state('');
 
   $effect(() => {
@@ -39,6 +41,7 @@
     repeatMode = s.repeat;
     radioMode = s.radioMode;
     radioStation = s.radioStation;
+    radioUuid = s.radioUuid;
     radioArtwork = s.radioArtwork;
   }
 
@@ -122,7 +125,13 @@
     <div class="meta">
       {#if radioMode && radioStation}
         <span class="title">{title || radioStation}</span>
-        <span class="artist">{title ? radioStation : 'Radio'}</span>
+        {#if radioUuid}
+          <button type="button" class="artist station-link" onclick={() => openRadioStation(radioUuid, { name: radioStation })}>
+            {title ? radioStation : 'View station'}
+          </button>
+        {:else}
+          <span class="artist">Radio</span>
+        {/if}
       {:else if !isStopped && title}
         <span class="title">{title}</span>
         <span class="artist">{artist}{album ? ` - ${album}` : ''}</span>
@@ -280,6 +289,19 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .station-link {
+    padding: 0;
+    border: none;
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .station-link:hover {
+    color: var(--accent);
+    text-decoration: underline;
   }
 
   .controls {

--- a/frontend/src/RadioStationView.svelte
+++ b/frontend/src/RadioStationView.svelte
@@ -218,6 +218,7 @@
   {:else if error && !station}
     <div class="error-state" role="alert">{error}</div>
   {:else if station}
+    {@const detail = station}
     <div class="station-header">
       {#if proxiedIcon}
         <img class="station-art" src={proxiedIcon} alt="" />
@@ -260,23 +261,23 @@
       {#if linkMessage}
         <p class="link-message" role="status">{linkMessage}</p>
       {/if}
-      {#if station.homepage}
+      {#if detail.homepage}
         <div class="link-row">
           <span class="link-label">Website</span>
-          <a class="link-url" href={station.homepage} onclick={(e) => { e.preventDefault(); void openLink(station.homepage); }}>
-            {station.homepage}
+          <a class="link-url" href={detail.homepage} onclick={(e) => { e.preventDefault(); void openLink(detail.homepage); }}>
+            {detail.homepage}
           </a>
-          <button class="link-action" type="button" onclick={() => copyLink(station.homepage, 'Website')}>Copy</button>
+          <button class="link-action" type="button" onclick={() => copyLink(detail.homepage, 'Website')}>Copy</button>
         </div>
       {/if}
-      {#if station.streamUrl}
+      {#if detail.streamUrl}
         <div class="link-row">
           <span class="link-label">Stream</span>
-          <span class="link-url mono">{station.streamUrl}</span>
-          <button class="link-action" type="button" onclick={() => copyLink(station.streamUrl, 'Stream URL')}>Copy</button>
+          <span class="link-url mono">{detail.streamUrl}</span>
+          <button class="link-action" type="button" onclick={() => copyLink(detail.streamUrl, 'Stream URL')}>Copy</button>
         </div>
       {/if}
-      {#if !station.homepage && !station.streamUrl}
+      {#if !detail.homepage && !detail.streamUrl}
         <p class="empty-links">No links available for this station.</p>
       {/if}
     </section>

--- a/frontend/src/RadioStationView.svelte
+++ b/frontend/src/RadioStationView.svelte
@@ -1,0 +1,544 @@
+<script lang="ts">
+  import { LibraryService, PlayerService } from "../bindings/github.com/willfish/forte";
+  import { refreshPlaybackStatus, onPlaybackStatusChange } from './lib/playback';
+  import type { RadioStationHint } from './lib/stores';
+  import { browseRadioTag } from './lib/stores';
+
+  type StationDetail = {
+    uuid: string;
+    name: string;
+    streamUrl: string;
+    homepage: string;
+    favicon: string;
+    country: string;
+    tags: string;
+    bitrate: number;
+    codec: string;
+    votes: number;
+    clicks: number;
+  };
+
+  const {
+    stationUuid,
+    hint = null,
+    onback,
+  }: {
+    stationUuid: string;
+    hint?: RadioStationHint | null;
+    onback: () => void;
+  } = $props();
+
+  let station = $state<StationDetail | null>(null);
+  let loading = $state(true);
+  let error = $state('');
+  let favourite = $state(false);
+  let proxiedIcon = $state('');
+  let linkMessage = $state('');
+  let playbackState = $state('stopped');
+  let currentStationUuid = $state('');
+  let radioMode = $state(false);
+
+  $effect(() => {
+    return onPlaybackStatusChange(status => {
+      radioMode = status.radioMode;
+      currentStationUuid = status.radioUuid;
+      playbackState = status.state;
+    });
+  });
+
+  $effect(() => {
+    void loadStation(stationUuid, hint);
+  });
+
+  async function loadStation(uuid: string, initial: RadioStationHint | null) {
+    loading = true;
+    error = '';
+    linkMessage = '';
+    if (initial) {
+      station = hintToDetail(initial);
+    }
+
+    try {
+      const result = await LibraryService.GetRadioStationByUUID(uuid);
+      if (result) {
+        station = {
+          uuid: result.uuid,
+          name: result.name,
+          streamUrl: result.streamUrl,
+          homepage: result.homepage || '',
+          favicon: result.favicon || '',
+          country: result.country || '',
+          tags: result.tags || '',
+          bitrate: result.bitrate || 0,
+          codec: result.codec || '',
+          votes: result.votes || 0,
+          clicks: result.clicks || 0,
+        };
+        favourite = await LibraryService.IsRadioFavourite(uuid);
+        if (station.favicon) {
+          try {
+            proxiedIcon = await LibraryService.ProxyImageURL(station.favicon);
+          } catch {
+            proxiedIcon = '';
+          }
+        } else {
+          proxiedIcon = '';
+        }
+      }
+    } catch (err) {
+      if (!station) {
+        error = err instanceof Error ? err.message : String(err);
+      }
+    } finally {
+      loading = false;
+    }
+  }
+
+  function hintToDetail(initial: RadioStationHint): StationDetail {
+    return {
+      uuid: initial.uuid,
+      name: initial.name || 'Radio station',
+      streamUrl: initial.streamUrl || '',
+      homepage: initial.homepage || '',
+      favicon: initial.favicon || '',
+      country: initial.country || '',
+      tags: initial.tags || '',
+      bitrate: initial.bitrate || 0,
+      codec: initial.codec || '',
+      votes: 0,
+      clicks: 0,
+    };
+  }
+
+  function formatTags(tags: string): string[] {
+    if (!tags) return [];
+    return tags.split(',').map(t => t.trim()).filter(Boolean);
+  }
+
+  function stationInitials(name: string): string {
+    const cleaned = name.replace(/\([^)]*\)/g, ' ').replace(/[^a-zA-Z0-9]+/g, ' ').trim();
+    if (!cleaned) return 'R';
+    const words = cleaned.split(/\s+/).filter(word => !/^\d+$/.test(word));
+    const source = words.length > 0 ? words : cleaned.split(/\s+/);
+    if (source.length === 1) return source[0].slice(0, 2).toUpperCase();
+    return `${source[0][0]}${source[1][0]}`.toUpperCase();
+  }
+
+  function isCurrentStation(): boolean {
+    return radioMode && currentStationUuid === stationUuid;
+  }
+
+  function isPlaying(): boolean {
+    return isCurrentStation() && playbackState === 'playing';
+  }
+
+  function isPaused(): boolean {
+    return isCurrentStation() && playbackState === 'paused';
+  }
+
+  async function togglePlay() {
+    if (!station) return;
+    try {
+      if (isCurrentStation()) {
+        if (playbackState === 'playing') {
+          await PlayerService.Pause();
+        } else if (playbackState === 'paused') {
+          await PlayerService.Resume();
+        }
+      } else {
+        const art = station.favicon ? await LibraryService.ProxyImageURL(station.favicon) : '';
+        await PlayerService.PlayRadioStation(
+          station.uuid,
+          station.name,
+          station.streamUrl,
+          art,
+          station.homepage,
+          station.tags
+        );
+      }
+      await refreshPlaybackStatus();
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  async function toggleFavourite() {
+    if (!station) return;
+    try {
+      if (favourite) {
+        await LibraryService.RemoveRadioFavourite(station.uuid);
+        favourite = false;
+      } else {
+        await LibraryService.AddRadioFavourite(
+          station.uuid,
+          station.name,
+          station.streamUrl,
+          station.favicon,
+          station.homepage,
+          station.tags
+        );
+        favourite = true;
+      }
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  async function openLink(url: string) {
+    if (!url) return;
+    try {
+      await LibraryService.OpenURL(url);
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  async function copyLink(url: string, label: string) {
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      linkMessage = `${label} copied`;
+      setTimeout(() => { linkMessage = ''; }, 2000);
+    } catch {
+      linkMessage = 'Could not copy link';
+    }
+  }
+</script>
+
+<div class="station-view">
+  <button class="back-btn" type="button" onclick={onback}>
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+      <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+    </svg>
+    Radio
+  </button>
+
+  {#if loading && !station}
+    <div class="loading" role="status">Loading station...</div>
+  {:else if error && !station}
+    <div class="error-state" role="alert">{error}</div>
+  {:else if station}
+    <div class="station-header">
+      {#if proxiedIcon}
+        <img class="station-art" src={proxiedIcon} alt="" />
+      {:else}
+        <div class="station-art placeholder">
+          <span>{stationInitials(station.name)}</span>
+        </div>
+      {/if}
+      <div class="station-meta">
+        <h1>{station.name}</h1>
+        <div class="badges">
+          {#if isPlaying()}<span class="badge playing">Playing</span>{/if}
+          {#if isPaused()}<span class="badge">Paused</span>{/if}
+          {#if station.country}<span>{station.country}</span>{/if}
+          {#if station.codec}
+            <span>{station.codec}{#if station.bitrate} · {station.bitrate} kbps{/if}</span>
+          {/if}
+        </div>
+        {#if formatTags(station.tags).length > 0}
+          <div class="tags">
+            {#each formatTags(station.tags) as tag}
+              <button class="tag" type="button" onclick={() => browseRadioTag(tag)}>{tag}</button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </div>
+
+    <div class="actions">
+      <button class="primary-btn" type="button" onclick={togglePlay}>
+        {isPlaying() ? 'Pause' : isPaused() ? 'Resume' : 'Play'}
+      </button>
+      <button class="secondary-btn" class:active={favourite} type="button" onclick={toggleFavourite}>
+        {favourite ? 'Remove favourite' : 'Add favourite'}
+      </button>
+    </div>
+
+    <section class="links">
+      <h2>Links</h2>
+      {#if linkMessage}
+        <p class="link-message" role="status">{linkMessage}</p>
+      {/if}
+      {#if station.homepage}
+        <div class="link-row">
+          <span class="link-label">Website</span>
+          <a class="link-url" href={station.homepage} onclick={(e) => { e.preventDefault(); void openLink(station.homepage); }}>
+            {station.homepage}
+          </a>
+          <button class="link-action" type="button" onclick={() => copyLink(station.homepage, 'Website')}>Copy</button>
+        </div>
+      {/if}
+      {#if station.streamUrl}
+        <div class="link-row">
+          <span class="link-label">Stream</span>
+          <span class="link-url mono">{station.streamUrl}</span>
+          <button class="link-action" type="button" onclick={() => copyLink(station.streamUrl, 'Stream URL')}>Copy</button>
+        </div>
+      {/if}
+      {#if !station.homepage && !station.streamUrl}
+        <p class="empty-links">No links available for this station.</p>
+      {/if}
+    </section>
+
+    <section class="details">
+      <h2>Details</h2>
+      <dl>
+        <div><dt>Station ID</dt><dd class="mono">{station.uuid}</dd></div>
+        {#if station.votes > 0}<div><dt>Votes</dt><dd>{station.votes}</dd></div>{/if}
+        {#if station.clicks > 0}<div><dt>Clicks</dt><dd>{station.clicks}</dd></div>{/if}
+      </dl>
+    </section>
+
+    {#if error}
+      <div class="error-state" role="alert">{error}</div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .station-view {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    animation: view-enter 0.2s ease-out;
+  }
+
+  .back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0;
+    font-size: 0.9rem;
+  }
+
+  .back-btn:hover {
+    color: var(--text-primary);
+  }
+
+  .loading,
+  .error-state,
+  .empty-links {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+
+  .error-state {
+    color: var(--error);
+  }
+
+  .station-header {
+    display: flex;
+    gap: 1.25rem;
+    align-items: flex-start;
+  }
+
+  .station-art {
+    width: 120px;
+    height: 120px;
+    border-radius: 8px;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .station-art.placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 18%, var(--bg-elevated)) 0%, var(--bg-hover) 100%);
+    color: var(--accent);
+    border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--border));
+    font-size: 1.4rem;
+    font-weight: 700;
+  }
+
+  .station-meta {
+    min-width: 0;
+    flex: 1;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  h2 {
+    margin: 0 0 0.6rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.4rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+  }
+
+  .badge.playing {
+    color: var(--accent);
+    font-weight: 600;
+  }
+
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.6rem;
+  }
+
+  .tag {
+    font-size: 0.75rem;
+    padding: 0.15rem 0.45rem;
+    border-radius: 3px;
+    background: var(--bg-hover);
+    color: var(--text-secondary);
+    border: none;
+    cursor: pointer;
+  }
+
+  .tag:hover {
+    color: var(--text-primary);
+    background: var(--bg-elevated, var(--bg-hover));
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+  }
+
+  .primary-btn,
+  .secondary-btn,
+  .link-action {
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    padding: 0.45rem 0.8rem;
+  }
+
+  .primary-btn {
+    border: none;
+    background: var(--accent);
+    color: white;
+  }
+
+  .secondary-btn {
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-secondary);
+  }
+
+  .secondary-btn.active,
+  .secondary-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+
+  .secondary-btn.active {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  .links,
+  .details {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.9rem 1rem;
+  }
+
+  .link-message {
+    margin: 0 0 0.5rem;
+    font-size: 0.8rem;
+    color: var(--accent);
+  }
+
+  .link-row {
+    display: grid;
+    grid-template-columns: 5.5rem minmax(0, 1fr) auto;
+    gap: 0.5rem 0.75rem;
+    align-items: center;
+    padding: 0.35rem 0;
+  }
+
+  .link-row + .link-row {
+    border-top: 1px solid var(--border);
+  }
+
+  .link-label {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+  }
+
+  .link-url {
+    min-width: 0;
+    font-size: 0.85rem;
+    color: var(--accent);
+    text-decoration: none;
+    word-break: break-all;
+  }
+
+  .link-url:hover {
+    text-decoration: underline;
+  }
+
+  .mono {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.8rem;
+    word-break: break-all;
+  }
+
+  .link-action {
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-secondary);
+  }
+
+  .link-action:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  dl {
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  dl > div {
+    display: grid;
+    grid-template-columns: 6rem minmax(0, 1fr);
+    gap: 0.75rem;
+  }
+
+  dt {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+  }
+
+  dd {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--text-primary);
+  }
+
+  @media (max-width: 640px) {
+    .station-header {
+      flex-direction: column;
+    }
+
+    .link-row {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/src/RadioStationView.svelte
+++ b/frontend/src/RadioStationView.svelte
@@ -1,173 +1,144 @@
 <script lang="ts">
-  import { LibraryService, PlayerService } from "../bindings/github.com/willfish/forte";
-  import { refreshPlaybackStatus, onPlaybackStatusChange } from './lib/playback';
+  import { onMount } from 'svelte';
+  import { LibraryService, PlayerService } from '../bindings/github.com/willfish/forte';
+  import { RadioStationJSON } from '../bindings/github.com/willfish/forte/models';
+  import { onPlaybackStatusChange } from './lib/playback';
+  import type { PlaybackStatus } from './lib/types';
   import type { RadioStationHint } from './lib/stores';
-  import { browseRadioTag } from './lib/stores';
 
-  type StationDetail = {
-    uuid: string;
-    name: string;
-    streamUrl: string;
-    homepage: string;
-    favicon: string;
-    country: string;
-    tags: string;
-    bitrate: number;
-    codec: string;
-    votes: number;
-    clicks: number;
-  };
-
-  const {
-    stationUuid,
-    hint = null,
-    onback,
-  }: {
+  type Props = {
     stationUuid: string;
     hint?: RadioStationHint | null;
     onback: () => void;
-  } = $props();
+  };
 
-  let station = $state<StationDetail | null>(null);
+  let { stationUuid, hint = null, onback }: Props = $props();
+
+  let station = $state<RadioStationJSON | null>(null);
   let loading = $state(true);
   let error = $state('');
-  let favourite = $state(false);
-  let proxiedIcon = $state('');
-  let linkMessage = $state('');
-  let playbackState = $state('stopped');
+  let isFavourite = $state(false);
+  let isPinned = $state(false);
+  let playbackState = $state<'stopped' | 'playing' | 'paused'>('stopped');
   let currentStationUuid = $state('');
-  let radioMode = $state(false);
+  let playbackTitle = $state('');
+  let actionError = $state('');
 
-  $effect(() => {
-    return onPlaybackStatusChange(status => {
-      radioMode = status.radioMode;
-      currentStationUuid = status.radioUuid;
+  onMount(() => {
+    void loadStation();
+    return onPlaybackStatusChange((status: PlaybackStatus) => {
       playbackState = status.state;
+      currentStationUuid = status.radioUuid;
+      playbackTitle = status.title;
     });
   });
 
-  $effect(() => {
-    void loadStation(stationUuid, hint);
-  });
-
-  async function loadStation(uuid: string, initial: RadioStationHint | null) {
+  async function loadStation() {
     loading = true;
     error = '';
-    linkMessage = '';
-    if (initial) {
-      station = hintToDetail(initial);
-    }
-
+    actionError = '';
     try {
-      const result = await LibraryService.GetRadioStationByUUID(uuid);
-      if (result) {
-        station = {
-          uuid: result.uuid,
-          name: result.name,
-          streamUrl: result.streamUrl,
-          homepage: result.homepage || '',
-          favicon: result.favicon || '',
-          country: result.country || '',
-          tags: result.tags || '',
-          bitrate: result.bitrate || 0,
-          codec: result.codec || '',
-          votes: result.votes || 0,
-          clicks: result.clicks || 0,
-        };
-        favourite = await LibraryService.IsRadioFavourite(uuid);
-        if (station.favicon) {
-          try {
-            proxiedIcon = await LibraryService.ProxyImageURL(station.favicon);
-          } catch {
-            proxiedIcon = '';
-          }
-        } else {
-          proxiedIcon = '';
-        }
+      station = await LibraryService.GetRadioStationByUUID(stationUuid);
+      isFavourite = await LibraryService.IsRadioFavourite(stationUuid);
+      if (isFavourite) {
+        isPinned = await LibraryService.GetRadioFavouritePinned(stationUuid);
+      } else {
+        isPinned = false;
       }
     } catch (err) {
-      if (!station) {
-        error = err instanceof Error ? err.message : String(err);
+      if (hint?.name) {
+        station = RadioStationJSON.createFrom({
+          uuid: stationUuid,
+          name: hint.name,
+          streamUrl: hint.streamUrl ?? '',
+          favicon: hint.favicon ?? '',
+          homepage: hint.homepage ?? '',
+          country: hint.country ?? '',
+          tags: hint.tags ?? '',
+          codec: hint.codec ?? '',
+          bitrate: hint.bitrate ?? 0,
+        });
+        isFavourite = await LibraryService.IsRadioFavourite(stationUuid).catch(() => false);
+        if (isFavourite) {
+          isPinned = await LibraryService.GetRadioFavouritePinned(stationUuid).catch(() => false);
+        }
+        error = '';
+      } else {
+        station = null;
+        error = err instanceof Error ? err.message : 'Could not load station details.';
       }
     } finally {
       loading = false;
     }
   }
 
-  function hintToDetail(initial: RadioStationHint): StationDetail {
-    return {
-      uuid: initial.uuid,
-      name: initial.name || 'Radio station',
-      streamUrl: initial.streamUrl || '',
-      homepage: initial.homepage || '',
-      favicon: initial.favicon || '',
-      country: initial.country || '',
-      tags: initial.tags || '',
-      bitrate: initial.bitrate || 0,
-      codec: initial.codec || '',
-      votes: 0,
-      clicks: 0,
-    };
+  function isThisStationPlaying(): boolean {
+    return playbackState === 'playing' && currentStationUuid === stationUuid;
   }
 
-  function formatTags(tags: string): string[] {
-    if (!tags) return [];
-    return tags.split(',').map(t => t.trim()).filter(Boolean);
+  function isThisStationPaused(): boolean {
+    return playbackState === 'paused' && currentStationUuid === stationUuid;
   }
 
-  function stationInitials(name: string): string {
-    const cleaned = name.replace(/\([^)]*\)/g, ' ').replace(/[^a-zA-Z0-9]+/g, ' ').trim();
-    if (!cleaned) return 'R';
-    const words = cleaned.split(/\s+/).filter(word => !/^\d+$/.test(word));
-    const source = words.length > 0 ? words : cleaned.split(/\s+/);
-    if (source.length === 1) return source[0].slice(0, 2).toUpperCase();
-    return `${source[0][0]}${source[1][0]}`.toUpperCase();
+  function isThisStationActive(): boolean {
+    return currentStationUuid === stationUuid && playbackState !== 'stopped';
   }
 
-  function isCurrentStation(): boolean {
-    return radioMode && currentStationUuid === stationUuid;
+  function nowPlayingTrack(): string {
+    if (!isThisStationActive() || !playbackTitle) {
+      return '';
+    }
+    const name = station?.name ?? '';
+    if (playbackTitle === name) {
+      return '';
+    }
+    return playbackTitle;
   }
 
-  function isPlaying(): boolean {
-    return isCurrentStation() && playbackState === 'playing';
-  }
-
-  function isPaused(): boolean {
-    return isCurrentStation() && playbackState === 'paused';
+  function playLabel(): string {
+    if (isThisStationPlaying()) return 'Pause';
+    if (isThisStationPaused()) return 'Resume';
+    return 'Play';
   }
 
   async function togglePlay() {
     if (!station) return;
+    actionError = '';
     try {
-      if (isCurrentStation()) {
+      if (isThisStationActive()) {
         if (playbackState === 'playing') {
           await PlayerService.Pause();
-        } else if (playbackState === 'paused') {
+        } else {
           await PlayerService.Resume();
         }
-      } else {
-        const art = station.favicon ? await LibraryService.ProxyImageURL(station.favicon) : '';
-        await PlayerService.PlayRadioStation(
-          station.uuid,
-          station.name,
-          station.streamUrl,
-          art,
-          station.homepage,
-          station.tags
-        );
+        return;
       }
-      await refreshPlaybackStatus();
+
+      const art = station.favicon ? await LibraryService.ProxyImageURL(station.favicon) : '';
+      await PlayerService.PlayRadioStation(
+        station.uuid,
+        station.name,
+        station.streamUrl,
+        art,
+        station.homepage,
+        station.tags,
+        station.country,
+        station.codec,
+        station.bitrate
+      );
     } catch (err) {
-      error = err instanceof Error ? err.message : String(err);
+      actionError = err instanceof Error ? err.message : 'Could not change playback.';
     }
   }
 
   async function toggleFavourite() {
     if (!station) return;
+    actionError = '';
     try {
-      if (favourite) {
+      if (isFavourite) {
         await LibraryService.RemoveRadioFavourite(station.uuid);
-        favourite = false;
+        isFavourite = false;
+        isPinned = false;
       } else {
         await LibraryService.AddRadioFavourite(
           station.uuid,
@@ -175,124 +146,138 @@
           station.streamUrl,
           station.favicon,
           station.homepage,
-          station.tags
+          station.tags,
+          station.country,
+          station.codec,
+          station.bitrate
         );
-        favourite = true;
+        isFavourite = true;
+        isPinned = false;
       }
     } catch (err) {
-      error = err instanceof Error ? err.message : String(err);
+      actionError = err instanceof Error ? err.message : 'Could not update favourite.';
     }
   }
 
-  async function openLink(url: string) {
+  async function togglePin() {
+    if (!station || !isFavourite) return;
+    actionError = '';
+    try {
+      const next = !isPinned;
+      await LibraryService.SetRadioFavouritePinned(station.uuid, next);
+      isPinned = next;
+    } catch (err) {
+      actionError = err instanceof Error ? err.message : 'Could not update pin.';
+    }
+  }
+
+  async function openExternalURL(url: string) {
     if (!url) return;
     try {
       await LibraryService.OpenURL(url);
     } catch (err) {
-      error = err instanceof Error ? err.message : String(err);
+      actionError = err instanceof Error ? err.message : 'Could not open link.';
     }
   }
 
-  async function copyLink(url: string, label: string) {
-    if (!url) return;
+  function handleExternalLink(event: MouseEvent, url: string) {
+    event.preventDefault();
+    void openExternalURL(url);
+  }
+
+  async function copyToClipboard(value: string, label: string) {
+    if (!value) return;
     try {
-      await navigator.clipboard.writeText(url);
-      linkMessage = `${label} copied`;
-      setTimeout(() => { linkMessage = ''; }, 2000);
+      await navigator.clipboard.writeText(value);
     } catch {
-      linkMessage = 'Could not copy link';
+      actionError = `Could not copy ${label}.`;
     }
   }
 </script>
 
 <div class="station-view">
-  <button class="back-btn" type="button" onclick={onback}>
-    <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
-      <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
-    </svg>
-    Radio
-  </button>
+  <div class="station-toolbar">
+    <button type="button" class="back-btn" onclick={onback}>Radio</button>
+  </div>
 
-  {#if loading && !station}
-    <div class="loading" role="status">Loading station...</div>
-  {:else if error && !station}
-    <div class="error-state" role="alert">{error}</div>
+  {#if loading}
+    <p class="status">Loading station…</p>
+  {:else if error}
+    <p class="status error" role="alert">{error}</p>
   {:else if station}
-    {@const detail = station}
-    <div class="station-header">
-      {#if proxiedIcon}
-        <img class="station-art" src={proxiedIcon} alt="" />
+    {@const s = station}
+    <header class="station-header">
+      {#if s.favicon}
+        <img class="station-art" src={s.favicon} alt="" />
       {:else}
-        <div class="station-art placeholder">
-          <span>{stationInitials(station.name)}</span>
-        </div>
+        <div class="station-art placeholder" aria-hidden="true">📻</div>
       {/if}
       <div class="station-meta">
-        <h1>{station.name}</h1>
-        <div class="badges">
-          {#if isPlaying()}<span class="badge playing">Playing</span>{/if}
-          {#if isPaused()}<span class="badge">Paused</span>{/if}
-          {#if station.country}<span>{station.country}</span>{/if}
-          {#if station.codec}
-            <span>{station.codec}{#if station.bitrate} · {station.bitrate} kbps{/if}</span>
-          {/if}
-        </div>
-        {#if formatTags(station.tags).length > 0}
-          <div class="tags">
-            {#each formatTags(station.tags) as tag}
-              <button class="tag" type="button" onclick={() => browseRadioTag(tag)}>{tag}</button>
-            {/each}
-          </div>
+        <h1>{s.name}</h1>
+        {#if s.country}
+          <p class="country">{s.country}</p>
+        {/if}
+        {#if s.codec || s.bitrate}
+          <p class="technical">{s.codec}{#if s.codec && s.bitrate} · {/if}{#if s.bitrate}{s.bitrate} kbps{/if}</p>
+        {/if}
+        {#if s.tags}
+          <p class="tags">{s.tags}</p>
+        {/if}
+        {#if nowPlayingTrack()}
+          <p class="now-playing-track" aria-live="polite">Now playing: {nowPlayingTrack()}</p>
         {/if}
       </div>
-    </div>
+    </header>
 
-    <div class="actions">
-      <button class="primary-btn" type="button" onclick={togglePlay}>
-        {isPlaying() ? 'Pause' : isPaused() ? 'Resume' : 'Play'}
+    <div class="station-actions">
+      <button type="button" class="primary" onclick={togglePlay}>{playLabel()}</button>
+      <button type="button" class="secondary" onclick={toggleFavourite}>
+        {isFavourite ? 'Remove favourite' : 'Add favourite'}
       </button>
-      <button class="secondary-btn" class:active={favourite} type="button" onclick={toggleFavourite}>
-        {favourite ? 'Remove favourite' : 'Add favourite'}
-      </button>
+      {#if isFavourite}
+        <button type="button" class="secondary" onclick={togglePin}>
+          {isPinned ? 'Unpin' : 'Pin'}
+        </button>
+      {/if}
     </div>
 
     <section class="links">
       <h2>Links</h2>
-      {#if linkMessage}
-        <p class="link-message" role="status">{linkMessage}</p>
-      {/if}
-      {#if detail.homepage}
+      {#if s.homepage}
         <div class="link-row">
-          <span class="link-label">Website</span>
-          <a class="link-url" href={detail.homepage} onclick={(e) => { e.preventDefault(); void openLink(detail.homepage); }}>
-            {detail.homepage}
-          </a>
-          <button class="link-action" type="button" onclick={() => copyLink(detail.homepage, 'Website')}>Copy</button>
+          <span class="label">Website</span>
+          <a
+            class="url"
+            href={s.homepage}
+            rel="noopener noreferrer"
+            target="_blank"
+            onclick={(e) => handleExternalLink(e, s.homepage)}
+          >{s.homepage}</a>
+          <button type="button" class="ghost" onclick={() => openExternalURL(s.homepage)}>Open</button>
+          <button type="button" class="ghost" onclick={() => copyToClipboard(s.homepage, 'website URL')}>Copy</button>
         </div>
+      {:else}
+        <p class="muted">No website listed for this station.</p>
       {/if}
-      {#if detail.streamUrl}
+
+      {#if s.streamUrl}
         <div class="link-row">
-          <span class="link-label">Stream</span>
-          <span class="link-url mono">{detail.streamUrl}</span>
-          <button class="link-action" type="button" onclick={() => copyLink(detail.streamUrl, 'Stream URL')}>Copy</button>
+          <span class="label">Stream URL</span>
+          <a
+            class="url"
+            href={s.streamUrl}
+            rel="noopener noreferrer"
+            target="_blank"
+            onclick={(e) => handleExternalLink(e, s.streamUrl)}
+          >{s.streamUrl}</a>
+          <button type="button" class="ghost" onclick={() => openExternalURL(s.streamUrl)}>Open</button>
+          <button type="button" class="ghost" onclick={() => copyToClipboard(s.streamUrl, 'stream URL')}>Copy</button>
         </div>
-      {/if}
-      {#if !detail.homepage && !detail.streamUrl}
-        <p class="empty-links">No links available for this station.</p>
       {/if}
     </section>
 
-    <section class="details">
-      <h2>Details</h2>
-      <dl>
-        <div><dt>Station ID</dt><dd class="mono">{station.uuid}</dd></div>
-        {#if station.votes > 0}<div><dt>Votes</dt><dd>{station.votes}</dd></div>{/if}
-        {#if station.clicks > 0}<div><dt>Clicks</dt><dd>{station.clicks}</dd></div>{/if}
-      </dl>
-    </section>
-
-    {#if error}
-      <div class="error-state" role="alert">{error}</div>
+    {#if actionError}
+      <p class="status error" role="alert">{actionError}</p>
     {/if}
   {/if}
 </div>
@@ -301,245 +286,123 @@
   .station-view {
     display: flex;
     flex-direction: column;
-    gap: 1.25rem;
-    animation: view-enter 0.2s ease-out;
+    gap: 1rem;
+    min-height: 0;
+  }
+
+  .station-toolbar {
+    display: flex;
+    align-items: center;
   }
 
   .back-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
     border: none;
     background: transparent;
-    color: var(--text-secondary);
+    color: var(--accent);
     cursor: pointer;
+    font: inherit;
     padding: 0;
-    font-size: 0.9rem;
-  }
-
-  .back-btn:hover {
-    color: var(--text-primary);
-  }
-
-  .loading,
-  .error-state,
-  .empty-links {
-    color: var(--text-secondary);
-    font-size: 0.9rem;
-  }
-
-  .error-state {
-    color: var(--error);
   }
 
   .station-header {
     display: flex;
-    gap: 1.25rem;
+    gap: 1rem;
     align-items: flex-start;
   }
 
   .station-art {
-    width: 120px;
-    height: 120px;
-    border-radius: 8px;
+    width: 96px;
+    height: 96px;
+    border-radius: 12px;
     object-fit: cover;
     flex-shrink: 0;
   }
 
   .station-art.placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 18%, var(--bg-elevated)) 0%, var(--bg-hover) 100%);
-    color: var(--accent);
-    border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--border));
-    font-size: 1.4rem;
-    font-weight: 700;
+    display: grid;
+    place-items: center;
+    background: var(--surface-2);
+    font-size: 2rem;
   }
 
-  .station-meta {
-    min-width: 0;
-    flex: 1;
-  }
-
-  h1 {
-    margin: 0;
+  .station-meta h1 {
+    margin: 0 0 0.35rem;
     font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--text-primary);
   }
 
-  h2 {
-    margin: 0 0 0.6rem;
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: var(--text-primary);
+  .country,
+  .technical,
+  .tags,
+  .now-playing-track {
+    margin: 0.15rem 0;
+    color: var(--text-muted);
   }
 
-  .badges {
+  .now-playing-track {
+    color: var(--text);
+    font-weight: 500;
+  }
+
+  .station-actions {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
-    margin-top: 0.4rem;
-    font-size: 0.85rem;
-    color: var(--text-secondary);
   }
 
-  .badge.playing {
-    color: var(--accent);
-    font-weight: 600;
-  }
-
-  .tags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.25rem;
-    margin-top: 0.6rem;
-  }
-
-  .tag {
-    font-size: 0.75rem;
-    padding: 0.15rem 0.45rem;
-    border-radius: 3px;
-    background: var(--bg-hover);
-    color: var(--text-secondary);
-    border: none;
-    cursor: pointer;
-  }
-
-  .tag:hover {
-    color: var(--text-primary);
-    background: var(--bg-elevated, var(--bg-hover));
-  }
-
-  .actions {
-    display: flex;
-    gap: 0.6rem;
-    flex-wrap: wrap;
-  }
-
-  .primary-btn,
-  .secondary-btn,
-  .link-action {
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.9rem;
-    padding: 0.45rem 0.8rem;
-  }
-
-  .primary-btn {
-    border: none;
-    background: var(--accent);
-    color: white;
-  }
-
-  .secondary-btn {
-    border: 1px solid var(--border);
-    background: transparent;
-    color: var(--text-secondary);
-  }
-
-  .secondary-btn.active,
-  .secondary-btn:hover {
-    color: var(--text-primary);
-    background: var(--bg-hover);
-  }
-
-  .secondary-btn.active {
-    border-color: var(--accent);
-    color: var(--accent);
-  }
-
-  .links,
-  .details {
-    border: 1px solid var(--border);
+  .primary,
+  .secondary,
+  .ghost {
     border-radius: 8px;
-    padding: 0.9rem 1rem;
+    padding: 0.45rem 0.75rem;
+    font: inherit;
+    cursor: pointer;
   }
 
-  .link-message {
+  .primary {
+    border: 1px solid var(--accent);
+    background: var(--accent);
+    color: var(--accent-contrast, #fff);
+  }
+
+  .secondary,
+  .ghost {
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+  }
+
+  .links h2 {
     margin: 0 0 0.5rem;
-    font-size: 0.8rem;
-    color: var(--accent);
+    font-size: 1rem;
   }
 
   .link-row {
     display: grid;
-    grid-template-columns: 5.5rem minmax(0, 1fr) auto;
-    gap: 0.5rem 0.75rem;
-    align-items: center;
-    padding: 0.35rem 0;
-  }
-
-  .link-row + .link-row {
-    border-top: 1px solid var(--border);
-  }
-
-  .link-label {
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-  }
-
-  .link-url {
-    min-width: 0;
-    font-size: 0.85rem;
-    color: var(--accent);
-    text-decoration: none;
-    word-break: break-all;
-  }
-
-  .link-url:hover {
-    text-decoration: underline;
-  }
-
-  .mono {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    font-size: 0.8rem;
-    word-break: break-all;
-  }
-
-  .link-action {
-    border: 1px solid var(--border);
-    background: transparent;
-    color: var(--text-secondary);
-  }
-
-  .link-action:hover {
-    background: var(--bg-hover);
-    color: var(--text-primary);
-  }
-
-  dl {
-    margin: 0;
-    display: grid;
+    grid-template-columns: auto 1fr auto auto;
     gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.65rem;
   }
 
-  dl > div {
-    display: grid;
-    grid-template-columns: 6rem minmax(0, 1fr);
-    gap: 0.75rem;
-  }
-
-  dt {
-    margin: 0;
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-  }
-
-  dd {
-    margin: 0;
+  .label {
+    color: var(--text-muted);
     font-size: 0.85rem;
-    color: var(--text-primary);
   }
 
-  @media (max-width: 640px) {
-    .station-header {
-      flex-direction: column;
-    }
+  .url {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--accent);
+    font-size: 0.85rem;
+  }
 
-    .link-row {
-      grid-template-columns: 1fr;
-    }
+  .muted,
+  .status {
+    color: var(--text-muted);
+  }
+
+  .status.error {
+    color: var(--danger, #c0392b);
   }
 </style>

--- a/frontend/src/RadioView.svelte
+++ b/frontend/src/RadioView.svelte
@@ -34,6 +34,9 @@
     streamUrl: string;
     faviconUrl: string;
     homepage: string;
+    country: string;
+    codec: string;
+    bitrate: number;
     tags: string;
     addedAt: string;
     pinned: boolean;
@@ -44,6 +47,7 @@
     name: string;
     streamUrl: string;
     faviconUrl: string;
+    homepage: string;
     tags: string;
     createdAt: string;
   };
@@ -54,6 +58,9 @@
     streamUrl: string;
     faviconUrl: string;
     homepage: string;
+    country: string;
+    codec: string;
+    bitrate: number;
     tags: string;
     lastTitle: string;
     lastError: string;
@@ -80,6 +87,7 @@
   let customName = $state('');
   let customStreamUrl = $state('');
   let customFaviconUrl = $state('');
+  let customHomepage = $state('');
   let customTags = $state('');
   let radioMode = $state(false);
   let currentStationUuid = $state('');
@@ -296,6 +304,9 @@
         streamUrl: f.streamUrl,
         faviconUrl: f.faviconUrl,
         homepage: f.homepage || '',
+        country: f.country || '',
+        codec: f.codec || '',
+        bitrate: f.bitrate || 0,
         tags: f.tags,
         addedAt: f.addedAt,
         pinned: Boolean(f.pinned),
@@ -316,6 +327,7 @@
         name: s.name,
         streamUrl: s.streamUrl,
         faviconUrl: s.faviconUrl,
+        homepage: s.homepage || '',
         tags: s.tags,
         createdAt: s.createdAt,
       }));
@@ -334,8 +346,11 @@
         streamUrl: h.streamUrl,
         faviconUrl: h.faviconUrl,
         homepage: h.homepage || '',
+        country: h.country || '',
+        codec: h.codec || '',
+        bitrate: h.bitrate || 0,
         tags: h.tags,
-        lastTitle: h.lastTitle,
+        lastTitle: h.trackTitle || h.lastTitle || '',
         lastError: h.lastError,
         playCount: h.playCount,
         lastPlayedAt: h.lastPlayedAt,
@@ -384,6 +399,9 @@
       favicon: fav.faviconUrl,
       homepage: fav.homepage,
       tags: fav.tags,
+      country: fav.country,
+      codec: fav.codec,
+      bitrate: fav.bitrate,
     };
   }
 
@@ -395,6 +413,20 @@
       favicon: item.faviconUrl,
       homepage: item.homepage,
       tags: item.tags,
+      country: item.country,
+      codec: item.codec,
+      bitrate: item.bitrate,
+    };
+  }
+
+  function stationHintFromCustom(station: CustomStation): RadioStationHint {
+    return {
+      uuid: station.stationUuid,
+      name: station.name,
+      streamUrl: station.streamUrl,
+      favicon: station.faviconUrl,
+      homepage: station.homepage,
+      tags: station.tags,
     };
   }
 
@@ -539,7 +571,10 @@
     url: string,
     favicon: string,
     homepage: string,
-    tags: string
+    tags: string,
+    country = '',
+    codec = '',
+    bitrate = 0
   ) {
     try {
       clearRadioError();
@@ -555,7 +590,7 @@
 
       // Proxy artwork so the webview can display it.
       const art = favicon ? await LibraryService.ProxyImageURL(favicon) : '';
-      await PlayerService.PlayRadioStation(stationUuid, name, url, art, homepage, tags);
+      await PlayerService.PlayRadioStation(stationUuid, name, url, art, homepage, tags, country, codec, bitrate);
       await refreshPlaybackStatus();
       await loadHistory();
     } catch (err) {
@@ -570,14 +605,17 @@
     url: string,
     favicon: string,
     homepage: string,
-    tags: string
+    tags: string,
+    country = '',
+    codec = '',
+    bitrate = 0
   ) {
     const target = event.target as HTMLElement;
     const interactiveTarget = target.closest('button, input, a, select, textarea');
     if (interactiveTarget && !interactiveTarget.classList.contains('station-main')) {
       return;
     }
-    await playStation(stationUuid, name, url, favicon, homepage, tags);
+    await playStation(stationUuid, name, url, favicon, homepage, tags, country, codec, bitrate);
   }
 
   async function handleStationKeydown(
@@ -587,7 +625,10 @@
     url: string,
     favicon: string,
     homepage: string,
-    tags: string
+    tags: string,
+    country = '',
+    codec = '',
+    bitrate = 0
   ) {
     if (event.key !== 'Enter' && event.key !== ' ') {
       return;
@@ -598,7 +639,7 @@
       return;
     }
     event.preventDefault();
-    await playStation(stationUuid, name, url, favicon, homepage, tags);
+    await playStation(stationUuid, name, url, favicon, homepage, tags, country, codec, bitrate);
   }
 
   function handleGlobalKeydown(event: KeyboardEvent) {
@@ -643,7 +684,15 @@
     } else {
       try {
         await LibraryService.AddRadioFavourite(
-          station.uuid, station.name, station.streamUrl, station.favicon, station.homepage, station.tags
+          station.uuid,
+          station.name,
+          station.streamUrl,
+          station.favicon,
+          station.homepage,
+          station.tags,
+          station.country,
+          station.codec,
+          station.bitrate
         );
         favouriteUuids.add(station.uuid);
         favouriteUuids = new Set(favouriteUuids);
@@ -686,14 +735,23 @@
         name,
         streamUrl,
         customFaviconUrl.trim(),
+        customHomepage.trim(),
         customTags.trim()
       );
       customName = '';
       customStreamUrl = '';
       customFaviconUrl = '';
+      customHomepage = '';
       customTags = '';
       await loadCustomStations();
-      await playStation(saved.stationUuid, saved.name, saved.streamUrl, saved.faviconUrl, saved.homepage || '', saved.tags);
+      await playStation(
+        saved.stationUuid,
+        saved.name,
+        saved.streamUrl,
+        saved.faviconUrl,
+        saved.homepage || '',
+        saved.tags
+      );
     } catch (err: any) {
       customError = err?.message || String(err);
     } finally {
@@ -913,7 +971,7 @@
             aria-current={isCurrentStation(station.uuid) ? 'true' : undefined}
             class:playing={isCurrentStation(station.uuid)}
           >
-            <button class="station-play" class:playing={isCurrentStation(station.uuid)} onclick={() => playStation(station.uuid, station.name, station.streamUrl, station.favicon, station.homepage, station.tags)} aria-label={isPlayingStation(station.uuid) ? `Pause ${station.name}` : `Play ${station.name}`}>
+            <button class="station-play" class:playing={isCurrentStation(station.uuid)} onclick={() => playStation(station.uuid, station.name, station.streamUrl, station.favicon, station.homepage, station.tags, station.country, station.codec, station.bitrate)} aria-label={isPlayingStation(station.uuid) ? `Pause ${station.name}` : `Play ${station.name}`}>
               {#if isPlayingStation(station.uuid)}
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
                   <path d="M6 19h4V5H6zm8-14v14h4V5z"/>
@@ -930,8 +988,8 @@
               class="station-main"
               aria-label={`Play or pause ${station.name}`}
               title="Double-click or press Enter to play or pause"
-              ondblclick={(event) => handleStationDoubleClick(event, station.uuid, station.name, station.streamUrl, station.favicon, station.homepage, station.tags)}
-              onkeydown={(event) => handleStationKeydown(event, station.uuid, station.name, station.streamUrl, station.favicon, station.homepage, station.tags)}
+              ondblclick={(event) => handleStationDoubleClick(event, station.uuid, station.name, station.streamUrl, station.favicon, station.homepage, station.tags, station.country, station.codec, station.bitrate)}
+              onkeydown={(event) => handleStationKeydown(event, station.uuid, station.name, station.streamUrl, station.favicon, station.homepage, station.tags, station.country, station.codec, station.bitrate)}
             >
             {#if resolvedIcon(station.favicon)}
               <img class="station-icon" src={resolvedIcon(station.favicon)} alt="" />
@@ -995,7 +1053,7 @@
             aria-current={isCurrentStation(fav.stationUuid) ? 'true' : undefined}
             class:playing={isCurrentStation(fav.stationUuid)}
           >
-            <button class="station-play" class:playing={isCurrentStation(fav.stationUuid)} onclick={() => playStation(fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.homepage, fav.tags)} aria-label={isPlayingStation(fav.stationUuid) ? `Pause ${fav.name}` : `Play ${fav.name}`}>
+            <button class="station-play" class:playing={isCurrentStation(fav.stationUuid)} onclick={() => playStation(fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.homepage, fav.tags, fav.country, fav.codec, fav.bitrate)} aria-label={isPlayingStation(fav.stationUuid) ? `Pause ${fav.name}` : `Play ${fav.name}`}>
               {#if isPlayingStation(fav.stationUuid)}
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
                   <path d="M6 19h4V5H6zm8-14v14h4V5z"/>
@@ -1012,8 +1070,8 @@
               class="station-main"
               aria-label={`Play or pause ${fav.name}`}
               title="Double-click or press Enter to play or pause"
-              ondblclick={(event) => handleStationDoubleClick(event, fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.homepage, fav.tags)}
-              onkeydown={(event) => handleStationKeydown(event, fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.homepage, fav.tags)}
+              ondblclick={(event) => handleStationDoubleClick(event, fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.homepage, fav.tags, fav.country, fav.codec, fav.bitrate)}
+              onkeydown={(event) => handleStationKeydown(event, fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.homepage, fav.tags, fav.country, fav.codec, fav.bitrate)}
             >
             {#if resolvedIcon(fav.faviconUrl)}
               <img class="station-icon" src={resolvedIcon(fav.faviconUrl)} alt="" />
@@ -1071,6 +1129,9 @@
       </div>
       <div class="form-row">
         <input type="url" bind:value={customFaviconUrl} placeholder="Artwork URL" aria-label="Artwork URL" />
+        <input type="url" bind:value={customHomepage} placeholder="Website URL (optional)" aria-label="Website URL" />
+      </div>
+      <div class="form-row">
         <input type="text" bind:value={customTags} placeholder="Tags" aria-label="Tags" />
       </div>
       <div class="form-actions">
@@ -1094,7 +1155,7 @@
             aria-current={isCurrentStation(station.stationUuid) ? 'true' : undefined}
             class:playing={isCurrentStation(station.stationUuid)}
           >
-            <button class="station-play" class:playing={isCurrentStation(station.stationUuid)} onclick={() => playStation(station.stationUuid, station.name, station.streamUrl, station.faviconUrl, '', station.tags)} aria-label={isPlayingStation(station.stationUuid) ? `Pause ${station.name}` : `Play ${station.name}`}>
+            <button class="station-play" class:playing={isCurrentStation(station.stationUuid)} onclick={() => playStation(station.stationUuid, station.name, station.streamUrl, station.faviconUrl, station.homepage, station.tags)} aria-label={isPlayingStation(station.stationUuid) ? `Pause ${station.name}` : `Play ${station.name}`}>
               {#if isPlayingStation(station.stationUuid)}
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
                   <path d="M6 19h4V5H6zm8-14v14h4V5z"/>
@@ -1111,8 +1172,8 @@
               class="station-main"
               aria-label={`Play or pause ${station.name}`}
               title="Double-click or press Enter to play or pause"
-              ondblclick={(event) => handleStationDoubleClick(event, station.stationUuid, station.name, station.streamUrl, station.faviconUrl, '', station.tags)}
-              onkeydown={(event) => handleStationKeydown(event, station.stationUuid, station.name, station.streamUrl, station.faviconUrl, '', station.tags)}
+              ondblclick={(event) => handleStationDoubleClick(event, station.stationUuid, station.name, station.streamUrl, station.faviconUrl, station.homepage, station.tags)}
+              onkeydown={(event) => handleStationKeydown(event, station.stationUuid, station.name, station.streamUrl, station.faviconUrl, station.homepage, station.tags)}
             >
             {#if resolvedIcon(station.faviconUrl)}
               <img class="station-icon" src={resolvedIcon(station.faviconUrl)} alt="" />
@@ -1122,7 +1183,7 @@
               </div>
             {/if}
             <div class="station-info">
-              <button type="button" class="station-name" onclick={(event) => { event.stopPropagation(); openStationDetail({ uuid: station.stationUuid, name: station.name, streamUrl: station.streamUrl, favicon: station.faviconUrl, tags: station.tags }); }}>{station.name}</button>
+              <button type="button" class="station-name" onclick={(event) => { event.stopPropagation(); openStationDetail(stationHintFromCustom(station)); }}>{station.name}</button>
               {#if isPlayingStation(station.stationUuid)}
                 <div class="station-meta"><span class="playing-badge">Playing</span></div>
               {/if}
@@ -1166,7 +1227,7 @@
             aria-current={isCurrentStation(item.stationUuid) ? 'true' : undefined}
             class:playing={isCurrentStation(item.stationUuid)}
           >
-            <button class="station-play" class:playing={isCurrentStation(item.stationUuid)} onclick={() => playStation(item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.homepage, item.tags)} aria-label={isPlayingStation(item.stationUuid) ? `Pause ${item.name}` : `Play ${item.name}`}>
+            <button class="station-play" class:playing={isCurrentStation(item.stationUuid)} onclick={() => playStation(item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.homepage, item.tags, item.country, item.codec, item.bitrate)} aria-label={isPlayingStation(item.stationUuid) ? `Pause ${item.name}` : `Play ${item.name}`}>
               {#if isPlayingStation(item.stationUuid)}
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
                   <path d="M6 19h4V5H6zm8-14v14h4V5z"/>
@@ -1183,8 +1244,8 @@
               class="station-main"
               aria-label={`Play or pause ${item.name}`}
               title="Double-click or press Enter to play or pause"
-              ondblclick={(event) => handleStationDoubleClick(event, item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.homepage, item.tags)}
-              onkeydown={(event) => handleStationKeydown(event, item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.homepage, item.tags)}
+              ondblclick={(event) => handleStationDoubleClick(event, item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.homepage, item.tags, item.country, item.codec, item.bitrate)}
+              onkeydown={(event) => handleStationKeydown(event, item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.homepage, item.tags, item.country, item.codec, item.bitrate)}
             >
             {#if resolvedIcon(item.faviconUrl)}
               <img class="station-icon" src={resolvedIcon(item.faviconUrl)} alt="" />

--- a/frontend/src/RadioView.svelte
+++ b/frontend/src/RadioView.svelte
@@ -2,13 +2,23 @@
   import { tick } from 'svelte';
   import { LibraryService, PlayerService } from "../bindings/github.com/willfish/forte";
   import { onPlaybackStatusChange, refreshPlaybackStatus } from './lib/playback';
-  import { getRadioTagFilter, onRadioTagFilterChange } from './lib/stores';
+  import {
+    clearRadioStationDetail,
+    getRadioStationDetail,
+    getRadioStationHint,
+    onRadioStationDetailChange,
+    onRadioTagFilterChange,
+    getRadioTagFilter,
+    type RadioStationHint,
+  } from './lib/stores';
+  import RadioStationView from './RadioStationView.svelte';
   import type { PlaybackState } from './lib/types';
 
   type Station = {
     uuid: string;
     name: string;
     streamUrl: string;
+    homepage: string;
     favicon: string;
     country: string;
     tags: string;
@@ -23,6 +33,7 @@
     name: string;
     streamUrl: string;
     faviconUrl: string;
+    homepage: string;
     tags: string;
     addedAt: string;
     pinned: boolean;
@@ -42,6 +53,7 @@
     name: string;
     streamUrl: string;
     faviconUrl: string;
+    homepage: string;
     tags: string;
     lastTitle: string;
     lastError: string;
@@ -73,6 +85,8 @@
   let currentStationUuid = $state('');
   let playbackState = $state<PlaybackState>('stopped');
   let searchInputRef: HTMLInputElement | undefined = $state();
+  let selectedStationUuid = $state<string | null>(getRadioStationDetail());
+  let selectedStationHint = $state<RadioStationHint | null>(getRadioStationHint());
 
   // Active filters.
   let activeTags = $state<string[]>([]);
@@ -281,6 +295,7 @@
         name: f.name,
         streamUrl: f.streamUrl,
         faviconUrl: f.faviconUrl,
+        homepage: f.homepage || '',
         tags: f.tags,
         addedAt: f.addedAt,
         pinned: Boolean(f.pinned),
@@ -318,6 +333,7 @@
         name: h.name,
         streamUrl: h.streamUrl,
         faviconUrl: h.faviconUrl,
+        homepage: h.homepage || '',
         tags: h.tags,
         lastTitle: h.lastTitle,
         lastError: h.lastError,
@@ -335,6 +351,7 @@
       uuid: s.uuid,
       name: s.name,
       streamUrl: s.streamUrl,
+      homepage: s.homepage || '',
       favicon: s.favicon,
       country: s.country,
       tags: s.tags,
@@ -342,6 +359,42 @@
       codec: s.codec,
       votes: s.votes,
       clicks: s.clicks,
+    };
+  }
+
+  function stationHintFromStation(station: Station): RadioStationHint {
+    return {
+      uuid: station.uuid,
+      name: station.name,
+      streamUrl: station.streamUrl,
+      favicon: station.favicon,
+      homepage: station.homepage,
+      tags: station.tags,
+      country: station.country,
+      bitrate: station.bitrate,
+      codec: station.codec,
+    };
+  }
+
+  function stationHintFromFavourite(fav: Favourite): RadioStationHint {
+    return {
+      uuid: fav.stationUuid,
+      name: fav.name,
+      streamUrl: fav.streamUrl,
+      favicon: fav.faviconUrl,
+      homepage: fav.homepage,
+      tags: fav.tags,
+    };
+  }
+
+  function stationHintFromHistory(item: HistoryEntry): RadioStationHint {
+    return {
+      uuid: item.stationUuid,
+      name: item.name,
+      streamUrl: item.streamUrl,
+      favicon: item.faviconUrl,
+      homepage: item.homepage,
+      tags: item.tags,
     };
   }
 
@@ -469,7 +522,25 @@
     reloadBrowseStations();
   }
 
-  async function playStation(stationUuid: string, name: string, url: string, favicon: string, tags: string) {
+  function openStationDetail(hint: RadioStationHint) {
+    selectedStationUuid = hint.uuid;
+    selectedStationHint = hint;
+  }
+
+  function closeStationDetail() {
+    selectedStationUuid = null;
+    selectedStationHint = null;
+    clearRadioStationDetail();
+  }
+
+  async function playStation(
+    stationUuid: string,
+    name: string,
+    url: string,
+    favicon: string,
+    homepage: string,
+    tags: string
+  ) {
     try {
       clearRadioError();
       if (isCurrentStation(stationUuid)) {
@@ -484,7 +555,7 @@
 
       // Proxy artwork so the webview can display it.
       const art = favicon ? await LibraryService.ProxyImageURL(favicon) : '';
-      await PlayerService.PlayRadioStation(stationUuid, name, url, art, tags);
+      await PlayerService.PlayRadioStation(stationUuid, name, url, art, homepage, tags);
       await refreshPlaybackStatus();
       await loadHistory();
     } catch (err) {
@@ -498,6 +569,7 @@
     name: string,
     url: string,
     favicon: string,
+    homepage: string,
     tags: string
   ) {
     const target = event.target as HTMLElement;
@@ -505,7 +577,7 @@
     if (interactiveTarget && !interactiveTarget.classList.contains('station-main')) {
       return;
     }
-    await playStation(stationUuid, name, url, favicon, tags);
+    await playStation(stationUuid, name, url, favicon, homepage, tags);
   }
 
   async function handleStationKeydown(
@@ -514,6 +586,7 @@
     name: string,
     url: string,
     favicon: string,
+    homepage: string,
     tags: string
   ) {
     if (event.key !== 'Enter' && event.key !== ' ') {
@@ -525,7 +598,7 @@
       return;
     }
     event.preventDefault();
-    await playStation(stationUuid, name, url, favicon, tags);
+    await playStation(stationUuid, name, url, favicon, homepage, tags);
   }
 
   function handleGlobalKeydown(event: KeyboardEvent) {
@@ -570,7 +643,7 @@
     } else {
       try {
         await LibraryService.AddRadioFavourite(
-          station.uuid, station.name, station.streamUrl, station.favicon, station.tags
+          station.uuid, station.name, station.streamUrl, station.favicon, station.homepage, station.tags
         );
         favouriteUuids.add(station.uuid);
         favouriteUuids = new Set(favouriteUuids);
@@ -620,7 +693,7 @@
       customFaviconUrl = '';
       customTags = '';
       await loadCustomStations();
-      await playStation(saved.stationUuid, saved.name, saved.streamUrl, saved.faviconUrl, saved.tags);
+      await playStation(saved.stationUuid, saved.name, saved.streamUrl, saved.faviconUrl, saved.homepage || '', saved.tags);
     } catch (err: any) {
       customError = err?.message || String(err);
     } finally {
@@ -670,6 +743,13 @@
     }
     return onRadioTagFilterChange(addTagFilter);
   });
+
+  $effect(() => {
+    return onRadioStationDetailChange((uuid, hint) => {
+      selectedStationUuid = uuid;
+      selectedStationHint = hint;
+    });
+  });
 </script>
 
 <svelte:window onkeydown={handleGlobalKeydown} />
@@ -677,6 +757,13 @@
 <div class="radio-view">
   <h2>Radio</h2>
 
+  {#if selectedStationUuid}
+    <RadioStationView
+      stationUuid={selectedStationUuid}
+      hint={selectedStationHint}
+      onback={closeStationDetail}
+    />
+  {:else}
   <div class="tabs" role="tablist" aria-label="Radio sections">
     <button class="tab" class:active={tab === 'featured'} role="tab" aria-selected={tab === 'featured'} aria-controls="radio-panel-featured" id="radio-tab-featured" onclick={() => tab = 'featured'}>
       Browse
@@ -826,7 +913,7 @@
             aria-current={isCurrentStation(station.uuid) ? 'true' : undefined}
             class:playing={isCurrentStation(station.uuid)}
           >
-            <button class="station-play" class:playing={isCurrentStation(station.uuid)} onclick={() => playStation(station.uuid, station.name, station.streamUrl, station.favicon, station.tags)} aria-label={isPlayingStation(station.uuid) ? `Pause ${station.name}` : `Play ${station.name}`}>
+            <button class="station-play" class:playing={isCurrentStation(station.uuid)} onclick={() => playStation(station.uuid, station.name, station.streamUrl, station.favicon, station.homepage, station.tags)} aria-label={isPlayingStation(station.uuid) ? `Pause ${station.name}` : `Play ${station.name}`}>
               {#if isPlayingStation(station.uuid)}
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
                   <path d="M6 19h4V5H6zm8-14v14h4V5z"/>
@@ -843,8 +930,8 @@
               class="station-main"
               aria-label={`Play or pause ${station.name}`}
               title="Double-click or press Enter to play or pause"
-              ondblclick={(event) => handleStationDoubleClick(event, station.uuid, station.name, station.streamUrl, station.favicon, station.tags)}
-              onkeydown={(event) => handleStationKeydown(event, station.uuid, station.name, station.streamUrl, station.favicon, station.tags)}
+              ondblclick={(event) => handleStationDoubleClick(event, station.uuid, station.name, station.streamUrl, station.favicon, station.homepage, station.tags)}
+              onkeydown={(event) => handleStationKeydown(event, station.uuid, station.name, station.streamUrl, station.favicon, station.homepage, station.tags)}
             >
             {#if resolvedIcon(station.favicon)}
               <img class="station-icon" src={resolvedIcon(station.favicon)} alt="" />
@@ -854,7 +941,7 @@
               </div>
             {/if}
             <div class="station-info">
-              <div class="station-name">{station.name}</div>
+              <button type="button" class="station-name" onclick={(event) => { event.stopPropagation(); openStationDetail(stationHintFromStation(station)); }}>{station.name}</button>
               <div class="station-meta">
                 {#if isPlayingStation(station.uuid)}<span class="playing-badge">Playing</span>{/if}
                 {#if isPausedStation(station.uuid)}<span class="playing-badge">Paused</span>{/if}
@@ -908,7 +995,7 @@
             aria-current={isCurrentStation(fav.stationUuid) ? 'true' : undefined}
             class:playing={isCurrentStation(fav.stationUuid)}
           >
-            <button class="station-play" class:playing={isCurrentStation(fav.stationUuid)} onclick={() => playStation(fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.tags)} aria-label={isPlayingStation(fav.stationUuid) ? `Pause ${fav.name}` : `Play ${fav.name}`}>
+            <button class="station-play" class:playing={isCurrentStation(fav.stationUuid)} onclick={() => playStation(fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.homepage, fav.tags)} aria-label={isPlayingStation(fav.stationUuid) ? `Pause ${fav.name}` : `Play ${fav.name}`}>
               {#if isPlayingStation(fav.stationUuid)}
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
                   <path d="M6 19h4V5H6zm8-14v14h4V5z"/>
@@ -925,8 +1012,8 @@
               class="station-main"
               aria-label={`Play or pause ${fav.name}`}
               title="Double-click or press Enter to play or pause"
-              ondblclick={(event) => handleStationDoubleClick(event, fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.tags)}
-              onkeydown={(event) => handleStationKeydown(event, fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.tags)}
+              ondblclick={(event) => handleStationDoubleClick(event, fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.homepage, fav.tags)}
+              onkeydown={(event) => handleStationKeydown(event, fav.stationUuid, fav.name, fav.streamUrl, fav.faviconUrl, fav.homepage, fav.tags)}
             >
             {#if resolvedIcon(fav.faviconUrl)}
               <img class="station-icon" src={resolvedIcon(fav.faviconUrl)} alt="" />
@@ -936,7 +1023,7 @@
               </div>
             {/if}
             <div class="station-info">
-              <div class="station-name">{fav.name}</div>
+              <button type="button" class="station-name" onclick={(event) => { event.stopPropagation(); openStationDetail(stationHintFromFavourite(fav)); }}>{fav.name}</button>
               <div class="station-meta">
                 {#if isPlayingStation(fav.stationUuid)}<span class="playing-badge">Playing</span>{/if}
                 {#if isPausedStation(fav.stationUuid)}<span class="playing-badge">Paused</span>{/if}
@@ -1007,7 +1094,7 @@
             aria-current={isCurrentStation(station.stationUuid) ? 'true' : undefined}
             class:playing={isCurrentStation(station.stationUuid)}
           >
-            <button class="station-play" class:playing={isCurrentStation(station.stationUuid)} onclick={() => playStation(station.stationUuid, station.name, station.streamUrl, station.faviconUrl, station.tags)} aria-label={isPlayingStation(station.stationUuid) ? `Pause ${station.name}` : `Play ${station.name}`}>
+            <button class="station-play" class:playing={isCurrentStation(station.stationUuid)} onclick={() => playStation(station.stationUuid, station.name, station.streamUrl, station.faviconUrl, '', station.tags)} aria-label={isPlayingStation(station.stationUuid) ? `Pause ${station.name}` : `Play ${station.name}`}>
               {#if isPlayingStation(station.stationUuid)}
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
                   <path d="M6 19h4V5H6zm8-14v14h4V5z"/>
@@ -1024,8 +1111,8 @@
               class="station-main"
               aria-label={`Play or pause ${station.name}`}
               title="Double-click or press Enter to play or pause"
-              ondblclick={(event) => handleStationDoubleClick(event, station.stationUuid, station.name, station.streamUrl, station.faviconUrl, station.tags)}
-              onkeydown={(event) => handleStationKeydown(event, station.stationUuid, station.name, station.streamUrl, station.faviconUrl, station.tags)}
+              ondblclick={(event) => handleStationDoubleClick(event, station.stationUuid, station.name, station.streamUrl, station.faviconUrl, '', station.tags)}
+              onkeydown={(event) => handleStationKeydown(event, station.stationUuid, station.name, station.streamUrl, station.faviconUrl, '', station.tags)}
             >
             {#if resolvedIcon(station.faviconUrl)}
               <img class="station-icon" src={resolvedIcon(station.faviconUrl)} alt="" />
@@ -1035,7 +1122,7 @@
               </div>
             {/if}
             <div class="station-info">
-              <div class="station-name">{station.name}</div>
+              <button type="button" class="station-name" onclick={(event) => { event.stopPropagation(); openStationDetail({ uuid: station.stationUuid, name: station.name, streamUrl: station.streamUrl, favicon: station.faviconUrl, tags: station.tags }); }}>{station.name}</button>
               {#if isPlayingStation(station.stationUuid)}
                 <div class="station-meta"><span class="playing-badge">Playing</span></div>
               {/if}
@@ -1079,7 +1166,7 @@
             aria-current={isCurrentStation(item.stationUuid) ? 'true' : undefined}
             class:playing={isCurrentStation(item.stationUuid)}
           >
-            <button class="station-play" class:playing={isCurrentStation(item.stationUuid)} onclick={() => playStation(item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.tags)} aria-label={isPlayingStation(item.stationUuid) ? `Pause ${item.name}` : `Play ${item.name}`}>
+            <button class="station-play" class:playing={isCurrentStation(item.stationUuid)} onclick={() => playStation(item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.homepage, item.tags)} aria-label={isPlayingStation(item.stationUuid) ? `Pause ${item.name}` : `Play ${item.name}`}>
               {#if isPlayingStation(item.stationUuid)}
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
                   <path d="M6 19h4V5H6zm8-14v14h4V5z"/>
@@ -1096,8 +1183,8 @@
               class="station-main"
               aria-label={`Play or pause ${item.name}`}
               title="Double-click or press Enter to play or pause"
-              ondblclick={(event) => handleStationDoubleClick(event, item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.tags)}
-              onkeydown={(event) => handleStationKeydown(event, item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.tags)}
+              ondblclick={(event) => handleStationDoubleClick(event, item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.homepage, item.tags)}
+              onkeydown={(event) => handleStationKeydown(event, item.stationUuid, item.name, item.streamUrl, item.faviconUrl, item.homepage, item.tags)}
             >
             {#if resolvedIcon(item.faviconUrl)}
               <img class="station-icon" src={resolvedIcon(item.faviconUrl)} alt="" />
@@ -1107,7 +1194,7 @@
               </div>
             {/if}
             <div class="station-info">
-              <div class="station-name">{item.name}</div>
+              <button type="button" class="station-name" onclick={(event) => { event.stopPropagation(); openStationDetail(stationHintFromHistory(item)); }}>{item.name}</button>
               <div class="station-meta">
                 {#if isPlayingStation(item.stationUuid)}<span class="playing-badge">Playing</span>{/if}
                 {#if isPausedStation(item.stationUuid)}<span class="playing-badge">Paused</span>{/if}
@@ -1129,6 +1216,7 @@
       </div>
     {/if}
     </div>
+  {/if}
   {/if}
 </div>
 
@@ -1446,12 +1534,24 @@
   }
 
   .station-name {
+    display: block;
+    width: 100%;
+    padding: 0;
+    border: none;
+    background: transparent;
+    text-align: left;
     font-size: 0.9rem;
     font-weight: 500;
     color: var(--text-primary);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    cursor: pointer;
+  }
+
+  .station-name:hover {
+    color: var(--accent);
+    text-decoration: underline;
   }
 
   .station-meta {

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -21,6 +21,22 @@ const _titlebarPreferenceListeners: Array<(enabled: boolean) => void> = [];
 let _radioTagFilter = '';
 const _radioTagFilterListeners: Array<(tag: string) => void> = [];
 
+export type RadioStationHint = {
+  uuid: string;
+  name?: string;
+  streamUrl?: string;
+  favicon?: string;
+  homepage?: string;
+  tags?: string;
+  country?: string;
+  bitrate?: number;
+  codec?: string;
+};
+
+let _radioStationDetail: string | null = null;
+let _radioStationHint: RadioStationHint | null = null;
+const _radioStationDetailListeners: Array<(uuid: string | null, hint: RadioStationHint | null) => void> = [];
+
 export function getCurrentView(): View {
   return _currentView;
 }
@@ -126,5 +142,40 @@ export function onRadioTagFilterChange(fn: (tag: string) => void): () => void {
   return () => {
     const idx = _radioTagFilterListeners.indexOf(fn);
     if (idx >= 0) _radioTagFilterListeners.splice(idx, 1);
+  };
+}
+
+export function getRadioStationDetail(): string | null {
+  return _radioStationDetail;
+}
+
+export function getRadioStationHint(): RadioStationHint | null {
+  return _radioStationHint;
+}
+
+export function openRadioStation(uuid: string, hint: Omit<RadioStationHint, 'uuid'> = {}) {
+  _radioStationDetail = uuid;
+  _radioStationHint = { uuid, ...hint };
+  setCurrentView('radio');
+  for (const fn of _radioStationDetailListeners) {
+    fn(uuid, _radioStationHint);
+  }
+}
+
+export function clearRadioStationDetail() {
+  _radioStationDetail = null;
+  _radioStationHint = null;
+  for (const fn of _radioStationDetailListeners) {
+    fn(null, null);
+  }
+}
+
+export function onRadioStationDetailChange(
+  fn: (uuid: string | null, hint: RadioStationHint | null) => void
+): () => void {
+  _radioStationDetailListeners.push(fn);
+  return () => {
+    const idx = _radioStationDetailListeners.indexOf(fn);
+    if (idx >= 0) _radioStationDetailListeners.splice(idx, 1);
   };
 }

--- a/frontend/tests/mocks/wails-runtime.ts
+++ b/frontend/tests/mocks/wails-runtime.ts
@@ -15,7 +15,7 @@ let radioFavourites = [
 let customStations: any[] = [];
 
 let radioHistory = [
-  { stationUuid: "st-3", name: "Classical 24", streamUrl: "https://stream.example.com/classical", faviconUrl: "https://img.example.com/classical.png", tags: "classical", lastTitle: "Morning Concert", lastError: "", playCount: 3, lastPlayedAt: "2024-01-02 09:00:00" },
+  { stationUuid: "st-3", name: "Classical 24", streamUrl: "https://stream.example.com/classical", faviconUrl: "https://img.example.com/classical.png", homepage: "https://classical24.example.com/", tags: "classical", lastTitle: "Morning Concert", lastError: "", playCount: 3, lastPlayedAt: "2024-01-02 09:00:00" },
 ];
 
 let playbackStatus = {
@@ -44,8 +44,8 @@ function stationIcon(label: string, background: string, foreground = "ffffff") {
 }
 
 const demoStations = [
-  { uuid: "somafm-missioncontrol", name: "Ishq - Iqqoa", streamUrl: "https://stream.example.com/mission-control", favicon: stationIcon("MC", "1f2937"), country: "SomaFM Mission Control", tags: "ambient,space,electronic", bitrate: 128, codec: "MP3" },
-  { uuid: "st-jazz-fm", name: "Jazz FM", streamUrl: "https://stream.example.com/jazz-fm", favicon: stationIcon("JF", "2563eb"), country: "United Kingdom", tags: "jazz,smooth", bitrate: 128, codec: "MP3" },
+  { uuid: "somafm-missioncontrol", name: "Ishq - Iqqoa", streamUrl: "https://stream.example.com/mission-control", homepage: "https://somafm.com/missioncontrol/", favicon: stationIcon("MC", "1f2937"), country: "SomaFM Mission Control", tags: "ambient,space,electronic", bitrate: 128, codec: "MP3" },
+  { uuid: "st-jazz-fm", name: "Jazz FM", streamUrl: "https://stream.example.com/jazz-fm", homepage: "https://www.jazzfm.com/", favicon: stationIcon("JF", "2563eb"), country: "United Kingdom", tags: "jazz,smooth", bitrate: 128, codec: "MP3" },
   { uuid: "st-classical-24", name: "Classical 24", streamUrl: "https://stream.example.com/classical", favicon: stationIcon("C24", "7c2d12"), country: "France", tags: "classical,orchestral", bitrate: 320, codec: "MP3" },
   { uuid: "st-mangoradio", name: "MANGORADIO", streamUrl: "https://stream.example.com/mango", favicon: stationIcon("M", "f59e0b", "111827"), country: "Germany", tags: "music,variety", bitrate: 128, codec: "MP3" },
   { uuid: "st-radio-paradise", name: "Radio Paradise Main Mix (EU) 320k AAC", streamUrl: "https://stream.example.com/rp", favicon: stationIcon("RP", "f8fafc", "334155"), country: "The United States Of America", tags: "california,eclectic,free,internet", bitrate: 320, codec: "AAC" },
@@ -55,7 +55,7 @@ const demoStations = [
   { uuid: "st-walm-old-time", name: "WALM - Old Time Radio", streamUrl: "https://stream.example.com/walm", favicon: stationIcon("OTR", "22c55e", "052e16"), country: "The United States Of America", tags: "78,78-rpm,classic", bitrate: 64, codec: "MP3" },
 ];
 
-function upsertHistory(stationUuid: string, name: string, streamUrl: string, faviconUrl: string, tags: string) {
+function upsertHistory(stationUuid: string, name: string, streamUrl: string, faviconUrl: string, homepage: string, tags: string) {
   const existing = radioHistory.find((h) => h.stationUuid === stationUuid);
   if (existing) {
     existing.playCount += 1;
@@ -68,6 +68,7 @@ function upsertHistory(stationUuid: string, name: string, streamUrl: string, fav
     name,
     streamUrl,
     faviconUrl,
+    homepage,
     tags,
     lastTitle: "",
     lastError: "",
@@ -226,11 +227,21 @@ const fixtures: Record<number, (...args: any[]) => any> = {
   // GetRadioFavourites
   590575721: () => radioFavourites,
   // AddRadioFavourite
-  3744144887: (stationUuid: string, name: string, streamUrl: string, faviconUrl: string, tags: string) => {
+  3744144887: (stationUuid: string, name: string, streamUrl: string, faviconUrl: string, homepage: string, tags: string) => {
     if (!radioFavourites.some((f) => f.stationUuid === stationUuid)) {
-      radioFavourites.push({ stationUuid, name, streamUrl, faviconUrl, tags, addedAt: "2024-01-03 10:00:00", pinned: false });
+      radioFavourites.push({ stationUuid, name, streamUrl, faviconUrl, homepage, tags, addedAt: "2024-01-03 10:00:00", pinned: false });
     }
   },
+  // GetRadioStationByUUID
+  4150278773: (stationUuid: string) => {
+    const station = demoStations.find((s) => s.uuid === stationUuid);
+    if (!station) {
+      throw new Error("station not found");
+    }
+    return { ...station, votes: 120, clicks: 340 };
+  },
+  // OpenURL
+  1380764543: () => undefined,
   // RemoveRadioFavourite
   876184048: (stationUuid: string) => {
     radioFavourites = radioFavourites.filter((f) => f.stationUuid !== stationUuid);
@@ -285,11 +296,11 @@ const fixtures: Record<number, (...args: any[]) => any> = {
   // PlayRadio
   1236378929: () => undefined,
   // PlayRadioStation
-  3331506535: (stationUuid: string, name: string, streamUrl: string, artworkUrl: string, tags: string) => {
+  3331506535: (stationUuid: string, name: string, streamUrl: string, artworkUrl: string, homepage: string, tags: string) => {
     if (globalThis.localStorage?.getItem("forte.failPlayRadioStation") === "true") {
       throw new Error("stream unavailable");
     }
-    upsertHistory(stationUuid, name, streamUrl, artworkUrl, tags);
+    upsertHistory(stationUuid, name, streamUrl, artworkUrl, homepage, tags);
     playbackStatus = {
       ...playbackStatus,
       state: "playing",

--- a/frontend/tests/mocks/wails-runtime.ts
+++ b/frontend/tests/mocks/wails-runtime.ts
@@ -227,9 +227,31 @@ const fixtures: Record<number, (...args: any[]) => any> = {
   // GetRadioFavourites
   590575721: () => radioFavourites,
   // AddRadioFavourite
-  3744144887: (stationUuid: string, name: string, streamUrl: string, faviconUrl: string, homepage: string, tags: string) => {
+  3744144887: (
+    stationUuid: string,
+    name: string,
+    streamUrl: string,
+    faviconUrl: string,
+    homepage: string,
+    tags: string,
+    country = "",
+    codec = "",
+    bitrate = 0
+  ) => {
     if (!radioFavourites.some((f) => f.stationUuid === stationUuid)) {
-      radioFavourites.push({ stationUuid, name, streamUrl, faviconUrl, homepage, tags, addedAt: "2024-01-03 10:00:00", pinned: false });
+      radioFavourites.push({
+        stationUuid,
+        name,
+        streamUrl,
+        faviconUrl,
+        homepage,
+        tags,
+        country,
+        codec,
+        bitrate,
+        addedAt: "2024-01-03 10:00:00",
+        pinned: false,
+      });
     }
   },
   // GetRadioStationByUUID
@@ -254,15 +276,18 @@ const fixtures: Record<number, (...args: any[]) => any> = {
   },
   // IsRadioFavourite
   329793224: (stationUuid: string) => radioFavourites.some((f) => f.stationUuid === stationUuid),
+  // GetRadioFavouritePinned
+  4094481906: (stationUuid: string) => radioFavourites.find((f) => f.stationUuid === stationUuid)?.pinned ?? false,
   // GetCustomRadioStations
   2495430549: () => customStations,
   // AddCustomRadioStation
-  3781401643: (name: string, streamUrl: string, faviconUrl: string, tags: string) => {
+  3781401643: (name: string, streamUrl: string, faviconUrl: string, homepage: string, tags: string) => {
     const station = {
       stationUuid: `custom-${customStations.length + 1}`,
       name,
       streamUrl,
       faviconUrl,
+      homepage: homepage || (streamUrl.includes("example.org") ? "https://example.org/" : ""),
       tags,
       createdAt: "2024-01-03 10:00:00",
     };
@@ -296,7 +321,17 @@ const fixtures: Record<number, (...args: any[]) => any> = {
   // PlayRadio
   1236378929: () => undefined,
   // PlayRadioStation
-  3331506535: (stationUuid: string, name: string, streamUrl: string, artworkUrl: string, homepage: string, tags: string) => {
+  3331506535: (
+    stationUuid: string,
+    name: string,
+    streamUrl: string,
+    artworkUrl: string,
+    homepage: string,
+    tags: string,
+    _country = "",
+    _codec = "",
+    _bitrate = 0
+  ) => {
     if (globalThis.localStorage?.getItem("forte.failPlayRadioStation") === "true") {
       throw new Error("stream unavailable");
     }
@@ -304,7 +339,7 @@ const fixtures: Record<number, (...args: any[]) => any> = {
     playbackStatus = {
       ...playbackStatus,
       state: "playing",
-      title: name,
+      title: stationUuid === "st-jazz-fm" ? "Live at Ronnie Scott's" : name,
       artist: stationUuid === "somafm-missioncontrol" ? "SomaFM Mission Control (128k MP3)" : "Radio",
       album: "",
       mediaPath: streamUrl,

--- a/frontend/tests/radio.spec.ts
+++ b/frontend/tests/radio.spec.ts
@@ -260,6 +260,19 @@ test('pressing enter on a focused radio station toggles play and pause', async (
   await expect(station.getByText('Paused')).toBeVisible();
 });
 
+test('opens station detail with homepage and stream links', async ({ page }) => {
+  await radioNavButton(page).click();
+
+  await page.getByRole('button', { name: 'Jazz FM', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Jazz FM', level: 1 })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Links' })).toBeVisible();
+  await expect(page.getByText('https://www.jazzfm.com/')).toBeVisible();
+  await expect(page.getByText('https://stream.example.com/jazz-fm')).toBeVisible();
+
+  await page.locator('.station-view').getByRole('button', { name: 'Radio' }).click();
+  await expect(page.getByRole('tab', { name: 'Browse' })).toBeVisible();
+});
+
 test('shows a recoverable error when a station cannot play', async ({ page }) => {
   await page.evaluate(() => localStorage.setItem('forte.failPlayRadioStation', 'true'));
   await page.reload();

--- a/frontend/tests/radio.spec.ts
+++ b/frontend/tests/radio.spec.ts
@@ -266,11 +266,33 @@ test('opens station detail with homepage and stream links', async ({ page }) => 
   await page.getByRole('button', { name: 'Jazz FM', exact: true }).click();
   await expect(page.getByRole('heading', { name: 'Jazz FM', level: 1 })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Links' })).toBeVisible();
-  await expect(page.getByText('https://www.jazzfm.com/')).toBeVisible();
-  await expect(page.getByText('https://stream.example.com/jazz-fm')).toBeVisible();
 
+  const website = page.getByRole('link', { name: 'https://www.jazzfm.com/' });
+  await expect(website).toHaveAttribute('href', 'https://www.jazzfm.com/');
+  await expect(website).toHaveAttribute('rel', 'noopener noreferrer');
+
+  const stream = page.getByRole('link', { name: 'https://stream.example.com/jazz-fm' });
+  await expect(stream).toHaveAttribute('href', 'https://stream.example.com/jazz-fm');
+  await expect(stream).toHaveAttribute('rel', 'noopener noreferrer');
+
+  await page.locator('.station-view').getByRole('button', { name: 'Open' }).first().click();
   await page.locator('.station-view').getByRole('button', { name: 'Radio' }).click();
   await expect(page.getByRole('tab', { name: 'Browse' })).toBeVisible();
+});
+
+test('station detail shows now playing track when station is active', async ({ page }) => {
+  await radioNavButton(page).click();
+  await page.getByRole('button', { name: 'Play Jazz FM' }).click();
+  await page.locator('.station-list').getByRole('button', { name: 'Jazz FM', exact: true }).click();
+  await expect(page.getByText("Now playing: Live at Ronnie Scott's")).toBeVisible();
+});
+
+test('station detail can pin a favourite', async ({ page }) => {
+  await radioNavButton(page).click();
+  await page.getByRole('button', { name: 'Jazz FM', exact: true }).click();
+  await page.getByRole('button', { name: 'Add favourite' }).click();
+  await page.getByRole('button', { name: 'Pin' }).click();
+  await expect(page.getByRole('button', { name: 'Unpin' })).toBeVisible();
 });
 
 test('shows a recoverable error when a station cannot play', async ({ page }) => {

--- a/internal/library/db.go
+++ b/internal/library/db.go
@@ -102,4 +102,5 @@ var migrations = []migration{
 	{version: 12, sql: migration012},
 	{version: 13, sql: migration013},
 	{version: 14, sql: migration014},
+	{version: 15, sql: migration015},
 }

--- a/internal/library/db.go
+++ b/internal/library/db.go
@@ -103,4 +103,5 @@ var migrations = []migration{
 	{version: 13, sql: migration013},
 	{version: 14, sql: migration014},
 	{version: 15, sql: migration015},
+	{version: 16, sql: migration016},
 }

--- a/internal/library/radio_favourites.go
+++ b/internal/library/radio_favourites.go
@@ -14,6 +14,7 @@ type RadioFavourite struct {
 	Name        string
 	StreamURL   string
 	FaviconURL  string
+	Homepage    string
 	Tags        string
 	AddedAt     string
 	Pinned      bool
@@ -25,6 +26,7 @@ type RadioCustomStation struct {
 	Name        string
 	StreamURL   string
 	FaviconURL  string
+	Homepage    string
 	Tags        string
 	CreatedAt   string
 	UpdatedAt   string
@@ -36,6 +38,7 @@ type RadioHistoryEntry struct {
 	Name         string
 	StreamURL    string
 	FaviconURL   string
+	Homepage     string
 	Tags         string
 	TrackTitle   string
 	PlayCount    int
@@ -55,14 +58,15 @@ type AppPreferences struct {
 // AddRadioFavourite saves a radio station to favourites.
 func (db *DB) AddRadioFavourite(f RadioFavourite) error {
 	_, err := db.Exec(
-		`INSERT INTO radio_favourites (station_uuid, name, stream_url, favicon_url, tags, pinned)
-		 VALUES (?, ?, ?, ?, ?, ?)
+		`INSERT INTO radio_favourites (station_uuid, name, stream_url, favicon_url, homepage, tags, pinned)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(station_uuid) DO UPDATE SET
 			name = excluded.name,
 			stream_url = excluded.stream_url,
 			favicon_url = excluded.favicon_url,
+			homepage = excluded.homepage,
 			tags = excluded.tags`,
-		f.StationUUID, f.Name, f.StreamURL, f.FaviconURL, f.Tags, boolToInt(f.Pinned),
+		f.StationUUID, f.Name, f.StreamURL, f.FaviconURL, f.Homepage, f.Tags, boolToInt(f.Pinned),
 	)
 	if err != nil {
 		return fmt.Errorf("add radio favourite: %w", err)
@@ -91,7 +95,7 @@ func (db *DB) RemoveRadioFavourite(stationUUID string) error {
 // GetRadioFavourites returns all saved radio stations ordered by name.
 func (db *DB) GetRadioFavourites() ([]RadioFavourite, error) {
 	rows, err := db.Query(
-		`SELECT station_uuid, name, stream_url, favicon_url, tags, added_at, pinned
+		`SELECT station_uuid, name, stream_url, favicon_url, homepage, tags, added_at, pinned
 		 FROM radio_favourites
 		 ORDER BY pinned DESC, name COLLATE NOCASE`,
 	)
@@ -104,7 +108,7 @@ func (db *DB) GetRadioFavourites() ([]RadioFavourite, error) {
 	for rows.Next() {
 		var f RadioFavourite
 		var pinned int
-		if err := rows.Scan(&f.StationUUID, &f.Name, &f.StreamURL, &f.FaviconURL, &f.Tags, &f.AddedAt, &pinned); err != nil {
+		if err := rows.Scan(&f.StationUUID, &f.Name, &f.StreamURL, &f.FaviconURL, &f.Homepage, &f.Tags, &f.AddedAt, &pinned); err != nil {
 			return nil, fmt.Errorf("scan radio favourite: %w", err)
 		}
 		f.Pinned = pinned != 0
@@ -129,15 +133,16 @@ func (db *DB) AddCustomRadioStation(st RadioCustomStation) (RadioCustomStation, 
 		st.StationUUID = CustomRadioStationUUID(st.StreamURL)
 	}
 	_, err := db.Exec(
-		`INSERT INTO radio_custom_stations (station_uuid, name, stream_url, favicon_url, tags)
-		 VALUES (?, ?, ?, ?, ?)
+		`INSERT INTO radio_custom_stations (station_uuid, name, stream_url, favicon_url, homepage, tags)
+		 VALUES (?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(station_uuid) DO UPDATE SET
 			name = excluded.name,
 			stream_url = excluded.stream_url,
 			favicon_url = excluded.favicon_url,
+			homepage = excluded.homepage,
 			tags = excluded.tags,
 			updated_at = datetime('now')`,
-		st.StationUUID, st.Name, st.StreamURL, st.FaviconURL, st.Tags,
+		st.StationUUID, st.Name, st.StreamURL, st.FaviconURL, st.Homepage, st.Tags,
 	)
 	if err != nil {
 		return st, fmt.Errorf("add custom radio station: %w", err)
@@ -157,7 +162,7 @@ func (db *DB) DeleteCustomRadioStation(stationUUID string) error {
 // GetCustomRadioStations returns saved user-defined stations.
 func (db *DB) GetCustomRadioStations() ([]RadioCustomStation, error) {
 	rows, err := db.Query(
-		`SELECT station_uuid, name, stream_url, favicon_url, tags, created_at, updated_at
+		`SELECT station_uuid, name, stream_url, favicon_url, homepage, tags, created_at, updated_at
 		 FROM radio_custom_stations
 		 ORDER BY name COLLATE NOCASE`,
 	)
@@ -169,7 +174,7 @@ func (db *DB) GetCustomRadioStations() ([]RadioCustomStation, error) {
 	var stations []RadioCustomStation
 	for rows.Next() {
 		var st RadioCustomStation
-		if err := rows.Scan(&st.StationUUID, &st.Name, &st.StreamURL, &st.FaviconURL, &st.Tags, &st.CreatedAt, &st.UpdatedAt); err != nil {
+		if err := rows.Scan(&st.StationUUID, &st.Name, &st.StreamURL, &st.FaviconURL, &st.Homepage, &st.Tags, &st.CreatedAt, &st.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan custom radio station: %w", err)
 		}
 		stations = append(stations, st)
@@ -180,18 +185,19 @@ func (db *DB) GetCustomRadioStations() ([]RadioCustomStation, error) {
 // RecordRadioPlayback upserts a station into radio playback history.
 func (db *DB) RecordRadioPlayback(st RadioHistoryEntry) error {
 	_, err := db.Exec(
-		`INSERT INTO radio_history (station_uuid, name, stream_url, favicon_url, tags, track_title, play_count, last_error)
-		 VALUES (?, ?, ?, ?, ?, ?, 1, ?)
+		`INSERT INTO radio_history (station_uuid, name, stream_url, favicon_url, homepage, tags, track_title, play_count, last_error)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)
 		 ON CONFLICT(station_uuid) DO UPDATE SET
 			name = excluded.name,
 			stream_url = excluded.stream_url,
 			favicon_url = excluded.favicon_url,
+			homepage = CASE WHEN excluded.homepage != '' THEN excluded.homepage ELSE radio_history.homepage END,
 			tags = excluded.tags,
 			track_title = excluded.track_title,
 			play_count = radio_history.play_count + 1,
 			last_error = excluded.last_error,
 			last_played_at = datetime('now')`,
-		st.StationUUID, st.Name, st.StreamURL, st.FaviconURL, st.Tags, st.TrackTitle, st.LastError,
+		st.StationUUID, st.Name, st.StreamURL, st.FaviconURL, st.Homepage, st.Tags, st.TrackTitle, st.LastError,
 	)
 	if err != nil {
 		return fmt.Errorf("record radio playback: %w", err)
@@ -223,7 +229,7 @@ func (db *DB) GetRadioHistory(limit int) ([]RadioHistoryEntry, error) {
 		limit = 25
 	}
 	rows, err := db.Query(
-		`SELECT station_uuid, name, stream_url, favicon_url, tags, track_title, play_count, last_error, last_played_at
+		`SELECT station_uuid, name, stream_url, favicon_url, homepage, tags, track_title, play_count, last_error, last_played_at
 		 FROM radio_history
 		 ORDER BY last_played_at DESC
 		 LIMIT ?`,
@@ -237,7 +243,7 @@ func (db *DB) GetRadioHistory(limit int) ([]RadioHistoryEntry, error) {
 	var entries []RadioHistoryEntry
 	for rows.Next() {
 		var e RadioHistoryEntry
-		if err := rows.Scan(&e.StationUUID, &e.Name, &e.StreamURL, &e.FaviconURL, &e.Tags, &e.TrackTitle, &e.PlayCount, &e.LastError, &e.LastPlayedAt); err != nil {
+		if err := rows.Scan(&e.StationUUID, &e.Name, &e.StreamURL, &e.FaviconURL, &e.Homepage, &e.Tags, &e.TrackTitle, &e.PlayCount, &e.LastError, &e.LastPlayedAt); err != nil {
 			return nil, fmt.Errorf("scan radio history: %w", err)
 		}
 		entries = append(entries, e)

--- a/internal/library/radio_favourites.go
+++ b/internal/library/radio_favourites.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/willfish/forte/internal/logx"
 )
@@ -15,6 +16,9 @@ type RadioFavourite struct {
 	StreamURL   string
 	FaviconURL  string
 	Homepage    string
+	Country     string
+	Codec       string
+	Bitrate     int
 	Tags        string
 	AddedAt     string
 	Pinned      bool
@@ -27,6 +31,9 @@ type RadioCustomStation struct {
 	StreamURL   string
 	FaviconURL  string
 	Homepage    string
+	Country     string
+	Codec       string
+	Bitrate     int
 	Tags        string
 	CreatedAt   string
 	UpdatedAt   string
@@ -39,6 +46,9 @@ type RadioHistoryEntry struct {
 	StreamURL    string
 	FaviconURL   string
 	Homepage     string
+	Country      string
+	Codec        string
+	Bitrate      int
 	Tags         string
 	TrackTitle   string
 	PlayCount    int
@@ -58,15 +68,18 @@ type AppPreferences struct {
 // AddRadioFavourite saves a radio station to favourites.
 func (db *DB) AddRadioFavourite(f RadioFavourite) error {
 	_, err := db.Exec(
-		`INSERT INTO radio_favourites (station_uuid, name, stream_url, favicon_url, homepage, tags, pinned)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO radio_favourites (station_uuid, name, stream_url, favicon_url, homepage, country, codec, bitrate, tags, pinned)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(station_uuid) DO UPDATE SET
 			name = excluded.name,
 			stream_url = excluded.stream_url,
 			favicon_url = excluded.favicon_url,
-			homepage = excluded.homepage,
+			homepage = CASE WHEN excluded.homepage != '' THEN excluded.homepage ELSE radio_favourites.homepage END,
+			country = CASE WHEN excluded.country != '' THEN excluded.country ELSE radio_favourites.country END,
+			codec = CASE WHEN excluded.codec != '' THEN excluded.codec ELSE radio_favourites.codec END,
+			bitrate = CASE WHEN excluded.bitrate > 0 THEN excluded.bitrate ELSE radio_favourites.bitrate END,
 			tags = excluded.tags`,
-		f.StationUUID, f.Name, f.StreamURL, f.FaviconURL, f.Homepage, f.Tags, boolToInt(f.Pinned),
+		f.StationUUID, f.Name, f.StreamURL, f.FaviconURL, f.Homepage, f.Country, f.Codec, f.Bitrate, f.Tags, boolToInt(f.Pinned),
 	)
 	if err != nil {
 		return fmt.Errorf("add radio favourite: %w", err)
@@ -95,7 +108,7 @@ func (db *DB) RemoveRadioFavourite(stationUUID string) error {
 // GetRadioFavourites returns all saved radio stations ordered by name.
 func (db *DB) GetRadioFavourites() ([]RadioFavourite, error) {
 	rows, err := db.Query(
-		`SELECT station_uuid, name, stream_url, favicon_url, homepage, tags, added_at, pinned
+		`SELECT station_uuid, name, stream_url, favicon_url, homepage, country, codec, bitrate, tags, added_at, pinned
 		 FROM radio_favourites
 		 ORDER BY pinned DESC, name COLLATE NOCASE`,
 	)
@@ -108,13 +121,23 @@ func (db *DB) GetRadioFavourites() ([]RadioFavourite, error) {
 	for rows.Next() {
 		var f RadioFavourite
 		var pinned int
-		if err := rows.Scan(&f.StationUUID, &f.Name, &f.StreamURL, &f.FaviconURL, &f.Homepage, &f.Tags, &f.AddedAt, &pinned); err != nil {
+		if err := rows.Scan(&f.StationUUID, &f.Name, &f.StreamURL, &f.FaviconURL, &f.Homepage, &f.Country, &f.Codec, &f.Bitrate, &f.Tags, &f.AddedAt, &pinned); err != nil {
 			return nil, fmt.Errorf("scan radio favourite: %w", err)
 		}
 		f.Pinned = pinned != 0
 		favs = append(favs, f)
 	}
 	return favs, rows.Err()
+}
+
+// GetRadioFavouritePinned returns whether a favourite station is pinned.
+func (db *DB) GetRadioFavouritePinned(stationUUID string) (bool, error) {
+	var pinned int
+	err := db.QueryRow("SELECT pinned FROM radio_favourites WHERE station_uuid = ?", stationUUID).Scan(&pinned)
+	if err != nil {
+		return false, nil
+	}
+	return pinned != 0, nil
 }
 
 // IsRadioFavourite checks if a station is in favourites.
@@ -132,17 +155,23 @@ func (db *DB) AddCustomRadioStation(st RadioCustomStation) (RadioCustomStation, 
 	if st.StationUUID == "" {
 		st.StationUUID = CustomRadioStationUUID(st.StreamURL)
 	}
+	if strings.TrimSpace(st.Homepage) == "" {
+		st.Homepage = DeriveHomepageFromStreamURL(st.StreamURL)
+	}
 	_, err := db.Exec(
-		`INSERT INTO radio_custom_stations (station_uuid, name, stream_url, favicon_url, homepage, tags)
-		 VALUES (?, ?, ?, ?, ?, ?)
+		`INSERT INTO radio_custom_stations (station_uuid, name, stream_url, favicon_url, homepage, country, codec, bitrate, tags)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(station_uuid) DO UPDATE SET
 			name = excluded.name,
 			stream_url = excluded.stream_url,
 			favicon_url = excluded.favicon_url,
 			homepage = excluded.homepage,
+			country = excluded.country,
+			codec = excluded.codec,
+			bitrate = excluded.bitrate,
 			tags = excluded.tags,
 			updated_at = datetime('now')`,
-		st.StationUUID, st.Name, st.StreamURL, st.FaviconURL, st.Homepage, st.Tags,
+		st.StationUUID, st.Name, st.StreamURL, st.FaviconURL, st.Homepage, st.Country, st.Codec, st.Bitrate, st.Tags,
 	)
 	if err != nil {
 		return st, fmt.Errorf("add custom radio station: %w", err)
@@ -162,7 +191,7 @@ func (db *DB) DeleteCustomRadioStation(stationUUID string) error {
 // GetCustomRadioStations returns saved user-defined stations.
 func (db *DB) GetCustomRadioStations() ([]RadioCustomStation, error) {
 	rows, err := db.Query(
-		`SELECT station_uuid, name, stream_url, favicon_url, homepage, tags, created_at, updated_at
+		`SELECT station_uuid, name, stream_url, favicon_url, homepage, country, codec, bitrate, tags, created_at, updated_at
 		 FROM radio_custom_stations
 		 ORDER BY name COLLATE NOCASE`,
 	)
@@ -174,7 +203,7 @@ func (db *DB) GetCustomRadioStations() ([]RadioCustomStation, error) {
 	var stations []RadioCustomStation
 	for rows.Next() {
 		var st RadioCustomStation
-		if err := rows.Scan(&st.StationUUID, &st.Name, &st.StreamURL, &st.FaviconURL, &st.Homepage, &st.Tags, &st.CreatedAt, &st.UpdatedAt); err != nil {
+		if err := rows.Scan(&st.StationUUID, &st.Name, &st.StreamURL, &st.FaviconURL, &st.Homepage, &st.Country, &st.Codec, &st.Bitrate, &st.Tags, &st.CreatedAt, &st.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan custom radio station: %w", err)
 		}
 		stations = append(stations, st)
@@ -185,19 +214,22 @@ func (db *DB) GetCustomRadioStations() ([]RadioCustomStation, error) {
 // RecordRadioPlayback upserts a station into radio playback history.
 func (db *DB) RecordRadioPlayback(st RadioHistoryEntry) error {
 	_, err := db.Exec(
-		`INSERT INTO radio_history (station_uuid, name, stream_url, favicon_url, homepage, tags, track_title, play_count, last_error)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)
+		`INSERT INTO radio_history (station_uuid, name, stream_url, favicon_url, homepage, country, codec, bitrate, tags, track_title, play_count, last_error)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
 		 ON CONFLICT(station_uuid) DO UPDATE SET
 			name = excluded.name,
 			stream_url = excluded.stream_url,
 			favicon_url = excluded.favicon_url,
 			homepage = CASE WHEN excluded.homepage != '' THEN excluded.homepage ELSE radio_history.homepage END,
+			country = CASE WHEN excluded.country != '' THEN excluded.country ELSE radio_history.country END,
+			codec = CASE WHEN excluded.codec != '' THEN excluded.codec ELSE radio_history.codec END,
+			bitrate = CASE WHEN excluded.bitrate > 0 THEN excluded.bitrate ELSE radio_history.bitrate END,
 			tags = excluded.tags,
 			track_title = excluded.track_title,
 			play_count = radio_history.play_count + 1,
 			last_error = excluded.last_error,
 			last_played_at = datetime('now')`,
-		st.StationUUID, st.Name, st.StreamURL, st.FaviconURL, st.Homepage, st.Tags, st.TrackTitle, st.LastError,
+		st.StationUUID, st.Name, st.StreamURL, st.FaviconURL, st.Homepage, st.Country, st.Codec, st.Bitrate, st.Tags, st.TrackTitle, st.LastError,
 	)
 	if err != nil {
 		return fmt.Errorf("record radio playback: %w", err)
@@ -229,7 +261,7 @@ func (db *DB) GetRadioHistory(limit int) ([]RadioHistoryEntry, error) {
 		limit = 25
 	}
 	rows, err := db.Query(
-		`SELECT station_uuid, name, stream_url, favicon_url, homepage, tags, track_title, play_count, last_error, last_played_at
+		`SELECT station_uuid, name, stream_url, favicon_url, homepage, country, codec, bitrate, tags, track_title, play_count, last_error, last_played_at
 		 FROM radio_history
 		 ORDER BY last_played_at DESC
 		 LIMIT ?`,
@@ -243,7 +275,7 @@ func (db *DB) GetRadioHistory(limit int) ([]RadioHistoryEntry, error) {
 	var entries []RadioHistoryEntry
 	for rows.Next() {
 		var e RadioHistoryEntry
-		if err := rows.Scan(&e.StationUUID, &e.Name, &e.StreamURL, &e.FaviconURL, &e.Homepage, &e.Tags, &e.TrackTitle, &e.PlayCount, &e.LastError, &e.LastPlayedAt); err != nil {
+		if err := rows.Scan(&e.StationUUID, &e.Name, &e.StreamURL, &e.FaviconURL, &e.Homepage, &e.Country, &e.Codec, &e.Bitrate, &e.Tags, &e.TrackTitle, &e.PlayCount, &e.LastError, &e.LastPlayedAt); err != nil {
 			return nil, fmt.Errorf("scan radio history: %w", err)
 		}
 		entries = append(entries, e)

--- a/internal/library/radio_favourites_test.go
+++ b/internal/library/radio_favourites_test.go
@@ -17,6 +17,50 @@ func testDB(t *testing.T) *DB {
 	return db
 }
 
+func TestRadioHomepagePersistence(t *testing.T) {
+	db := openTestDB(t)
+
+	fav := RadioFavourite{
+		StationUUID: "abc-123",
+		Name:        "Jazz FM",
+		StreamURL:   "https://stream.example.com/jazz",
+		FaviconURL:  "https://example.com/icon.png",
+		Homepage:    "https://jazzfm.com/",
+		Tags:        "jazz",
+	}
+	if err := db.AddRadioFavourite(fav); err != nil {
+		t.Fatalf("AddRadioFavourite: %v", err)
+	}
+
+	favs, err := db.GetRadioFavourites()
+	if err != nil {
+		t.Fatalf("GetRadioFavourites: %v", err)
+	}
+	if len(favs) != 1 || favs[0].Homepage != fav.Homepage {
+		t.Fatalf("favourite homepage = %q, want %q", favs[0].Homepage, fav.Homepage)
+	}
+
+	entry := RadioHistoryEntry{
+		StationUUID: fav.StationUUID,
+		Name:        fav.Name,
+		StreamURL:   fav.StreamURL,
+		FaviconURL:  fav.FaviconURL,
+		Homepage:    fav.Homepage,
+		Tags:        fav.Tags,
+	}
+	if err := db.RecordRadioPlayback(entry); err != nil {
+		t.Fatalf("RecordRadioPlayback: %v", err)
+	}
+
+	history, err := db.GetRadioHistory(5)
+	if err != nil {
+		t.Fatalf("GetRadioHistory: %v", err)
+	}
+	if len(history) != 1 || history[0].Homepage != fav.Homepage {
+		t.Fatalf("history homepage = %q, want %q", history[0].Homepage, fav.Homepage)
+	}
+}
+
 func TestRadioFavouritesRoundTrip(t *testing.T) {
 	db := testDB(t)
 

--- a/internal/library/radio_favourites_test.go
+++ b/internal/library/radio_favourites_test.go
@@ -61,6 +61,91 @@ func TestRadioHomepagePersistence(t *testing.T) {
 	}
 }
 
+func TestRadioStationMetadataPersistence(t *testing.T) {
+	db := openTestDB(t)
+
+	fav := RadioFavourite{
+		StationUUID: "meta-1",
+		Name:        "Classic FM",
+		StreamURL:   "https://stream.example.com/classic",
+		Homepage:    "https://classic.example.com/",
+		Country:     "United Kingdom",
+		Codec:       "MP3",
+		Bitrate:     192,
+		Tags:        "classical",
+	}
+	if err := db.AddRadioFavourite(fav); err != nil {
+		t.Fatalf("AddRadioFavourite: %v", err)
+	}
+
+	favs, err := db.GetRadioFavourites()
+	if err != nil {
+		t.Fatalf("GetRadioFavourites: %v", err)
+	}
+	if len(favs) != 1 {
+		t.Fatalf("got %d favourites, want 1", len(favs))
+	}
+	got := favs[0]
+	if got.Country != fav.Country || got.Codec != fav.Codec || got.Bitrate != fav.Bitrate {
+		t.Fatalf("favourite metadata = %+v, want country=%q codec=%q bitrate=%d", got, fav.Country, fav.Codec, fav.Bitrate)
+	}
+
+	entry := RadioHistoryEntry{
+		StationUUID: fav.StationUUID,
+		Name:        fav.Name,
+		StreamURL:   fav.StreamURL,
+		Homepage:    fav.Homepage,
+		Country:     fav.Country,
+		Codec:       fav.Codec,
+		Bitrate:     fav.Bitrate,
+		Tags:        fav.Tags,
+	}
+	if err := db.RecordRadioPlayback(entry); err != nil {
+		t.Fatalf("RecordRadioPlayback: %v", err)
+	}
+
+	history, err := db.GetRadioHistory(5)
+	if err != nil {
+		t.Fatalf("GetRadioHistory: %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("got %d history rows, want 1", len(history))
+	}
+	h := history[0]
+	if h.Country != fav.Country || h.Codec != fav.Codec || h.Bitrate != fav.Bitrate {
+		t.Fatalf("history metadata = %+v, want country=%q codec=%q bitrate=%d", h, fav.Country, fav.Codec, fav.Bitrate)
+	}
+
+	station, err := db.AddCustomRadioStation(RadioCustomStation{
+		Name:      "My Stream",
+		StreamURL: "https://live.example.org/main.mp3",
+		Homepage:  "https://example.org/",
+		Country:   "Testland",
+		Codec:     "AAC",
+		Bitrate:   128,
+	})
+	if err != nil {
+		t.Fatalf("AddCustomRadioStation: %v", err)
+	}
+	if station.Homepage != "https://example.org/" {
+		t.Fatalf("custom homepage = %q, want https://example.org/", station.Homepage)
+	}
+	if station.Country != "Testland" || station.Codec != "AAC" || station.Bitrate != 128 {
+		t.Fatalf("custom metadata = %+v", station)
+	}
+
+	derived, err := db.AddCustomRadioStation(RadioCustomStation{
+		Name:      "Derived Site",
+		StreamURL: "https://radio.example.net/live",
+	})
+	if err != nil {
+		t.Fatalf("AddCustomRadioStation derived: %v", err)
+	}
+	if derived.Homepage != "https://radio.example.net/" {
+		t.Fatalf("derived homepage = %q, want https://radio.example.net/", derived.Homepage)
+	}
+}
+
 func TestRadioFavouritesRoundTrip(t *testing.T) {
 	db := testDB(t)
 

--- a/internal/library/radio_homepage.go
+++ b/internal/library/radio_homepage.go
@@ -1,0 +1,23 @@
+package library
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+// DeriveHomepageFromStreamURL returns a best-effort website URL from a stream URL host.
+func DeriveHomepageFromStreamURL(streamURL string) string {
+	u, err := url.Parse(strings.TrimSpace(streamURL))
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	host := u.Hostname()
+	if host == "" || host == "localhost" || strings.HasSuffix(host, ".local") {
+		return ""
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ""
+	}
+	return "https://" + host + "/"
+}

--- a/internal/library/radio_homepage_test.go
+++ b/internal/library/radio_homepage_test.go
@@ -1,0 +1,24 @@
+package library
+
+import "testing"
+
+func TestDeriveHomepageFromStreamURL(t *testing.T) {
+	tests := []struct {
+		stream string
+		want   string
+	}{
+		{"https://stream.example.com/jazz-fm", "https://stream.example.com/"},
+		{"http://radio.host/path/live.mp3", "https://radio.host/"},
+		{"", ""},
+		{"not-a-url", ""},
+		{"http://127.0.0.1/stream", ""},
+		{"http://localhost/stream", ""},
+	}
+
+	for _, tt := range tests {
+		got := DeriveHomepageFromStreamURL(tt.stream)
+		if got != tt.want {
+			t.Errorf("DeriveHomepageFromStreamURL(%q) = %q, want %q", tt.stream, got, tt.want)
+		}
+	}
+}

--- a/internal/library/schema.go
+++ b/internal/library/schema.go
@@ -230,6 +230,12 @@ const migration014 = `
 ALTER TABLE app_preferences ADD COLUMN log_level TEXT NOT NULL DEFAULT 'warn';
 `
 
+const migration015 = `
+ALTER TABLE radio_favourites ADD COLUMN homepage TEXT NOT NULL DEFAULT '';
+ALTER TABLE radio_history ADD COLUMN homepage TEXT NOT NULL DEFAULT '';
+ALTER TABLE radio_custom_stations ADD COLUMN homepage TEXT NOT NULL DEFAULT '';
+`
+
 const migration013 = `
 DROP TABLE fts_tracks;
 

--- a/internal/library/schema.go
+++ b/internal/library/schema.go
@@ -236,6 +236,20 @@ ALTER TABLE radio_history ADD COLUMN homepage TEXT NOT NULL DEFAULT '';
 ALTER TABLE radio_custom_stations ADD COLUMN homepage TEXT NOT NULL DEFAULT '';
 `
 
+const migration016 = `
+ALTER TABLE radio_favourites ADD COLUMN country TEXT NOT NULL DEFAULT '';
+ALTER TABLE radio_favourites ADD COLUMN codec TEXT NOT NULL DEFAULT '';
+ALTER TABLE radio_favourites ADD COLUMN bitrate INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE radio_history ADD COLUMN country TEXT NOT NULL DEFAULT '';
+ALTER TABLE radio_history ADD COLUMN codec TEXT NOT NULL DEFAULT '';
+ALTER TABLE radio_history ADD COLUMN bitrate INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE radio_custom_stations ADD COLUMN country TEXT NOT NULL DEFAULT '';
+ALTER TABLE radio_custom_stations ADD COLUMN codec TEXT NOT NULL DEFAULT '';
+ALTER TABLE radio_custom_stations ADD COLUMN bitrate INTEGER NOT NULL DEFAULT 0;
+`
+
 const migration013 = `
 DROP TABLE fts_tracks;
 

--- a/internal/radio/radiobrowser.go
+++ b/internal/radio/radiobrowser.go
@@ -197,6 +197,19 @@ func (c *Client) TopVoted(limit int) ([]Station, error) {
 	return c.fetchStations("/json/stations/topvote", params)
 }
 
+// ByUUID returns a station by its RadioBrowser UUID.
+func (c *Client) ByUUID(stationUUID string) ([]Station, error) {
+	stationUUID = strings.TrimSpace(stationUUID)
+	if stationUUID == "" {
+		return nil, fmt.Errorf("radiobrowser: station uuid is required")
+	}
+	params := url.Values{
+		"uuid":       {stationUUID},
+		"hidebroken": {"true"},
+	}
+	return c.fetchStations("/json/stations/byuuid", params)
+}
+
 // TopClicked returns the most clicked stations.
 func (c *Client) TopClicked(limit int) ([]Station, error) {
 	params := url.Values{

--- a/internal/radio/radiobrowser_test.go
+++ b/internal/radio/radiobrowser_test.go
@@ -128,6 +128,41 @@ func TestClientSearch(t *testing.T) {
 	}
 }
 
+func TestClientByUUID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/json/stations/byuuid" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("uuid"); got != "abc-123" {
+			t.Errorf("uuid = %q, want abc-123", got)
+		}
+		stations := []Station{
+			{
+				UUID:      "abc-123",
+				Name:      "Detail Radio",
+				Homepage:  "https://example.com/",
+				StreamURL: "https://stream.example.com/radio",
+			},
+		}
+		_ = json.NewEncoder(w).Encode(stations)
+	}))
+	defer server.Close()
+
+	c := NewClient()
+	c.servers = []string{server.URL}
+
+	stations, err := c.ByUUID("abc-123")
+	if err != nil {
+		t.Fatalf("ByUUID: %v", err)
+	}
+	if len(stations) != 1 {
+		t.Fatalf("expected 1 station, got %d", len(stations))
+	}
+	if stations[0].Homepage != "https://example.com/" {
+		t.Errorf("Homepage = %q", stations[0].Homepage)
+	}
+}
+
 func TestClientTopVoted(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/json/stations/topvote" {

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -930,6 +930,7 @@ type RadioStationJSON struct {
 	UUID      string `json:"uuid"`
 	Name      string `json:"name"`
 	StreamURL string `json:"streamUrl"`
+	Homepage  string `json:"homepage"`
 	Favicon   string `json:"favicon"`
 	Country   string `json:"country"`
 	Tags      string `json:"tags"`
@@ -949,6 +950,7 @@ func stationsToJSON(stations []radio.Station) []RadioStationJSON {
 			UUID:      s.UUID,
 			Name:      s.Name,
 			StreamURL: normalizeRadioStreamURL(s.StreamURL),
+			Homepage:  strings.TrimSpace(s.Homepage),
 			Favicon:   favicons[i],
 			Country:   s.Country,
 			Tags:      s.Tags,
@@ -993,6 +995,106 @@ func normalizeRadioStreamURL(streamURL string) string {
 }
 
 var radioClient = radio.NewClient()
+
+// GetRadioStationByUUID returns full station metadata, fetching from RadioBrowser when possible.
+func (s *LibraryService) GetRadioStationByUUID(stationUUID string) (RadioStationJSON, error) {
+	stationUUID = strings.TrimSpace(stationUUID)
+	if stationUUID == "" {
+		return RadioStationJSON{}, fmt.Errorf("station uuid is required")
+	}
+
+	if stations, err := radioClient.ByUUID(stationUUID); err == nil && len(stations) > 0 {
+		return stationsToJSON(stations)[0], nil
+	}
+
+	if strings.HasPrefix(stationUUID, "somafm-") {
+		stations, err := somafmClient.Stations()
+		if err != nil {
+			return RadioStationJSON{}, err
+		}
+		for _, station := range stations {
+			if station.UUID == stationUUID {
+				return stationsToJSON([]radio.Station{station})[0], nil
+			}
+		}
+	}
+
+	if s.db != nil {
+		if station, ok, err := s.lookupSavedRadioStation(stationUUID); err != nil {
+			return RadioStationJSON{}, err
+		} else if ok {
+			return station, nil
+		}
+	}
+
+	return RadioStationJSON{}, fmt.Errorf("station not found")
+}
+
+func (s *LibraryService) lookupSavedRadioStation(stationUUID string) (RadioStationJSON, bool, error) {
+	custom, err := s.db.GetCustomRadioStations()
+	if err != nil {
+		return RadioStationJSON{}, false, err
+	}
+	for _, station := range custom {
+		if station.StationUUID == stationUUID {
+			return savedRadioStationJSON(stationUUID, station.Name, station.StreamURL, station.FaviconURL, station.Homepage, station.Tags, "", 0, ""), true, nil
+		}
+	}
+
+	favs, err := s.db.GetRadioFavourites()
+	if err != nil {
+		return RadioStationJSON{}, false, err
+	}
+	for _, fav := range favs {
+		if fav.StationUUID == stationUUID {
+			return savedRadioStationJSON(fav.StationUUID, fav.Name, fav.StreamURL, fav.FaviconURL, fav.Homepage, fav.Tags, "", 0, ""), true, nil
+		}
+	}
+
+	history, err := s.db.GetRadioHistory(200)
+	if err != nil {
+		return RadioStationJSON{}, false, err
+	}
+	for _, entry := range history {
+		if entry.StationUUID == stationUUID {
+			return savedRadioStationJSON(entry.StationUUID, entry.Name, entry.StreamURL, entry.FaviconURL, entry.Homepage, entry.Tags, "", 0, ""), true, nil
+		}
+	}
+
+	return RadioStationJSON{}, false, nil
+}
+
+func savedRadioStationJSON(stationUUID, name, streamURL, faviconURL, homepage, tags, country string, bitrate int, codec string) RadioStationJSON {
+	favicon := faviconURL
+	if favicon == "" && homepage != "" {
+		favicon = resolveRadioArtwork("", homepage)
+	}
+	return RadioStationJSON{
+		UUID:      stationUUID,
+		Name:      name,
+		StreamURL: normalizeRadioStreamURL(streamURL),
+		Homepage:  strings.TrimSpace(homepage),
+		Favicon:   favicon,
+		Country:   country,
+		Tags:      tags,
+		Bitrate:   bitrate,
+		Codec:     codec,
+	}
+}
+
+// OpenURL opens an http(s) URL in the system browser.
+func (s *LibraryService) OpenURL(rawURL string) error {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("invalid URL")
+	}
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return fmt.Errorf("invalid URL scheme")
+	}
+	return browser.OpenURL(u.String())
+}
 
 // SearchRadioStations searches for radio stations by name.
 func (s *LibraryService) SearchRadioStations(query string, limit int) ([]RadioStationJSON, error) {
@@ -1063,6 +1165,7 @@ type RadioFavouriteJSON struct {
 	Name        string `json:"name"`
 	StreamURL   string `json:"streamUrl"`
 	FaviconURL  string `json:"faviconUrl"`
+	Homepage    string `json:"homepage"`
 	Tags        string `json:"tags"`
 	AddedAt     string `json:"addedAt"`
 	Pinned      bool   `json:"pinned"`
@@ -1074,6 +1177,7 @@ type RadioHistoryJSON struct {
 	Name         string `json:"name"`
 	StreamURL    string `json:"streamUrl"`
 	FaviconURL   string `json:"faviconUrl"`
+	Homepage     string `json:"homepage"`
 	Tags         string `json:"tags"`
 	TrackTitle   string `json:"trackTitle"`
 	PlayCount    int    `json:"playCount"`
@@ -1087,6 +1191,7 @@ type RadioCustomStationJSON struct {
 	Name        string `json:"name"`
 	StreamURL   string `json:"streamUrl"`
 	FaviconURL  string `json:"faviconUrl"`
+	Homepage    string `json:"homepage"`
 	Tags        string `json:"tags"`
 	CreatedAt   string `json:"createdAt"`
 	UpdatedAt   string `json:"updatedAt"`
@@ -1118,6 +1223,7 @@ func (s *LibraryService) GetRadioFavourites() ([]RadioFavouriteJSON, error) {
 			Name:        f.Name,
 			StreamURL:   f.StreamURL,
 			FaviconURL:  f.FaviconURL,
+			Homepage:    f.Homepage,
 			Tags:        f.Tags,
 			AddedAt:     f.AddedAt,
 			Pinned:      f.Pinned,
@@ -1127,7 +1233,7 @@ func (s *LibraryService) GetRadioFavourites() ([]RadioFavouriteJSON, error) {
 }
 
 // AddRadioFavourite saves a radio station to favourites.
-func (s *LibraryService) AddRadioFavourite(stationUUID, name, streamURL, faviconURL, tags string) error {
+func (s *LibraryService) AddRadioFavourite(stationUUID, name, streamURL, faviconURL, homepage, tags string) error {
 	if s.db == nil {
 		return fmt.Errorf("library not initialised")
 	}
@@ -1136,6 +1242,7 @@ func (s *LibraryService) AddRadioFavourite(stationUUID, name, streamURL, favicon
 		Name:        name,
 		StreamURL:   streamURL,
 		FaviconURL:  faviconURL,
+		Homepage:    strings.TrimSpace(homepage),
 		Tags:        tags,
 	})
 }
@@ -1227,6 +1334,7 @@ func (s *LibraryService) GetRadioHistory(limit int) ([]RadioHistoryJSON, error) 
 			Name:         entry.Name,
 			StreamURL:    entry.StreamURL,
 			FaviconURL:   entry.FaviconURL,
+			Homepage:     entry.Homepage,
 			Tags:         entry.Tags,
 			TrackTitle:   entry.TrackTitle,
 			PlayCount:    entry.PlayCount,
@@ -1323,6 +1431,7 @@ func customStationToJSON(station library.RadioCustomStation) RadioCustomStationJ
 		Name:        station.Name,
 		StreamURL:   station.StreamURL,
 		FaviconURL:  station.FaviconURL,
+		Homepage:    station.Homepage,
 		Tags:        station.Tags,
 		CreatedAt:   station.CreatedAt,
 		UpdatedAt:   station.UpdatedAt,

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -1037,7 +1037,7 @@ func (s *LibraryService) lookupSavedRadioStation(stationUUID string) (RadioStati
 	}
 	for _, station := range custom {
 		if station.StationUUID == stationUUID {
-			return savedRadioStationJSON(stationUUID, station.Name, station.StreamURL, station.FaviconURL, station.Homepage, station.Tags, "", 0, ""), true, nil
+			return savedRadioStationJSON(stationUUID, station.Name, station.StreamURL, station.FaviconURL, station.Homepage, station.Tags, station.Country, station.Bitrate, station.Codec), true, nil
 		}
 	}
 
@@ -1047,7 +1047,7 @@ func (s *LibraryService) lookupSavedRadioStation(stationUUID string) (RadioStati
 	}
 	for _, fav := range favs {
 		if fav.StationUUID == stationUUID {
-			return savedRadioStationJSON(fav.StationUUID, fav.Name, fav.StreamURL, fav.FaviconURL, fav.Homepage, fav.Tags, "", 0, ""), true, nil
+			return savedRadioStationJSON(fav.StationUUID, fav.Name, fav.StreamURL, fav.FaviconURL, fav.Homepage, fav.Tags, fav.Country, fav.Bitrate, fav.Codec), true, nil
 		}
 	}
 
@@ -1057,7 +1057,7 @@ func (s *LibraryService) lookupSavedRadioStation(stationUUID string) (RadioStati
 	}
 	for _, entry := range history {
 		if entry.StationUUID == stationUUID {
-			return savedRadioStationJSON(entry.StationUUID, entry.Name, entry.StreamURL, entry.FaviconURL, entry.Homepage, entry.Tags, "", 0, ""), true, nil
+			return savedRadioStationJSON(entry.StationUUID, entry.Name, entry.StreamURL, entry.FaviconURL, entry.Homepage, entry.Tags, entry.Country, entry.Bitrate, entry.Codec), true, nil
 		}
 	}
 
@@ -1166,6 +1166,9 @@ type RadioFavouriteJSON struct {
 	StreamURL   string `json:"streamUrl"`
 	FaviconURL  string `json:"faviconUrl"`
 	Homepage    string `json:"homepage"`
+	Country     string `json:"country"`
+	Codec       string `json:"codec"`
+	Bitrate     int    `json:"bitrate"`
 	Tags        string `json:"tags"`
 	AddedAt     string `json:"addedAt"`
 	Pinned      bool   `json:"pinned"`
@@ -1178,6 +1181,9 @@ type RadioHistoryJSON struct {
 	StreamURL    string `json:"streamUrl"`
 	FaviconURL   string `json:"faviconUrl"`
 	Homepage     string `json:"homepage"`
+	Country      string `json:"country"`
+	Codec        string `json:"codec"`
+	Bitrate      int    `json:"bitrate"`
 	Tags         string `json:"tags"`
 	TrackTitle   string `json:"trackTitle"`
 	PlayCount    int    `json:"playCount"`
@@ -1192,6 +1198,9 @@ type RadioCustomStationJSON struct {
 	StreamURL   string `json:"streamUrl"`
 	FaviconURL  string `json:"faviconUrl"`
 	Homepage    string `json:"homepage"`
+	Country     string `json:"country"`
+	Codec       string `json:"codec"`
+	Bitrate     int    `json:"bitrate"`
 	Tags        string `json:"tags"`
 	CreatedAt   string `json:"createdAt"`
 	UpdatedAt   string `json:"updatedAt"`
@@ -1224,6 +1233,9 @@ func (s *LibraryService) GetRadioFavourites() ([]RadioFavouriteJSON, error) {
 			StreamURL:   f.StreamURL,
 			FaviconURL:  f.FaviconURL,
 			Homepage:    f.Homepage,
+			Country:     f.Country,
+			Codec:       f.Codec,
+			Bitrate:     f.Bitrate,
 			Tags:        f.Tags,
 			AddedAt:     f.AddedAt,
 			Pinned:      f.Pinned,
@@ -1233,7 +1245,7 @@ func (s *LibraryService) GetRadioFavourites() ([]RadioFavouriteJSON, error) {
 }
 
 // AddRadioFavourite saves a radio station to favourites.
-func (s *LibraryService) AddRadioFavourite(stationUUID, name, streamURL, faviconURL, homepage, tags string) error {
+func (s *LibraryService) AddRadioFavourite(stationUUID, name, streamURL, faviconURL, homepage, tags, country, codec string, bitrate int) error {
 	if s.db == nil {
 		return fmt.Errorf("library not initialised")
 	}
@@ -1243,8 +1255,19 @@ func (s *LibraryService) AddRadioFavourite(stationUUID, name, streamURL, favicon
 		StreamURL:   streamURL,
 		FaviconURL:  faviconURL,
 		Homepage:    strings.TrimSpace(homepage),
+		Country:     strings.TrimSpace(country),
+		Codec:       strings.TrimSpace(codec),
+		Bitrate:     bitrate,
 		Tags:        tags,
 	})
+}
+
+// GetRadioFavouritePinned reports whether a favourite station is pinned.
+func (s *LibraryService) GetRadioFavouritePinned(stationUUID string) (bool, error) {
+	if s.db == nil {
+		return false, fmt.Errorf("library not initialised")
+	}
+	return s.db.GetRadioFavouritePinned(stationUUID)
 }
 
 // RemoveRadioFavourite removes a radio station from favourites.
@@ -1272,7 +1295,7 @@ func (s *LibraryService) IsRadioFavourite(stationUUID string) (bool, error) {
 }
 
 // AddCustomRadioStation saves a user-defined radio station.
-func (s *LibraryService) AddCustomRadioStation(name, streamURL, faviconURL, tags string) (RadioCustomStationJSON, error) {
+func (s *LibraryService) AddCustomRadioStation(name, streamURL, faviconURL, homepage, tags string) (RadioCustomStationJSON, error) {
 	if s.db == nil {
 		return RadioCustomStationJSON{}, fmt.Errorf("library not initialised")
 	}
@@ -1282,10 +1305,15 @@ func (s *LibraryService) AddCustomRadioStation(name, streamURL, faviconURL, tags
 	if err := validateStreamURL(streamURL); err != nil {
 		return RadioCustomStationJSON{}, err
 	}
+	homepage = strings.TrimSpace(homepage)
+	if homepage == "" {
+		homepage = library.DeriveHomepageFromStreamURL(streamURL)
+	}
 	station, err := s.db.AddCustomRadioStation(library.RadioCustomStation{
 		Name:       strings.TrimSpace(name),
 		StreamURL:  strings.TrimSpace(streamURL),
 		FaviconURL: strings.TrimSpace(faviconURL),
+		Homepage:   homepage,
 		Tags:       strings.TrimSpace(tags),
 	})
 	if err != nil {
@@ -1335,6 +1363,9 @@ func (s *LibraryService) GetRadioHistory(limit int) ([]RadioHistoryJSON, error) 
 			StreamURL:    entry.StreamURL,
 			FaviconURL:   entry.FaviconURL,
 			Homepage:     entry.Homepage,
+			Country:      entry.Country,
+			Codec:        entry.Codec,
+			Bitrate:      entry.Bitrate,
 			Tags:         entry.Tags,
 			TrackTitle:   entry.TrackTitle,
 			PlayCount:    entry.PlayCount,
@@ -1432,6 +1463,9 @@ func customStationToJSON(station library.RadioCustomStation) RadioCustomStationJ
 		StreamURL:   station.StreamURL,
 		FaviconURL:  station.FaviconURL,
 		Homepage:    station.Homepage,
+		Country:     station.Country,
+		Codec:       station.Codec,
+		Bitrate:     station.Bitrate,
 		Tags:        station.Tags,
 		CreatedAt:   station.CreatedAt,
 		UpdatedAt:   station.UpdatedAt,

--- a/playerservice.go
+++ b/playerservice.go
@@ -56,6 +56,7 @@ type PlayerService struct {
 	radioName             string
 	radioStreamURL        string
 	radioArtworkURL       string
+	radioHomepage         string
 	radioTags             string
 	radioLastTitle        string // last ICY stream title, for change detection
 	radioReconnectPending bool
@@ -195,7 +196,7 @@ func (p *PlayerService) startLastRadioStation() {
 	}
 	last := history[0]
 	go func() {
-		if err := p.playRadioStation(last.StationUUID, last.Name, last.StreamURL, last.FaviconURL, last.Tags, false, true); err != nil {
+		if err := p.playRadioStation(last.StationUUID, last.Name, last.StreamURL, last.FaviconURL, last.Homepage, last.Tags, false, true); err != nil {
 			log.Printf("start last radio station: %v", err)
 		}
 	}()
@@ -1131,15 +1132,15 @@ func (p *PlayerService) flushListenBrainzQueue() {
 // PlayRadio starts playback of a radio stream. It saves the current library
 // queue and enters radio mode where next/prev/shuffle/repeat are disabled.
 func (p *PlayerService) PlayRadio(stationName, streamURL, artworkURL string) error {
-	return p.playRadioStation(library.CustomRadioStationUUID(streamURL), stationName, streamURL, artworkURL, "", true, true)
+	return p.playRadioStation(library.CustomRadioStationUUID(streamURL), stationName, streamURL, artworkURL, "", "", true, true)
 }
 
 // PlayRadioStation starts playback of a radio stream with stable station metadata.
-func (p *PlayerService) PlayRadioStation(stationUUID, stationName, streamURL, artworkURL, tags string) error {
-	return p.playRadioStation(stationUUID, stationName, streamURL, artworkURL, tags, true, true)
+func (p *PlayerService) PlayRadioStation(stationUUID, stationName, streamURL, artworkURL, homepage, tags string) error {
+	return p.playRadioStation(stationUUID, stationName, streamURL, artworkURL, homepage, tags, true, true)
 }
 
-func (p *PlayerService) playRadioStation(stationUUID, stationName, streamURL, artworkURL, tags string, countPlay, resetReconnect bool) error {
+func (p *PlayerService) playRadioStation(stationUUID, stationName, streamURL, artworkURL, homepage, tags string, countPlay, resetReconnect bool) error {
 	if stationUUID == "" {
 		stationUUID = library.CustomRadioStationUUID(streamURL)
 	}
@@ -1157,6 +1158,7 @@ func (p *PlayerService) playRadioStation(stationUUID, stationName, streamURL, ar
 	p.radioName = stationName
 	p.radioStreamURL = streamURL
 	p.radioArtworkURL = artworkURL
+	p.radioHomepage = homepage
 	p.radioTags = tags
 	p.radioLastTitle = ""
 	if resetReconnect {
@@ -1179,6 +1181,7 @@ func (p *PlayerService) playRadioStation(stationUUID, stationName, streamURL, ar
 			Name:        stationName,
 			StreamURL:   streamURL,
 			FaviconURL:  artworkURL,
+			Homepage:    homepage,
 			Tags:        tags,
 		})
 	}
@@ -1243,6 +1246,7 @@ func (p *PlayerService) StopRadio() {
 	p.radioName = ""
 	p.radioStreamURL = ""
 	p.radioArtworkURL = ""
+	p.radioHomepage = ""
 	p.radioTags = ""
 	p.radioLastTitle = ""
 	p.radioReconnectPending = false
@@ -1341,6 +1345,7 @@ func (p *PlayerService) handleRadioStreamError() {
 	name := p.radioName
 	streamURL := p.radioStreamURL
 	artworkURL := p.radioArtworkURL
+	homepage := p.radioHomepage
 	tags := p.radioTags
 	p.radioMu.Unlock()
 
@@ -1370,7 +1375,7 @@ func (p *PlayerService) handleRadioStreamError() {
 			if !stillCurrent {
 				return
 			}
-			if err := p.playRadioStation(stationUUID, name, streamURL, artworkURL, tags, false, false); err == nil {
+			if err := p.playRadioStation(stationUUID, name, streamURL, artworkURL, homepage, tags, false, false); err == nil {
 				p.radioMu.Lock()
 				p.radioReconnectPending = false
 				p.radioMu.Unlock()

--- a/playerservice.go
+++ b/playerservice.go
@@ -196,7 +196,7 @@ func (p *PlayerService) startLastRadioStation() {
 	}
 	last := history[0]
 	go func() {
-		if err := p.playRadioStation(last.StationUUID, last.Name, last.StreamURL, last.FaviconURL, last.Homepage, last.Tags, false, true); err != nil {
+		if err := p.playRadioStation(last.StationUUID, last.Name, last.StreamURL, last.FaviconURL, last.Homepage, last.Tags, last.Country, last.Codec, last.Bitrate, false, true); err != nil {
 			log.Printf("start last radio station: %v", err)
 		}
 	}()
@@ -1132,15 +1132,15 @@ func (p *PlayerService) flushListenBrainzQueue() {
 // PlayRadio starts playback of a radio stream. It saves the current library
 // queue and enters radio mode where next/prev/shuffle/repeat are disabled.
 func (p *PlayerService) PlayRadio(stationName, streamURL, artworkURL string) error {
-	return p.playRadioStation(library.CustomRadioStationUUID(streamURL), stationName, streamURL, artworkURL, "", "", true, true)
+	return p.playRadioStation(library.CustomRadioStationUUID(streamURL), stationName, streamURL, artworkURL, "", "", "", "", 0, true, true)
 }
 
 // PlayRadioStation starts playback of a radio stream with stable station metadata.
-func (p *PlayerService) PlayRadioStation(stationUUID, stationName, streamURL, artworkURL, homepage, tags string) error {
-	return p.playRadioStation(stationUUID, stationName, streamURL, artworkURL, homepage, tags, true, true)
+func (p *PlayerService) PlayRadioStation(stationUUID, stationName, streamURL, artworkURL, homepage, tags, country, codec string, bitrate int) error {
+	return p.playRadioStation(stationUUID, stationName, streamURL, artworkURL, homepage, tags, country, codec, bitrate, true, true)
 }
 
-func (p *PlayerService) playRadioStation(stationUUID, stationName, streamURL, artworkURL, homepage, tags string, countPlay, resetReconnect bool) error {
+func (p *PlayerService) playRadioStation(stationUUID, stationName, streamURL, artworkURL, homepage, tags, country, codec string, bitrate int, countPlay, resetReconnect bool) error {
 	if stationUUID == "" {
 		stationUUID = library.CustomRadioStationUUID(streamURL)
 	}
@@ -1182,6 +1182,9 @@ func (p *PlayerService) playRadioStation(stationUUID, stationName, streamURL, ar
 			StreamURL:   streamURL,
 			FaviconURL:  artworkURL,
 			Homepage:    homepage,
+			Country:     country,
+			Codec:       codec,
+			Bitrate:     bitrate,
 			Tags:        tags,
 		})
 	}
@@ -1375,7 +1378,7 @@ func (p *PlayerService) handleRadioStreamError() {
 			if !stillCurrent {
 				return
 			}
-			if err := p.playRadioStation(stationUUID, name, streamURL, artworkURL, homepage, tags, false, false); err == nil {
+			if err := p.playRadioStation(stationUUID, name, streamURL, artworkURL, homepage, tags, "", "", 0, false, false); err == nil {
 				p.radioMu.Lock()
 				p.radioReconnectPending = false
 				p.radioMu.Unlock()


### PR DESCRIPTION
Closes #191

## What?

- [x] Station detail view from browse/favourites/history lists (click station name)
- [x] Open detail from now playing bar when a station is active
- [x] Homepage and stream URL sections with open-in-browser and copy
- [x] `GetRadioStationByUUID` with RadioBrowser lookup and local fallbacks
- [x] Persist `homepage` on favourites and history (migration 15)
- [x] Playwright coverage for the detail page

## Why?

Radio lists only showed enough metadata to start playback. Issue #191 asked for a proper station page with the broadcaster website, stream URL, and full metadata when available.

## How?

```mermaid
flowchart LR
  UI[RadioView / NowPlayingBar] --> API[GetRadioStationByUUID]
  API --> RB[RadioBrowser byuuid]
  API --> DB[(favourites / history / custom)]
  UI --> Open[OpenURL / clipboard]
```

- Backend exposes `homepage` on `RadioStationJSON` and adds `OpenURL` for external links.
- `RadioStationView` loads by UUID, with list hints for instant render while fetching.
- DB migration 15 adds `homepage` columns; playback recording keeps homepage when known.

## Risk

Low. UI-only surface plus additive schema migration. RadioBrowser lookup failure still falls back to saved station rows.

## Test plan

- [x] `go test ./internal/radio/... ./internal/library/...`
- [x] `npm run build` in `frontend/`
- [x] `npx playwright test tests/radio.spec.ts`