### PR TITLE
Add shared radio station fixtures and source integration tests

### DIFF
--- a/frontend/tests/fixtures/radio-stations.ts
+++ b/frontend/tests/fixtures/radio-stations.ts
@@ -1,0 +1,41 @@
+import stationsJson from "@radio-fixtures";
+
+export type RadioStationFixture = {
+  uuid: string;
+  name: string;
+  streamUrl: string;
+  homepage: string;
+  favicon: string;
+  country: string;
+  tags: string;
+  bitrate: number;
+  codec: string;
+  votes?: number;
+  clicks?: number;
+};
+
+export type CustomStationFixture = {
+  name: string;
+  streamUrl: string;
+  homepage: string;
+  derivedHomepage: string;
+  faviconUrl: string;
+  tags: string;
+  country: string;
+  codec: string;
+  bitrate: number;
+};
+
+export type RadioFixtures = {
+  radiobrowser: RadioStationFixture;
+  somafm: RadioStationFixture;
+  custom: CustomStationFixture;
+  favouriteOnly: RadioStationFixture;
+  historyOnly: RadioStationFixture;
+  browse: RadioStationFixture;
+};
+
+export const radioFixtures = stationsJson as RadioFixtures;
+
+/** Stable UUID for the custom fixture stream (matches Go CustomRadioStationUUID). */
+export const customFixtureUUID = "custom-d8c4e31cbf14b18f";

--- a/frontend/tests/mocks/wails-runtime.ts
+++ b/frontend/tests/mocks/wails-runtime.ts
@@ -1,6 +1,12 @@
 // Mock @wailsio/runtime for Playwright e2e tests.
 // Maps Wails Call.ByID numeric identifiers to fixture responses.
 
+import {
+  customFixtureUUID,
+  radioFixtures,
+  type RadioStationFixture,
+} from "../fixtures/radio-stations";
+
 let appPreferences = {
   libraryEnabled: false,
   startLastStation: true,
@@ -43,9 +49,23 @@ function stationIcon(label: string, background: string, foreground = "ffffff") {
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 
+function fixtureBrowseStation(f: RadioStationFixture, iconLabel: string, iconBg: string) {
+  return {
+    uuid: f.uuid,
+    name: f.name,
+    streamUrl: f.streamUrl,
+    homepage: f.homepage,
+    favicon: f.favicon || stationIcon(iconLabel, iconBg),
+    country: f.country,
+    tags: f.tags,
+    bitrate: f.bitrate,
+    codec: f.codec,
+  };
+}
+
 const demoStations = [
-  { uuid: "somafm-missioncontrol", name: "Ishq - Iqqoa", streamUrl: "https://stream.example.com/mission-control", homepage: "https://somafm.com/missioncontrol/", favicon: stationIcon("MC", "1f2937"), country: "SomaFM Mission Control", tags: "ambient,space,electronic", bitrate: 128, codec: "MP3" },
-  { uuid: "st-jazz-fm", name: "Jazz FM", streamUrl: "https://stream.example.com/jazz-fm", homepage: "https://www.jazzfm.com/", favicon: stationIcon("JF", "2563eb"), country: "United Kingdom", tags: "jazz,smooth", bitrate: 128, codec: "MP3" },
+  fixtureBrowseStation(radioFixtures.somafm, "MC", "1f2937"),
+  fixtureBrowseStation(radioFixtures.browse, "JF", "2563eb"),
   { uuid: "st-classical-24", name: "Classical 24", streamUrl: "https://stream.example.com/classical", favicon: stationIcon("C24", "7c2d12"), country: "France", tags: "classical,orchestral", bitrate: 320, codec: "MP3" },
   { uuid: "st-mangoradio", name: "MANGORADIO", streamUrl: "https://stream.example.com/mango", favicon: stationIcon("M", "f59e0b", "111827"), country: "Germany", tags: "music,variety", bitrate: 128, codec: "MP3" },
   { uuid: "st-radio-paradise", name: "Radio Paradise Main Mix (EU) 320k AAC", streamUrl: "https://stream.example.com/rp", favicon: stationIcon("RP", "f8fafc", "334155"), country: "The United States Of America", tags: "california,eclectic,free,internet", bitrate: 320, codec: "AAC" },
@@ -80,6 +100,104 @@ function upsertHistory(stationUuid: string, name: string, streamUrl: string, fav
 function hasTag(tags: string, tag: string) {
   if (!tag) return true;
   return tags.split(",").map((t) => t.trim().toLowerCase()).includes(tag.toLowerCase());
+}
+
+function resolveStationByUUID(stationUuid: string) {
+  const demo = demoStations.find((s) => s.uuid === stationUuid);
+  if (demo) {
+    return { ...demo, votes: 120, clicks: 340 };
+  }
+
+  const custom = customStations.find((s) => s.stationUuid === stationUuid);
+  if (custom) {
+    return {
+      uuid: custom.stationUuid,
+      name: custom.name,
+      streamUrl: custom.streamUrl,
+      homepage: custom.homepage || "",
+      favicon: custom.faviconUrl || "",
+      country: "",
+      tags: custom.tags,
+      bitrate: 0,
+      codec: "",
+      votes: 0,
+      clicks: 0,
+    };
+  }
+
+  const fav = radioFavourites.find((f) => f.stationUuid === stationUuid);
+  if (fav) {
+    return {
+      uuid: fav.stationUuid,
+      name: fav.name,
+      streamUrl: fav.streamUrl,
+      homepage: fav.homepage || "",
+      favicon: fav.faviconUrl || "",
+      country: fav.country || "",
+      tags: fav.tags,
+      bitrate: fav.bitrate || 0,
+      codec: fav.codec || "",
+      votes: 0,
+      clicks: 0,
+    };
+  }
+
+  const hist = radioHistory.find((h) => h.stationUuid === stationUuid);
+  if (hist) {
+    return {
+      uuid: hist.stationUuid,
+      name: hist.name,
+      streamUrl: hist.streamUrl,
+      homepage: hist.homepage || "",
+      favicon: hist.faviconUrl || "",
+      country: hist.country || "",
+      tags: hist.tags,
+      bitrate: hist.bitrate || 0,
+      codec: hist.codec || "",
+      votes: 0,
+      clicks: 0,
+    };
+  }
+
+  if (stationUuid === radioFixtures.favouriteOnly.uuid) {
+    const f = radioFixtures.favouriteOnly;
+    return {
+      uuid: f.uuid,
+      name: f.name,
+      streamUrl: f.streamUrl,
+      homepage: f.homepage,
+      favicon: f.favicon || "",
+      country: f.country,
+      tags: f.tags,
+      bitrate: f.bitrate,
+      codec: f.codec,
+      votes: 0,
+      clicks: 0,
+    };
+  }
+
+  if (stationUuid === radioFixtures.historyOnly.uuid) {
+    const h = radioFixtures.historyOnly;
+    return {
+      uuid: h.uuid,
+      name: h.name,
+      streamUrl: h.streamUrl,
+      homepage: h.homepage,
+      favicon: h.favicon || "",
+      country: h.country,
+      tags: h.tags,
+      bitrate: h.bitrate,
+      codec: h.codec,
+      votes: 0,
+      clicks: 0,
+    };
+  }
+
+  return null;
+}
+
+function somaFMStations() {
+  return demoStations.filter((s) => s.uuid.startsWith("somafm-"));
 }
 
 function filteredDemoStations(country = "", codec = "", tag = "") {
@@ -216,6 +334,8 @@ const fixtures: Record<number, (...args: any[]) => any> = {
   1619368624: () => demoStations.map((station, index) => ({ ...station, votes: 200 - index * 10, clicks: 500 - index * 20 })),
   // GetTopVotedRadioStations
   1723581283: () => demoStations.map((station, index) => ({ ...station, votes: 200 - index * 10, clicks: 500 - index * 20 })),
+  // GetSomaFMStations
+  3406641218: () => somaFMStations().map((station, index) => ({ ...station, votes: 50 - index, clicks: 100 - index })),
   // GetTopClickedRadioStations
   46869912: () => demoStations.map((station, index) => ({ ...station, votes: 200 - index * 10, clicks: 500 - index * 20 })),
   // SearchRadioStationsFiltered
@@ -256,11 +376,11 @@ const fixtures: Record<number, (...args: any[]) => any> = {
   },
   // GetRadioStationByUUID
   4150278773: (stationUuid: string) => {
-    const station = demoStations.find((s) => s.uuid === stationUuid);
+    const station = resolveStationByUUID(stationUuid);
     if (!station) {
       throw new Error("station not found");
     }
-    return { ...station, votes: 120, clicks: 340 };
+    return station;
   },
   // OpenURL
   1380764543: () => undefined,
@@ -282,12 +402,23 @@ const fixtures: Record<number, (...args: any[]) => any> = {
   2495430549: () => customStations,
   // AddCustomRadioStation
   3781401643: (name: string, streamUrl: string, faviconUrl: string, homepage: string, tags: string) => {
+    let derivedHomepage = homepage;
+    if (!derivedHomepage) {
+      try {
+        derivedHomepage = new URL(streamUrl).origin + "/";
+      } catch {
+        derivedHomepage = "";
+      }
+    }
     const station = {
-      stationUuid: `custom-${customStations.length + 1}`,
+      stationUuid:
+        streamUrl === radioFixtures.custom.streamUrl
+          ? customFixtureUUID
+          : `custom-${customStations.length + 1}`,
       name,
       streamUrl,
       faviconUrl,
-      homepage: homepage || (streamUrl.includes("example.org") ? "https://example.org/" : ""),
+      homepage: derivedHomepage,
       tags,
       createdAt: "2024-01-03 10:00:00",
     };

--- a/frontend/tests/radio.spec.ts
+++ b/frontend/tests/radio.spec.ts
@@ -295,6 +295,31 @@ test('station detail can pin a favourite', async ({ page }) => {
   await expect(page.getByRole('button', { name: 'Unpin' })).toBeVisible();
 });
 
+test('opens SomaFM station detail from browse filter', async ({ page }) => {
+  await radioNavButton(page).click();
+  await page.getByRole('button', { name: 'SomaFM' }).click();
+  await page.getByRole('button', { name: 'SomaFM Mission Control', exact: true }).click();
+
+  await expect(page.getByRole('heading', { name: 'SomaFM Mission Control', level: 1 })).toBeVisible();
+  const website = page.getByRole('link', { name: 'https://somafm.com/missioncontrol/' });
+  await expect(website).toHaveAttribute('href', 'https://somafm.com/missioncontrol/');
+});
+
+test('custom station detail shows derived website from stream host', async ({ page }) => {
+  await radioNavButton(page).click();
+  await page.getByRole('tab', { name: /Custom/ }).click();
+
+  await page.getByRole('textbox', { name: 'Station name' }).fill('Fixture Custom Stream');
+  await page.getByRole('textbox', { name: 'Stream URL' }).fill('https://live.custom-fixture.example.org/stream.mp3');
+  await page.getByRole('button', { name: 'Add Station' }).click();
+  await expect(page.locator('#radio-panel-custom').getByRole('button', { name: 'Fixture Custom Stream', exact: true })).toBeVisible();
+
+  await page.locator('#radio-panel-custom').getByRole('button', { name: 'Fixture Custom Stream', exact: true }).click();
+
+  const websiteRow = page.locator('.station-view .link-row').filter({ hasText: 'Website' });
+  await expect(websiteRow.getByRole('link')).toHaveAttribute('href', 'https://live.custom-fixture.example.org/');
+});
+
 test('shows a recoverable error when a station cannot play', async ({ page }) => {
   await page.evaluate(() => localStorage.setItem('forte.failPlayRadioStation', 'true'));
   await page.reload();

--- a/frontend/vite.config.test.ts
+++ b/frontend/vite.config.test.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@wailsio/runtime": path.resolve(__dirname, "tests/mocks/wails-runtime.ts"),
+      "@radio-fixtures": path.resolve(__dirname, "../testdata/radio/stations.json"),
     },
   },
 });

--- a/internal/radio/radiobrowser.go
+++ b/internal/radio/radiobrowser.go
@@ -41,6 +41,11 @@ func NewClient() *Client {
 	}
 }
 
+// SetServers pins API mirrors (for tests).
+func (c *Client) SetServers(servers []string) {
+	c.servers = servers
+}
+
 // discoverServers resolves RadioBrowser mirrors via DNS.
 func (c *Client) discoverServers() ([]string, error) {
 	if len(c.servers) > 0 {

--- a/internal/radio/radiobrowser_test.go
+++ b/internal/radio/radiobrowser_test.go
@@ -114,7 +114,7 @@ func TestClientSearch(t *testing.T) {
 	defer server.Close()
 
 	c := NewClient()
-	c.servers = []string{server.URL}
+	c.SetServers([]string{server.URL})
 
 	stations, err := c.Search("jazz", 10)
 	if err != nil {
@@ -149,7 +149,7 @@ func TestClientByUUID(t *testing.T) {
 	defer server.Close()
 
 	c := NewClient()
-	c.servers = []string{server.URL}
+	c.SetServers([]string{server.URL})
 
 	stations, err := c.ByUUID("abc-123")
 	if err != nil {
@@ -176,7 +176,7 @@ func TestClientTopVoted(t *testing.T) {
 	defer server.Close()
 
 	c := NewClient()
-	c.servers = []string{server.URL}
+	c.SetServers([]string{server.URL})
 
 	stations, err := c.TopVoted(5)
 	if err != nil {
@@ -213,7 +213,7 @@ func TestClientSearchFilteredCombinesFilters(t *testing.T) {
 	defer server.Close()
 
 	c := NewClient()
-	c.servers = []string{server.URL}
+	c.SetServers([]string{server.URL})
 
 	stations, err := c.SearchFiltered("GB", "MP3", "eclectic", 10)
 	if err != nil {

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -942,6 +942,16 @@ type RadioStationJSON struct {
 
 var somafmClient = radio.NewSomaFMClient()
 
+// somafmStationsProvider overrides SomaFM listing in tests. Production uses somafmClient.
+var somafmStationsProvider func() ([]radio.Station, error)
+
+func listSomaFMStations() ([]radio.Station, error) {
+	if somafmStationsProvider != nil {
+		return somafmStationsProvider()
+	}
+	return somafmClient.Stations()
+}
+
 func stationsToJSON(stations []radio.Station) []RadioStationJSON {
 	result := make([]RadioStationJSON, len(stations))
 	favicons := resolveStationFavicons(stations)
@@ -1008,7 +1018,7 @@ func (s *LibraryService) GetRadioStationByUUID(stationUUID string) (RadioStation
 	}
 
 	if strings.HasPrefix(stationUUID, "somafm-") {
-		stations, err := somafmClient.Stations()
+		stations, err := listSomaFMStations()
 		if err != nil {
 			return RadioStationJSON{}, err
 		}
@@ -1152,7 +1162,7 @@ func (s *LibraryService) GetTopClickedRadioStations(limit int) ([]RadioStationJS
 
 // GetSomaFMStations returns all SomaFM channels.
 func (s *LibraryService) GetSomaFMStations() ([]RadioStationJSON, error) {
-	stations, err := somafmClient.Stations()
+	stations, err := listSomaFMStations()
 	if err != nil {
 		return nil, err
 	}

--- a/libraryservice_radio_test.go
+++ b/libraryservice_radio_test.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/willfish/forte/internal/library"
+	"github.com/willfish/forte/internal/radio"
+)
+
+//go:embed testdata/radio/stations.json
+var radioStationsFixtureJSON []byte
+
+type radioStationsFixture struct {
+	RadioBrowser  radioStationFixture `json:"radiobrowser"`
+	SomaFM        radioStationFixture `json:"somafm"`
+	Custom        customFixture       `json:"custom"`
+	FavouriteOnly radioStationFixture `json:"favouriteOnly"`
+	HistoryOnly   radioStationFixture `json:"historyOnly"`
+}
+
+type radioStationFixture struct {
+	UUID      string `json:"uuid"`
+	Name      string `json:"name"`
+	StreamURL string `json:"streamUrl"`
+	Homepage  string `json:"homepage"`
+	Favicon   string `json:"favicon"`
+	Country   string `json:"country"`
+	Tags      string `json:"tags"`
+	Bitrate   int    `json:"bitrate"`
+	Codec     string `json:"codec"`
+	Votes     int    `json:"votes"`
+	Clicks    int    `json:"clicks"`
+}
+
+type customFixture struct {
+	Name              string `json:"name"`
+	StreamURL         string `json:"streamUrl"`
+	Homepage          string `json:"homepage"`
+	DerivedHomepage   string `json:"derivedHomepage"`
+	FaviconURL        string `json:"faviconUrl"`
+	Tags              string `json:"tags"`
+	Country           string `json:"country"`
+	Codec             string `json:"codec"`
+	Bitrate           int    `json:"bitrate"`
+}
+
+func loadRadioStationsFixture(t *testing.T) radioStationsFixture {
+	t.Helper()
+	var fx radioStationsFixture
+	if err := json.Unmarshal(radioStationsFixtureJSON, &fx); err != nil {
+		t.Fatalf("unmarshal radio fixtures: %v", err)
+	}
+	return fx
+}
+
+func fixtureToRadioStation(f radioStationFixture) radio.Station {
+	return radio.Station{
+		UUID:      f.UUID,
+		Name:      f.Name,
+		StreamURL: f.StreamURL,
+		Homepage:  f.Homepage,
+		Favicon:   f.Favicon,
+		Country:   f.Country,
+		Tags:      f.Tags,
+		Bitrate:   f.Bitrate,
+		Codec:     f.Codec,
+		Votes:     f.Votes,
+		Clicks:    f.Clicks,
+	}
+}
+
+func withRadioTestHooks(t *testing.T, rb *radio.Client, soma []radio.Station) func() {
+	t.Helper()
+	oldClient := radioClient
+	oldSoma := somafmStationsProvider
+	radioClient = rb
+	if soma != nil {
+		somafmStationsProvider = func() ([]radio.Station, error) { return soma, nil }
+	} else {
+		somafmStationsProvider = func() ([]radio.Station, error) { return nil, nil }
+	}
+	return func() {
+		radioClient = oldClient
+		somafmStationsProvider = oldSoma
+	}
+}
+
+func emptyRadioBrowserServer(t *testing.T) *radio.Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("[]"))
+	}))
+	t.Cleanup(server.Close)
+	c := radio.NewClient()
+	c.SetServers([]string{server.URL})
+	return c
+}
+
+func radioBrowserServerForStation(t *testing.T, station radio.Station) *radio.Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/json/stations/byuuid" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode([]radio.Station{station})
+	}))
+	t.Cleanup(server.Close)
+	c := radio.NewClient()
+	c.SetServers([]string{server.URL})
+	return c
+}
+
+func TestGetRadioStationByUUIDRadioBrowser(t *testing.T) {
+	fx := loadRadioStationsFixture(t)
+	station := fixtureToRadioStation(fx.RadioBrowser)
+	rb := radioBrowserServerForStation(t, station)
+	defer withRadioTestHooks(t, rb, nil)()
+
+	s := openTestService(t)
+	got, err := s.GetRadioStationByUUID(fx.RadioBrowser.UUID)
+	if err != nil {
+		t.Fatalf("GetRadioStationByUUID: %v", err)
+	}
+	if got.Name != fx.RadioBrowser.Name {
+		t.Fatalf("Name = %q, want %q", got.Name, fx.RadioBrowser.Name)
+	}
+	if got.Homepage != fx.RadioBrowser.Homepage {
+		t.Fatalf("Homepage = %q, want %q", got.Homepage, fx.RadioBrowser.Homepage)
+	}
+	if got.Codec != fx.RadioBrowser.Codec || got.Bitrate != fx.RadioBrowser.Bitrate {
+		t.Fatalf("metadata = codec %q bitrate %d", got.Codec, got.Bitrate)
+	}
+}
+
+func TestGetRadioStationByUUIDSomaFM(t *testing.T) {
+	fx := loadRadioStationsFixture(t)
+	soma := []radio.Station{fixtureToRadioStation(fx.SomaFM)}
+	rb := emptyRadioBrowserServer(t)
+	defer withRadioTestHooks(t, rb, soma)()
+
+	s := openTestService(t)
+	got, err := s.GetRadioStationByUUID(fx.SomaFM.UUID)
+	if err != nil {
+		t.Fatalf("GetRadioStationByUUID: %v", err)
+	}
+	if got.Name != fx.SomaFM.Name {
+		t.Fatalf("Name = %q, want %q", got.Name, fx.SomaFM.Name)
+	}
+	if got.Homepage != fx.SomaFM.Homepage {
+		t.Fatalf("Homepage = %q, want %q", got.Homepage, fx.SomaFM.Homepage)
+	}
+}
+
+func TestGetRadioStationByUUIDCustom(t *testing.T) {
+	fx := loadRadioStationsFixture(t)
+	rb := emptyRadioBrowserServer(t)
+	defer withRadioTestHooks(t, rb, nil)()
+
+	s := openTestService(t)
+	customUUID := library.CustomRadioStationUUID(fx.Custom.StreamURL)
+	if _, err := s.db.AddCustomRadioStation(library.RadioCustomStation{
+		StationUUID: customUUID,
+		Name:        fx.Custom.Name,
+		StreamURL:   fx.Custom.StreamURL,
+		Tags:        fx.Custom.Tags,
+	}); err != nil {
+		t.Fatalf("AddCustomRadioStation: %v", err)
+	}
+
+	got, err := s.GetRadioStationByUUID(customUUID)
+	if err != nil {
+		t.Fatalf("GetRadioStationByUUID: %v", err)
+	}
+	if got.Name != fx.Custom.Name {
+		t.Fatalf("Name = %q, want %q", got.Name, fx.Custom.Name)
+	}
+	if got.Homepage != fx.Custom.DerivedHomepage {
+		t.Fatalf("Homepage = %q, want derived %q", got.Homepage, fx.Custom.DerivedHomepage)
+	}
+}
+
+func TestGetRadioStationByUUIDFavouriteOnly(t *testing.T) {
+	fx := loadRadioStationsFixture(t)
+	rb := emptyRadioBrowserServer(t)
+	defer withRadioTestHooks(t, rb, nil)()
+
+	s := openTestService(t)
+	if err := s.db.AddRadioFavourite(library.RadioFavourite{
+		StationUUID: fx.FavouriteOnly.UUID,
+		Name:        fx.FavouriteOnly.Name,
+		StreamURL:   fx.FavouriteOnly.StreamURL,
+		Homepage:    fx.FavouriteOnly.Homepage,
+		Country:     fx.FavouriteOnly.Country,
+		Codec:       fx.FavouriteOnly.Codec,
+		Bitrate:     fx.FavouriteOnly.Bitrate,
+		Tags:        fx.FavouriteOnly.Tags,
+	}); err != nil {
+		t.Fatalf("AddRadioFavourite: %v", err)
+	}
+
+	got, err := s.GetRadioStationByUUID(fx.FavouriteOnly.UUID)
+	if err != nil {
+		t.Fatalf("GetRadioStationByUUID: %v", err)
+	}
+	if got.Country != fx.FavouriteOnly.Country || got.Codec != fx.FavouriteOnly.Codec {
+		t.Fatalf("metadata mismatch: %+v", got)
+	}
+}
+
+func TestGetRadioStationByUUIDHistoryOnly(t *testing.T) {
+	fx := loadRadioStationsFixture(t)
+	rb := emptyRadioBrowserServer(t)
+	defer withRadioTestHooks(t, rb, nil)()
+
+	s := openTestService(t)
+	if err := s.db.RecordRadioPlayback(library.RadioHistoryEntry{
+		StationUUID: fx.HistoryOnly.UUID,
+		Name:        fx.HistoryOnly.Name,
+		StreamURL:   fx.HistoryOnly.StreamURL,
+		Homepage:    fx.HistoryOnly.Homepage,
+		Country:     fx.HistoryOnly.Country,
+		Codec:       fx.HistoryOnly.Codec,
+		Bitrate:     fx.HistoryOnly.Bitrate,
+		Tags:        fx.HistoryOnly.Tags,
+	}); err != nil {
+		t.Fatalf("RecordRadioPlayback: %v", err)
+	}
+
+	got, err := s.GetRadioStationByUUID(fx.HistoryOnly.UUID)
+	if err != nil {
+		t.Fatalf("GetRadioStationByUUID: %v", err)
+	}
+	if got.Name != fx.HistoryOnly.Name {
+		t.Fatalf("Name = %q, want %q", got.Name, fx.HistoryOnly.Name)
+	}
+}
+
+func TestGetRadioStationByUUIDRadioBrowserPrecedenceOverSaved(t *testing.T) {
+	fx := loadRadioStationsFixture(t)
+	rbStation := fixtureToRadioStation(fx.RadioBrowser)
+	rbStation.Name = "Live RadioBrowser Name"
+	rb := radioBrowserServerForStation(t, rbStation)
+	defer withRadioTestHooks(t, rb, nil)()
+
+	s := openTestService(t)
+	if err := s.db.AddRadioFavourite(library.RadioFavourite{
+		StationUUID: fx.RadioBrowser.UUID,
+		Name:        "Stale Saved Name",
+		StreamURL:   fx.RadioBrowser.StreamURL,
+		Homepage:    fx.RadioBrowser.Homepage,
+		Tags:        fx.RadioBrowser.Tags,
+	}); err != nil {
+		t.Fatalf("AddRadioFavourite: %v", err)
+	}
+
+	got, err := s.GetRadioStationByUUID(fx.RadioBrowser.UUID)
+	if err != nil {
+		t.Fatalf("GetRadioStationByUUID: %v", err)
+	}
+	if got.Name != "Live RadioBrowser Name" {
+		t.Fatalf("Name = %q, want live API name", got.Name)
+	}
+}
+
+func TestGetRadioStationByUUIDNotFound(t *testing.T) {
+	rb := emptyRadioBrowserServer(t)
+	defer withRadioTestHooks(t, rb, nil)()
+
+	s := openTestService(t)
+	if _, err := s.GetRadioStationByUUID("missing-uuid"); err == nil {
+		t.Fatal("expected error for missing station")
+	}
+}

--- a/testdata/radio/stations.json
+++ b/testdata/radio/stations.json
@@ -1,0 +1,70 @@
+{
+  "radiobrowser": {
+    "uuid": "fixture-rb-jazz",
+    "name": "Fixture Jazz Radio",
+    "streamUrl": "https://stream.example.com/fixture-jazz",
+    "homepage": "https://fixture-jazz.example.com/",
+    "favicon": "https://fixture-jazz.example.com/icon.png",
+    "country": "United Kingdom",
+    "tags": "jazz,fixture",
+    "bitrate": 128,
+    "codec": "MP3",
+    "votes": 42,
+    "clicks": 100
+  },
+  "somafm": {
+    "uuid": "somafm-missioncontrol",
+    "name": "SomaFM Mission Control",
+    "streamUrl": "https://stream.example.com/somafm-missioncontrol",
+    "homepage": "https://somafm.com/missioncontrol/",
+    "favicon": "https://somafm.com/logos/512/missioncontrol512.png",
+    "country": "",
+    "tags": "ambient,space,electronic",
+    "bitrate": 128,
+    "codec": "MP3"
+  },
+  "custom": {
+    "name": "Fixture Custom Stream",
+    "streamUrl": "https://live.custom-fixture.example.org/stream.mp3",
+    "homepage": "",
+    "derivedHomepage": "https://live.custom-fixture.example.org/",
+    "faviconUrl": "",
+    "tags": "custom,fixture",
+    "country": "",
+    "codec": "",
+    "bitrate": 0
+  },
+  "favouriteOnly": {
+    "uuid": "fixture-favourite-only",
+    "name": "Fixture Favourite Only",
+    "streamUrl": "https://stream.example.com/favourite-only",
+    "homepage": "https://favourite-only.example.com/",
+    "faviconUrl": "",
+    "country": "France",
+    "codec": "AAC",
+    "bitrate": 256,
+    "tags": "favourite,fixture"
+  },
+  "historyOnly": {
+    "uuid": "fixture-history-only",
+    "name": "Fixture History Only",
+    "streamUrl": "https://stream.example.com/history-only",
+    "homepage": "https://history-only.example.com/",
+    "faviconUrl": "",
+    "country": "Germany",
+    "codec": "MP3",
+    "bitrate": 192,
+    "tags": "history,fixture"
+  },
+  "browse": {
+    "uuid": "st-jazz-fm",
+    "name": "Jazz FM",
+    "streamUrl": "https://stream.example.com/jazz-fm",
+    "homepage": "https://www.jazzfm.com/",
+    "favicon": "",
+    "country": "United Kingdom",
+    "tags": "jazz,smooth",
+    "bitrate": 128,
+    "codec": "MP3"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a canonical radio fixture set and tests that exercise every `GetRadioStationByUUID` resolution path (RadioBrowser, SomaFM, custom, favourites, history).

## Changes

- **`testdata/radio/stations.json`** — shared fixtures for all supported sources
- **`libraryservice_radio_test.go`** — integration tests with mocked RadioBrowser/SomaFM and SQLite saves
- **`somafmStationsProvider`** test hook + `radio.Client.SetServers()` for httptest
- **Playwright** — imports shared fixtures; `resolveStationByUUID` in mock; SomaFM filter + custom derived homepage E2E tests

## Testing

- `go test -run TestGetRadioStationByUUID .`
- `npm run test:e2e -- tests/radio.spec.ts` (30 passed locally)