### PR TITLE
BAU: Add sectioned TOML user config export/import

### DIFF
--- a/docs/user-config.md
+++ b/docs/user-config.md
@@ -1,0 +1,36 @@
+# User configuration file
+
+Forte can export and import portable user settings as a sectioned TOML file.
+
+## Location
+
+- **Path:** `~/.config/forte/config.toml` (XDG config dir + `forte/`)
+- **SQLite:** `~/.config/forte/library.db` (unchanged; still the runtime store)
+
+## Format
+
+- **Encoding:** TOML
+- **`schemaVersion`:** top-level integer; current version is `1`
+- **`exportedAt`:** RFC3339 UTC timestamp (set on export)
+
+### Sections (schema v1)
+
+| Section | TOML | Merge on import |
+|---------|------|-----------------|
+| App preferences | `[app]` | Overwrites `app_preferences` |
+| Radio favourites | `[[radio.favourites]]` | Upsert by `stationUuid`; `pinned` from file wins |
+| Custom stations | `[[radio.customStations]]` | Upsert by `stationUuid` |
+
+Unknown top-level sections in a future file should be ignored (not implemented yet). Unsupported `schemaVersion` fails import with a clear error; startup logs the error and continues with existing DB state.
+
+## Behaviour
+
+- **Startup:** if `config.toml` exists, Forte imports it before loading preferences.
+- **Settings:** Export / Import open a save/open dialog (TOML filter). Export writes the current DB state; Import applies the chosen file and refreshes app preferences in the UI.
+
+## Adding a new section
+
+1. Add structs in `internal/userconfig/config.go` and bump `SchemaVersion` when incompatible.
+2. Export in `BuildFromDB` and import in `ApplyToDB` (or a dedicated `importX` helper).
+3. Document merge rules in this file.
+4. Add a round-trip test in `internal/userconfig/config_test.go`.

--- a/docs/user-config.md
+++ b/docs/user-config.md
@@ -15,18 +15,22 @@ Forte can export and import portable user settings as a sectioned TOML file.
 
 ### Sections (schema v1)
 
-| Section | TOML | Merge on import |
-|---------|------|-----------------|
-| App preferences | `[app]` | Overwrites `app_preferences` |
-| Radio favourites | `[[radio.favourites]]` | Upsert by `stationUuid`; `pinned` from file wins |
-| Custom stations | `[[radio.customStations]]` | Upsert by `stationUuid` |
+| Section | TOML | Startup import (`config.toml`) | Settings → Import from file |
+|---------|------|-------------------------------|----------------------------|
+| App preferences | `[app]` | Overwrites `app_preferences` | Overwrites `app_preferences` |
+| Radio favourites | `[[radio.favourites]]` | **Merge** — insert only new `stationUuid` | **Replace** — upsert; file wins |
+| Custom stations | `[[radio.customStations]]` | **Merge** — insert only new UUID | **Replace** — upsert; file wins |
+
+**Merge** means stations already in the database are left unchanged (pins, names, and metadata are not rolled back by an older export). **Replace** is for restoring from a backup you explicitly chose.
 
 Unknown top-level sections in a future file should be ignored (not implemented yet). Unsupported `schemaVersion` fails import with a clear error; startup logs the error and continues with existing DB state.
 
 ## Behaviour
 
-- **Startup:** if `config.toml` exists, Forte imports it before loading preferences.
-- **Settings:** Export / Import open a save/open dialog (TOML filter). Export writes the current DB state; Import applies the chosen file and refreshes app preferences in the UI.
+- **Startup:** if `config.toml` exists, Forte merges radio sections then loads preferences.
+- **Settings → Save to config directory:** writes `~/.config/forte/config.toml` (primary dotfiles workflow).
+- **Settings → Export copy:** save-as elsewhere (backups, sharing).
+- **Settings → Import from file:** upsert from the chosen path (restore / migrate).
 
 ## Adding a new section
 

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,7 @@
             if pkgs.stdenv.isDarwin then
               "sha256-M356Dg/QaaeitWx7srKTH+Hpht+c/HfHLdSfwaGwJus="
             else
-              "sha256-PgFI1Kw2jw47OARij8R0LXGthSa/LItw5rNdOJCwb3k=";
+              "sha256-ET8WcOfBmVK5y4mqICLeD3OTTPd4eQ/ZwnnbImmRHd8=";
           modBuildPhase = ''
             runHook preBuild
 

--- a/frontend/bindings/github.com/willfish/forte/index.ts
+++ b/frontend/bindings/github.com/willfish/forte/index.ts
@@ -27,5 +27,6 @@ export {
     ServerConfig,
     ServerStatusJSON,
     SimilarArtistJSON,
-    StatEntryJSON
+    StatEntryJSON,
+    UserConfigImportResultJSON
 } from "./models.js";

--- a/frontend/bindings/github.com/willfish/forte/libraryservice.ts
+++ b/frontend/bindings/github.com/willfish/forte/libraryservice.ts
@@ -116,6 +116,20 @@ export function DisconnectListenBrainz(): $CancellablePromise<void> {
 }
 
 /**
+ * ExportUserConfig writes the canonical config file from current database state.
+ */
+export function ExportUserConfig(): $CancellablePromise<string> {
+    return $Call.ByID(63490165);
+}
+
+/**
+ * ExportUserConfigToPath writes user configuration to the given path.
+ */
+export function ExportUserConfigToPath(path: string): $CancellablePromise<void> {
+    return $Call.ByID(1374680739, path);
+}
+
+/**
  * GetAlbumTracks returns the tracks for a given album.
  */
 export function GetAlbumTracks(albumID: number): $CancellablePromise<$models.AlbumTrack[]> {
@@ -345,6 +359,31 @@ export function GetTopVotedRadioStations(limit: number): $CancellablePromise<$mo
 }
 
 /**
+ * GetUserConfigPath returns the canonical config file path (~/.config/forte/config.toml).
+ */
+export function GetUserConfigPath(): $CancellablePromise<string> {
+    return $Call.ByID(198184712);
+}
+
+/**
+ * ImportUserConfig loads and applies the canonical config file.
+ */
+export function ImportUserConfig(): $CancellablePromise<$models.UserConfigImportResultJSON> {
+    return $Call.ByID(188952206).then(($result: any) => {
+        return $$createType28($result);
+    });
+}
+
+/**
+ * ImportUserConfigFromPath loads and applies a config file from path.
+ */
+export function ImportUserConfigFromPath(path: string): $CancellablePromise<$models.UserConfigImportResultJSON> {
+    return $Call.ByID(2145098713, path).then(($result: any) => {
+        return $$createType28($result);
+    });
+}
+
+/**
  * IsRadioFavourite checks if a station is in favourites.
  */
 export function IsRadioFavourite(stationUUID: string): $CancellablePromise<boolean> {
@@ -414,7 +453,7 @@ export function SaveScrobbleAPIKeys(apiKey: string, apiSecret: string): $Cancell
  */
 export function Search(query: string, limit: number): $CancellablePromise<$models.SearchResult[]> {
     return $Call.ByID(2206755262, query, limit).then(($result: any) => {
-        return $$createType29($result);
+        return $$createType30($result);
     });
 }
 
@@ -522,5 +561,6 @@ const $$createType24 = $models.ServerConfig.createFrom;
 const $$createType25 = $Create.Array($$createType24);
 const $$createType26 = $models.StatEntryJSON.createFrom;
 const $$createType27 = $Create.Array($$createType26);
-const $$createType28 = $models.SearchResult.createFrom;
-const $$createType29 = $Create.Array($$createType28);
+const $$createType28 = $models.UserConfigImportResultJSON.createFrom;
+const $$createType29 = $models.SearchResult.createFrom;
+const $$createType30 = $Create.Array($$createType29);

--- a/frontend/bindings/github.com/willfish/forte/models.ts
+++ b/frontend/bindings/github.com/willfish/forte/models.ts
@@ -949,8 +949,57 @@ export class StatEntryJSON {
     }
 }
 
+/**
+ * UserConfigImportResultJSON reports the outcome of a config import.
+ */
+export class UserConfigImportResultJSON {
+    "path": string;
+    "sectionsApplied": string[];
+    "sectionsSkipped": string[];
+    "warnings": string[];
+
+    /** Creates a new UserConfigImportResultJSON instance. */
+    constructor($$source: Partial<UserConfigImportResultJSON> = {}) {
+        if (!("path" in $$source)) {
+            this["path"] = "";
+        }
+        if (!("sectionsApplied" in $$source)) {
+            this["sectionsApplied"] = [];
+        }
+        if (!("sectionsSkipped" in $$source)) {
+            this["sectionsSkipped"] = [];
+        }
+        if (!("warnings" in $$source)) {
+            this["warnings"] = [];
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new UserConfigImportResultJSON instance from a string or object.
+     */
+    static createFrom($$source: any = {}): UserConfigImportResultJSON {
+        const $$createField1_0 = $$createType4;
+        const $$createField2_0 = $$createType4;
+        const $$createField3_0 = $$createType4;
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("sectionsApplied" in $$parsedSource) {
+            $$parsedSource["sectionsApplied"] = $$createField1_0($$parsedSource["sectionsApplied"]);
+        }
+        if ("sectionsSkipped" in $$parsedSource) {
+            $$parsedSource["sectionsSkipped"] = $$createField2_0($$parsedSource["sectionsSkipped"]);
+        }
+        if ("warnings" in $$parsedSource) {
+            $$parsedSource["warnings"] = $$createField3_0($$parsedSource["warnings"]);
+        }
+        return new UserConfigImportResultJSON($$parsedSource as Partial<UserConfigImportResultJSON>);
+    }
+}
+
 // Private type creation functions
 const $$createType0 = SimilarArtistJSON.createFrom;
 const $$createType1 = $Create.Array($$createType0);
 const $$createType2 = Album.createFrom;
 const $$createType3 = $Create.Array($$createType2);
+const $$createType4 = $Create.Array($Create.Any);

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -137,24 +137,39 @@
     loadUserConfigPath();
   });
 
-  async function exportUserConfig() {
+  async function saveUserConfigHome() {
     userConfigBusy = true;
     userConfigStatus = null;
     try {
-      const defaultPath = userConfigPath || await LibraryService.GetUserConfigPath();
+      const path = await LibraryService.ExportUserConfig();
+      userConfigPath = path;
+      userConfigStatus = {
+        ok: true,
+        message: `Saved to ${path}. Restart merges new stations from this file without overwriting favourites already in the database.`,
+      };
+    } catch (err) {
+      userConfigStatus = { ok: false, message: err instanceof Error ? err.message : 'Save failed' };
+    } finally {
+      userConfigBusy = false;
+    }
+  }
+
+  async function exportUserConfigCopy() {
+    userConfigBusy = true;
+    userConfigStatus = null;
+    try {
       const savePath = await Dialogs.SaveFile({
-        Title: 'Export Forte configuration',
+        Title: 'Export Forte configuration copy',
         Filename: 'config.toml',
         Filters: [{ DisplayName: 'TOML configuration', Pattern: '*.toml' }],
       });
-      const path = (typeof savePath === 'string' && savePath) ? savePath : defaultPath;
+      const path = typeof savePath === 'string' ? savePath : '';
       if (!path) {
         userConfigStatus = { ok: false, message: 'Export cancelled' };
         return;
       }
       await LibraryService.ExportUserConfigToPath(path);
-      userConfigPath = path;
-      userConfigStatus = { ok: true, message: `Exported to ${path}` };
+      userConfigStatus = { ok: true, message: `Exported copy to ${path}` };
     } catch (err) {
       userConfigStatus = { ok: false, message: err instanceof Error ? err.message : 'Export failed' };
     } finally {
@@ -633,18 +648,22 @@
   <section class="section">
     <h3>Configuration file</h3>
     <p class="section-desc">
-      Export favourites, custom stations, and app preferences to a portable TOML file.
-      On startup Forte imports <code>config.toml</code> from your config directory when present.
+      Save favourites, custom stations, and app preferences to <code>config.toml</code> in your config directory.
+      On startup Forte merges in stations from that file (adds missing UUIDs; does not overwrite favourites already in the database).
+      Use Import to apply a chosen file and overwrite matching stations.
     </p>
     {#if userConfigPath}
       <p class="config-path">Default path: <span>{userConfigPath}</span></p>
     {/if}
     <div class="config-actions">
-      <button class="btn-save" type="button" onclick={exportUserConfig} disabled={userConfigBusy}>
-        Export configuration
+      <button class="btn-save" type="button" onclick={saveUserConfigHome} disabled={userConfigBusy}>
+        Save to config directory
       </button>
-      <button class="btn-save" type="button" onclick={importUserConfig} disabled={userConfigBusy}>
-        Import configuration
+      <button class="btn-cancel" type="button" onclick={exportUserConfigCopy} disabled={userConfigBusy}>
+        Export copy…
+      </button>
+      <button class="btn-cancel" type="button" onclick={importUserConfig} disabled={userConfigBusy}>
+        Import from file…
       </button>
     </div>
     {#if userConfigStatus}

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -15,6 +15,7 @@
     type ThemeTransparencyPreference
   } from './lib/theme';
   import { setLibraryEnabled, setTitlebarEnabled } from './lib/stores';
+  import { Dialogs } from '@wailsio/runtime';
   import { LibraryService } from "../bindings/github.com/willfish/forte";
   import type { ServerConfig } from './lib/types';
 
@@ -118,6 +119,74 @@
 
   async function saveLogLevel(level: string) {
     await saveAppPreferences({ ...appPreferences, logLevel: level });
+  }
+
+  let userConfigPath = $state('');
+  let userConfigStatus = $state<{ ok: boolean; message: string } | null>(null);
+  let userConfigBusy = $state(false);
+
+  async function loadUserConfigPath() {
+    try {
+      userConfigPath = await LibraryService.GetUserConfigPath() || '';
+    } catch {
+      userConfigPath = '';
+    }
+  }
+
+  $effect(() => {
+    loadUserConfigPath();
+  });
+
+  async function exportUserConfig() {
+    userConfigBusy = true;
+    userConfigStatus = null;
+    try {
+      const defaultPath = userConfigPath || await LibraryService.GetUserConfigPath();
+      const savePath = await Dialogs.SaveFile({
+        Title: 'Export Forte configuration',
+        Filename: 'config.toml',
+        Filters: [{ DisplayName: 'TOML configuration', Pattern: '*.toml' }],
+      });
+      const path = (typeof savePath === 'string' && savePath) ? savePath : defaultPath;
+      if (!path) {
+        userConfigStatus = { ok: false, message: 'Export cancelled' };
+        return;
+      }
+      await LibraryService.ExportUserConfigToPath(path);
+      userConfigPath = path;
+      userConfigStatus = { ok: true, message: `Exported to ${path}` };
+    } catch (err) {
+      userConfigStatus = { ok: false, message: err instanceof Error ? err.message : 'Export failed' };
+    } finally {
+      userConfigBusy = false;
+    }
+  }
+
+  async function importUserConfig() {
+    userConfigBusy = true;
+    userConfigStatus = null;
+    try {
+      const openPath = await Dialogs.OpenFile({
+        Title: 'Import Forte configuration',
+        CanChooseFiles: true,
+        CanChooseDirectories: false,
+        Filters: [{ DisplayName: 'TOML configuration', Pattern: '*.toml' }],
+      });
+      const path = Array.isArray(openPath) ? openPath[0] : openPath;
+      if (!path) {
+        userConfigStatus = { ok: false, message: 'Import cancelled' };
+        return;
+      }
+      const result = await LibraryService.ImportUserConfigFromPath(path);
+      await loadAppPreferences();
+      const sections = result?.sectionsApplied?.join(', ') || 'none';
+      const warnings = result?.warnings?.length ? ` Warnings: ${result.warnings.join('; ')}` : '';
+      userConfigStatus = { ok: true, message: `Imported from ${path}. Applied: ${sections}.${warnings}` };
+    } catch (err) {
+      userConfigStatus = { ok: false, message: err instanceof Error ? err.message : 'Import failed' };
+    } finally {
+      userConfigBusy = false;
+    }
   }
 
   const themeModeOptions: { value: ThemeMode; label: string; description: string }[] = [
@@ -559,6 +628,30 @@
         </select>
       </div>
     </div>
+  </section>
+
+  <section class="section">
+    <h3>Configuration file</h3>
+    <p class="section-desc">
+      Export favourites, custom stations, and app preferences to a portable TOML file.
+      On startup Forte imports <code>config.toml</code> from your config directory when present.
+    </p>
+    {#if userConfigPath}
+      <p class="config-path">Default path: <span>{userConfigPath}</span></p>
+    {/if}
+    <div class="config-actions">
+      <button class="btn-save" type="button" onclick={exportUserConfig} disabled={userConfigBusy}>
+        Export configuration
+      </button>
+      <button class="btn-save" type="button" onclick={importUserConfig} disabled={userConfigBusy}>
+        Import configuration
+      </button>
+    </div>
+    {#if userConfigStatus}
+      <p class="config-status" class:ok={userConfigStatus.ok} class:error={!userConfigStatus.ok}>
+        {userConfigStatus.message}
+      </p>
+    {/if}
   </section>
 
   {#if appPreferences.libraryEnabled}
@@ -1239,6 +1332,49 @@
 
   .btn-save:hover:not(:disabled) {
     filter: brightness(1.15);
+  }
+
+  .section-desc {
+    margin: 0 0 0.75rem;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    line-height: 1.45;
+  }
+
+  .section-desc code {
+    font-size: 0.8rem;
+  }
+
+  .config-path {
+    margin: 0 0 0.75rem;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    word-break: break-all;
+  }
+
+  .config-path span {
+    color: var(--text-primary);
+  }
+
+  .config-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .config-status {
+    margin: 0.75rem 0 0;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    word-break: break-word;
+  }
+
+  .config-status.ok {
+    color: var(--accent);
+  }
+
+  .config-status.error {
+    color: #e57373;
   }
 
   /* Sync */

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gen2brain/go-mpv v0.2.3
 	github.com/godbus/dbus/v5 v5.2.2
+	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/wailsapp/wails/v3 v3.0.0-alpha.95
 	go.senan.xyz/taglib v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
+github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
+github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=
 github.com/pjbgf/sha1cd v0.6.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/internal/library/radio_favourites.go
+++ b/internal/library/radio_favourites.go
@@ -78,7 +78,8 @@ func (db *DB) AddRadioFavourite(f RadioFavourite) error {
 			country = CASE WHEN excluded.country != '' THEN excluded.country ELSE radio_favourites.country END,
 			codec = CASE WHEN excluded.codec != '' THEN excluded.codec ELSE radio_favourites.codec END,
 			bitrate = CASE WHEN excluded.bitrate > 0 THEN excluded.bitrate ELSE radio_favourites.bitrate END,
-			tags = excluded.tags`,
+			tags = excluded.tags,
+			pinned = excluded.pinned`,
 		f.StationUUID, f.Name, f.StreamURL, f.FaviconURL, f.Homepage, f.Country, f.Codec, f.Bitrate, f.Tags, boolToInt(f.Pinned),
 	)
 	if err != nil {

--- a/internal/userconfig/config.go
+++ b/internal/userconfig/config.go
@@ -1,0 +1,76 @@
+// Package userconfig exports and imports sectioned Forte user configuration (TOML).
+package userconfig
+
+import "time"
+
+const (
+	// SchemaVersion is the current on-disk config schema.
+	SchemaVersion = 1
+	// FileName is the canonical config file under the Forte config directory.
+	FileName = "config.toml"
+)
+
+// File is the top-level config document written to ~/.config/forte/config.toml.
+type File struct {
+	SchemaVersion int          `toml:"schemaVersion"`
+	ExportedAt    string       `toml:"exportedAt,omitempty"`
+	App           AppSection   `toml:"app"`
+	Radio         RadioSection `toml:"radio"`
+}
+
+// AppSection holds product-level preferences (SQLite app_preferences).
+type AppSection struct {
+	LibraryEnabled   bool   `toml:"libraryEnabled"`
+	StartLastStation bool   `toml:"startLastStation"`
+	AutoReconnect    bool   `toml:"autoReconnect"`
+	ShowTitlebar     bool   `toml:"showTitlebar"`
+	LogLevel         string `toml:"logLevel"`
+}
+
+// RadioSection holds radio favourites and custom stations.
+type RadioSection struct {
+	Favourites     []FavouriteEntry     `toml:"favourites"`
+	CustomStations []CustomStationEntry `toml:"customStations"`
+}
+
+// FavouriteEntry is one saved radio favourite including pin state.
+type FavouriteEntry struct {
+	StationUUID string `toml:"stationUuid"`
+	Name        string `toml:"name"`
+	StreamURL   string `toml:"streamUrl"`
+	FaviconURL  string `toml:"faviconUrl"`
+	Homepage    string `toml:"homepage"`
+	Country     string `toml:"country"`
+	Codec       string `toml:"codec"`
+	Bitrate     int    `toml:"bitrate"`
+	Tags        string `toml:"tags"`
+	Pinned      bool   `toml:"pinned"`
+}
+
+// CustomStationEntry is one user-defined radio stream.
+type CustomStationEntry struct {
+	StationUUID string `toml:"stationUuid"`
+	Name        string `toml:"name"`
+	StreamURL   string `toml:"streamUrl"`
+	FaviconURL  string `toml:"faviconUrl"`
+	Homepage    string `toml:"homepage"`
+	Country     string `toml:"country"`
+	Codec       string `toml:"codec"`
+	Bitrate     int    `toml:"bitrate"`
+	Tags        string `toml:"tags"`
+}
+
+// ImportResult reports which sections were applied during import.
+type ImportResult struct {
+	Path            string
+	SectionsApplied []string
+	SectionsSkipped []string
+	Warnings        []string
+}
+
+func newExportFile() File {
+	return File{
+		SchemaVersion: SchemaVersion,
+		ExportedAt:    time.Now().UTC().Format(time.RFC3339),
+	}
+}

--- a/internal/userconfig/config_test.go
+++ b/internal/userconfig/config_test.go
@@ -62,7 +62,7 @@ func TestExportImportRoundTrip(t *testing.T) {
 	}
 
 	fresh := openTestDB(t)
-	if _, err := userconfig.ImportFile(fresh, path); err != nil {
+	if _, err := userconfig.ImportFile(fresh, path, userconfig.ReplaceOptions); err != nil {
 		t.Fatalf("ImportFile: %v", err)
 	}
 
@@ -88,6 +88,62 @@ func TestExportImportRoundTrip(t *testing.T) {
 	}
 	if len(custom) != 1 || custom[0].Name != "My Stream" {
 		t.Fatalf("custom stations mismatch: %#v", custom)
+	}
+}
+
+func TestMergeRadioPreservesExistingFavourites(t *testing.T) {
+	db := openTestDB(t)
+
+	if err := db.AddRadioFavourite(library.RadioFavourite{
+		StationUUID: "in-db",
+		Name:        "Live station",
+		StreamURL:   "https://stream.example/live",
+		Pinned:      true,
+	}); err != nil {
+		t.Fatalf("AddRadioFavourite: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	cfg := userconfig.File{
+		SchemaVersion: userconfig.SchemaVersion,
+		Radio: userconfig.RadioSection{
+			Favourites: []userconfig.FavouriteEntry{{
+				StationUUID: "from-file",
+				Name:        "File station",
+				StreamURL:   "https://stream.example/file",
+				Pinned:      false,
+			}, {
+				StationUUID: "in-db",
+				Name:        "Stale name",
+				StreamURL:   "https://stream.example/stale",
+				Pinned:      false,
+			}},
+		},
+	}
+	if err := userconfig.WriteFile(path, cfg); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if _, err := userconfig.ImportFile(db, path, userconfig.MergeOptions); err != nil {
+		t.Fatalf("ImportFile merge: %v", err)
+	}
+
+	favs, err := db.GetRadioFavourites()
+	if err != nil {
+		t.Fatalf("GetRadioFavourites: %v", err)
+	}
+	if len(favs) != 2 {
+		t.Fatalf("want 2 favourites, got %#v", favs)
+	}
+	byUUID := map[string]library.RadioFavourite{}
+	for _, f := range favs {
+		byUUID[f.StationUUID] = f
+	}
+	if byUUID["in-db"].Name != "Live station" || !byUUID["in-db"].Pinned {
+		t.Fatalf("existing favourite was clobbered: %#v", byUUID["in-db"])
+	}
+	if byUUID["from-file"].Name != "File station" {
+		t.Fatalf("file favourite not added: %#v", byUUID["from-file"])
 	}
 }
 

--- a/internal/userconfig/config_test.go
+++ b/internal/userconfig/config_test.go
@@ -1,0 +1,99 @@
+package userconfig_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/willfish/forte/internal/library"
+	"github.com/willfish/forte/internal/userconfig"
+)
+
+func openTestDB(t *testing.T) *library.DB {
+	t.Helper()
+	db, err := library.OpenDB(filepath.Join(t.TempDir(), "library.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestExportImportRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+
+	if err := db.AddRadioFavourite(library.RadioFavourite{
+		StationUUID: "uuid-1",
+		Name:        "Jazz FM",
+		StreamURL:   "https://stream.example/jazz",
+		Homepage:    "https://jazz.example",
+		Country:     "UK",
+		Codec:       "MP3",
+		Bitrate:     128,
+		Tags:        "jazz",
+		Pinned:      true,
+	}); err != nil {
+		t.Fatalf("AddRadioFavourite: %v", err)
+	}
+	if _, err := db.AddCustomRadioStation(library.RadioCustomStation{
+		StationUUID: "custom-1",
+		Name:        "My Stream",
+		StreamURL:   "https://stream.example/custom",
+		Tags:        "talk",
+	}); err != nil {
+		t.Fatalf("AddCustomRadioStation: %v", err)
+	}
+	if err := db.SaveAppPreferences(library.AppPreferences{
+		LibraryEnabled:   true,
+		StartLastStation: false,
+		AutoReconnect:    true,
+		ShowTitlebar:     true,
+		LogLevel:         "info",
+	}); err != nil {
+		t.Fatalf("SaveAppPreferences: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	cfg, err := userconfig.BuildFromDB(db)
+	if err != nil {
+		t.Fatalf("BuildFromDB: %v", err)
+	}
+	if err := userconfig.WriteFile(path, cfg); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	fresh := openTestDB(t)
+	if _, err := userconfig.ImportFile(fresh, path); err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+
+	prefs, err := fresh.GetAppPreferences()
+	if err != nil {
+		t.Fatalf("GetAppPreferences: %v", err)
+	}
+	if !prefs.LibraryEnabled || prefs.StartLastStation || !prefs.AutoReconnect || !prefs.ShowTitlebar || prefs.LogLevel != "info" {
+		t.Fatalf("app preferences mismatch: %#v", prefs)
+	}
+
+	favs, err := fresh.GetRadioFavourites()
+	if err != nil {
+		t.Fatalf("GetRadioFavourites: %v", err)
+	}
+	if len(favs) != 1 || favs[0].StationUUID != "uuid-1" || !favs[0].Pinned {
+		t.Fatalf("favourites mismatch: %#v", favs)
+	}
+
+	custom, err := fresh.GetCustomRadioStations()
+	if err != nil {
+		t.Fatalf("GetCustomRadioStations: %v", err)
+	}
+	if len(custom) != 1 || custom[0].Name != "My Stream" {
+		t.Fatalf("custom stations mismatch: %#v", custom)
+	}
+}
+
+func TestValidateSchemaRejectsUnknownVersion(t *testing.T) {
+	err := userconfig.ValidateSchema(userconfig.File{SchemaVersion: 99})
+	if err == nil {
+		t.Fatal("expected schema error")
+	}
+}

--- a/internal/userconfig/export.go
+++ b/internal/userconfig/export.go
@@ -1,0 +1,105 @@
+package userconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/willfish/forte/internal/library"
+)
+
+// BuildFromDB reads exportable user state from the library database.
+func BuildFromDB(db *library.DB) (File, error) {
+	out := newExportFile()
+
+	prefs, err := db.GetAppPreferences()
+	if err != nil {
+		return File{}, fmt.Errorf("export app preferences: %w", err)
+	}
+	out.App = AppSection{
+		LibraryEnabled:   prefs.LibraryEnabled,
+		StartLastStation: prefs.StartLastStation,
+		AutoReconnect:    prefs.AutoReconnect,
+		ShowTitlebar:     prefs.ShowTitlebar,
+		LogLevel:         prefs.LogLevel,
+	}
+
+	favs, err := db.GetRadioFavourites()
+	if err != nil {
+		return File{}, fmt.Errorf("export radio favourites: %w", err)
+	}
+	out.Radio.Favourites = make([]FavouriteEntry, len(favs))
+	for i, f := range favs {
+		out.Radio.Favourites[i] = FavouriteEntry{
+			StationUUID: f.StationUUID,
+			Name:        f.Name,
+			StreamURL:   f.StreamURL,
+			FaviconURL:  f.FaviconURL,
+			Homepage:    f.Homepage,
+			Country:     f.Country,
+			Codec:       f.Codec,
+			Bitrate:     f.Bitrate,
+			Tags:        f.Tags,
+			Pinned:      f.Pinned,
+		}
+	}
+
+	custom, err := db.GetCustomRadioStations()
+	if err != nil {
+		return File{}, fmt.Errorf("export custom radio stations: %w", err)
+	}
+	out.Radio.CustomStations = make([]CustomStationEntry, len(custom))
+	for i, st := range custom {
+		out.Radio.CustomStations[i] = CustomStationEntry{
+			StationUUID: st.StationUUID,
+			Name:        st.Name,
+			StreamURL:   st.StreamURL,
+			FaviconURL:  st.FaviconURL,
+			Homepage:    st.Homepage,
+			Country:     st.Country,
+			Codec:       st.Codec,
+			Bitrate:     st.Bitrate,
+			Tags:        st.Tags,
+		}
+	}
+
+	return out, nil
+}
+
+// WriteFile encodes cfg as TOML and writes it to path, creating parent directories.
+func WriteFile(path string, cfg File) error {
+	if cfg.SchemaVersion == 0 {
+		cfg.SchemaVersion = SchemaVersion
+	}
+	if cfg.ExportedAt == "" {
+		cfg.ExportedAt = newExportFile().ExportedAt
+	}
+	data, err := toml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("encode config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	return nil
+}
+
+// ExportToDBPath writes the canonical config file for the current database state.
+func ExportToDBPath(db *library.DB) (string, error) {
+	path, err := DefaultPath()
+	if err != nil {
+		return "", err
+	}
+	cfg, err := BuildFromDB(db)
+	if err != nil {
+		return "", err
+	}
+	if err := WriteFile(path, cfg); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/internal/userconfig/import.go
+++ b/internal/userconfig/import.go
@@ -1,0 +1,128 @@
+package userconfig
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/willfish/forte/internal/library"
+	"github.com/willfish/forte/internal/logx"
+)
+
+// ApplyToDB imports supported sections from cfg into the library database.
+//
+// Merge rules (schema v1):
+//   - app: overwrites app_preferences.
+//   - radio.favourites: upserts by stationUuid; pinned state from file wins.
+//   - radio.customStations: upserts by stationUuid.
+func ApplyToDB(db *library.DB, cfg File) (ImportResult, error) {
+	if err := ValidateSchema(cfg); err != nil {
+		return ImportResult{}, err
+	}
+
+	result := ImportResult{}
+
+	if err := importApp(db, cfg.App); err != nil {
+		return result, fmt.Errorf("import app: %w", err)
+	}
+	result.SectionsApplied = append(result.SectionsApplied, "app")
+
+	if len(cfg.Radio.Favourites) > 0 || len(cfg.Radio.CustomStations) > 0 {
+		if err := importRadio(db, cfg.Radio); err != nil {
+			return result, fmt.Errorf("import radio: %w", err)
+		}
+		result.SectionsApplied = append(result.SectionsApplied, "radio")
+	}
+
+	return result, nil
+}
+
+// ImportFile loads path and applies supported sections.
+func ImportFile(db *library.DB, path string) (ImportResult, error) {
+	cfg, err := LoadFile(path)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	result, err := ApplyToDB(db, cfg)
+	result.Path = path
+	return result, err
+}
+
+// ImportDefaultIfPresent loads the canonical config file when it exists.
+// Schema errors are returned; a missing file is not an error.
+func ImportDefaultIfPresent(db *library.DB) (ImportResult, error) {
+	path, err := DefaultPath()
+	if err != nil {
+		return ImportResult{}, err
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return ImportResult{Path: path}, nil
+		}
+		return ImportResult{}, fmt.Errorf("stat config: %w", err)
+	}
+	result, err := ImportFile(db, path)
+	if err != nil {
+		logx.Logger().Warn("user config import failed", "path", path, "error", err)
+		return result, err
+	}
+	if len(result.SectionsApplied) > 0 {
+		logx.Logger().Info("user config imported", "path", path, "sections", strings.Join(result.SectionsApplied, ","))
+	}
+	return result, nil
+}
+
+func importApp(db *library.DB, app AppSection) error {
+	logLevel := strings.TrimSpace(app.LogLevel)
+	if logLevel == "" {
+		logLevel = logx.LevelWarn
+	}
+	return db.SaveAppPreferences(library.AppPreferences{
+		LibraryEnabled:   app.LibraryEnabled,
+		StartLastStation: app.StartLastStation,
+		AutoReconnect:    app.AutoReconnect,
+		ShowTitlebar:     app.ShowTitlebar,
+		LogLevel:         logLevel,
+	})
+}
+
+func importRadio(db *library.DB, radio RadioSection) error {
+	for _, fav := range radio.Favourites {
+		if strings.TrimSpace(fav.StationUUID) == "" || strings.TrimSpace(fav.StreamURL) == "" {
+			continue
+		}
+		if err := db.AddRadioFavourite(library.RadioFavourite{
+			StationUUID: fav.StationUUID,
+			Name:        fav.Name,
+			StreamURL:   fav.StreamURL,
+			FaviconURL:  fav.FaviconURL,
+			Homepage:    fav.Homepage,
+			Country:     fav.Country,
+			Codec:       fav.Codec,
+			Bitrate:     fav.Bitrate,
+			Tags:        fav.Tags,
+			Pinned:      fav.Pinned,
+		}); err != nil {
+			return err
+		}
+	}
+	for _, st := range radio.CustomStations {
+		if strings.TrimSpace(st.StreamURL) == "" {
+			continue
+		}
+		if _, err := db.AddCustomRadioStation(library.RadioCustomStation{
+			StationUUID: st.StationUUID,
+			Name:        st.Name,
+			StreamURL:   st.StreamURL,
+			FaviconURL:  st.FaviconURL,
+			Homepage:    st.Homepage,
+			Country:     st.Country,
+			Codec:       st.Codec,
+			Bitrate:     st.Bitrate,
+			Tags:        st.Tags,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/userconfig/import.go
+++ b/internal/userconfig/import.go
@@ -12,10 +12,10 @@ import (
 // ApplyToDB imports supported sections from cfg into the library database.
 //
 // Merge rules (schema v1):
-//   - app: overwrites app_preferences.
-//   - radio.favourites: upserts by stationUuid; pinned state from file wins.
-//   - radio.customStations: upserts by stationUuid.
-func ApplyToDB(db *library.DB, cfg File) (ImportResult, error) {
+//   - app: always overwrites app_preferences.
+//   - radio: when opts.MergeRadio is true, inserts only new stationUuid values;
+//     when false, upserts by stationUuid (file wins for matches).
+func ApplyToDB(db *library.DB, cfg File, opts ApplyOptions) (ImportResult, error) {
 	if err := ValidateSchema(cfg); err != nil {
 		return ImportResult{}, err
 	}
@@ -28,7 +28,7 @@ func ApplyToDB(db *library.DB, cfg File) (ImportResult, error) {
 	result.SectionsApplied = append(result.SectionsApplied, "app")
 
 	if len(cfg.Radio.Favourites) > 0 || len(cfg.Radio.CustomStations) > 0 {
-		if err := importRadio(db, cfg.Radio); err != nil {
+		if err := importRadio(db, cfg.Radio, opts); err != nil {
 			return result, fmt.Errorf("import radio: %w", err)
 		}
 		result.SectionsApplied = append(result.SectionsApplied, "radio")
@@ -37,13 +37,13 @@ func ApplyToDB(db *library.DB, cfg File) (ImportResult, error) {
 	return result, nil
 }
 
-// ImportFile loads path and applies supported sections.
-func ImportFile(db *library.DB, path string) (ImportResult, error) {
+// ImportFile loads path and applies supported sections using opts.
+func ImportFile(db *library.DB, path string, opts ApplyOptions) (ImportResult, error) {
 	cfg, err := LoadFile(path)
 	if err != nil {
 		return ImportResult{}, err
 	}
-	result, err := ApplyToDB(db, cfg)
+	result, err := ApplyToDB(db, cfg, opts)
 	result.Path = path
 	return result, err
 }
@@ -61,7 +61,7 @@ func ImportDefaultIfPresent(db *library.DB) (ImportResult, error) {
 		}
 		return ImportResult{}, fmt.Errorf("stat config: %w", err)
 	}
-	result, err := ImportFile(db, path)
+	result, err := ImportFile(db, path, MergeOptions)
 	if err != nil {
 		logx.Logger().Warn("user config import failed", "path", path, "error", err)
 		return result, err
@@ -86,10 +86,30 @@ func importApp(db *library.DB, app AppSection) error {
 	})
 }
 
-func importRadio(db *library.DB, radio RadioSection) error {
+func importRadio(db *library.DB, radio RadioSection, opts ApplyOptions) error {
+	customExisting := map[string]struct{}{}
+	if opts.MergeRadio {
+		stations, err := db.GetCustomRadioStations()
+		if err != nil {
+			return err
+		}
+		for _, st := range stations {
+			customExisting[st.StationUUID] = struct{}{}
+		}
+	}
+
 	for _, fav := range radio.Favourites {
 		if strings.TrimSpace(fav.StationUUID) == "" || strings.TrimSpace(fav.StreamURL) == "" {
 			continue
+		}
+		if opts.MergeRadio {
+			exists, err := db.IsRadioFavourite(fav.StationUUID)
+			if err != nil {
+				return err
+			}
+			if exists {
+				continue
+			}
 		}
 		if err := db.AddRadioFavourite(library.RadioFavourite{
 			StationUUID: fav.StationUUID,
@@ -110,8 +130,17 @@ func importRadio(db *library.DB, radio RadioSection) error {
 		if strings.TrimSpace(st.StreamURL) == "" {
 			continue
 		}
+		uuid := st.StationUUID
+		if uuid == "" {
+			uuid = library.CustomRadioStationUUID(st.StreamURL)
+		}
+		if opts.MergeRadio {
+			if _, ok := customExisting[uuid]; ok {
+				continue
+			}
+		}
 		if _, err := db.AddCustomRadioStation(library.RadioCustomStation{
-			StationUUID: st.StationUUID,
+			StationUUID: uuid,
 			Name:        st.Name,
 			StreamURL:   st.StreamURL,
 			FaviconURL:  st.FaviconURL,

--- a/internal/userconfig/load.go
+++ b/internal/userconfig/load.go
@@ -1,0 +1,32 @@
+package userconfig
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// LoadFile reads and decodes a config file from disk.
+func LoadFile(path string) (File, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return File{}, fmt.Errorf("read config: %w", err)
+	}
+	var cfg File
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return File{}, fmt.Errorf("decode config: %w", err)
+	}
+	return cfg, nil
+}
+
+// ValidateSchema returns an error when the file version is not supported.
+func ValidateSchema(cfg File) error {
+	if cfg.SchemaVersion == 0 {
+		return fmt.Errorf("config missing schemaVersion (expected %d)", SchemaVersion)
+	}
+	if cfg.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("unsupported config schemaVersion %d (expected %d)", cfg.SchemaVersion, SchemaVersion)
+	}
+	return nil
+}

--- a/internal/userconfig/options.go
+++ b/internal/userconfig/options.go
@@ -1,0 +1,14 @@
+package userconfig
+
+// ApplyOptions controls how config sections are merged into the database.
+type ApplyOptions struct {
+	// MergeRadio inserts favourites and custom stations only when the UUID is
+	// not already in the database. Existing rows are left unchanged.
+	MergeRadio bool
+}
+
+// ReplaceOptions applies file values over matching database rows (upsert).
+var ReplaceOptions = ApplyOptions{}
+
+// MergeOptions adds radio entries from the file without updating existing UUIDs.
+var MergeOptions = ApplyOptions{MergeRadio: true}

--- a/internal/userconfig/path.go
+++ b/internal/userconfig/path.go
@@ -1,0 +1,25 @@
+package userconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Dir returns the Forte config directory (e.g. ~/.config/forte).
+func Dir() (string, error) {
+	dataDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("config dir: %w", err)
+	}
+	return filepath.Join(dataDir, "forte"), nil
+}
+
+// DefaultPath returns the canonical config file path (…/forte/config.toml).
+func DefaultPath() (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, FileName), nil
+}

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -25,6 +25,7 @@ import (
 	"github.com/willfish/forte/internal/scrobbling/listenbrainz"
 	"github.com/willfish/forte/internal/streaming/jellyfin"
 	"github.com/willfish/forte/internal/streaming/subsonic"
+	"github.com/willfish/forte/internal/userconfig"
 )
 
 // LibraryService exposes the music library to the frontend.
@@ -54,6 +55,10 @@ func (s *LibraryService) ServiceStartup(_ context.Context, _ application.Service
 		return fmt.Errorf("library startup: %w", err)
 	}
 	s.db = db
+
+	if _, err := userconfig.ImportDefaultIfPresent(db); err != nil {
+		log.Printf("user config import: %v", err)
+	}
 
 	prefs, err := db.GetAppPreferences()
 	if err != nil {

--- a/libraryservice_userconfig.go
+++ b/libraryservice_userconfig.go
@@ -49,7 +49,7 @@ func (s *LibraryService) ExportUserConfigToPath(path string) error {
 	return userconfig.WriteFile(path, cfg)
 }
 
-// ImportUserConfig loads and applies the canonical config file.
+// ImportUserConfig loads and merges the canonical config file (same rules as startup).
 func (s *LibraryService) ImportUserConfig() (UserConfigImportResultJSON, error) {
 	if s.db == nil {
 		return UserConfigImportResultJSON{}, fmt.Errorf("library not initialised")
@@ -58,7 +58,15 @@ func (s *LibraryService) ImportUserConfig() (UserConfigImportResultJSON, error) 
 	if err != nil {
 		return UserConfigImportResultJSON{}, err
 	}
-	return s.ImportUserConfigFromPath(path)
+	result, err := userconfig.ImportFile(s.db, path, userconfig.MergeOptions)
+	if err != nil {
+		return importResultToJSON(result), err
+	}
+	jsonResult := importResultToJSON(result)
+	if err := s.applyImportedAppPreferences(); err != nil {
+		return jsonResult, err
+	}
+	return jsonResult, nil
 }
 
 // ImportUserConfigFromPath loads and applies a config file from path.
@@ -66,7 +74,8 @@ func (s *LibraryService) ImportUserConfigFromPath(path string) (UserConfigImport
 	if s.db == nil {
 		return UserConfigImportResultJSON{}, fmt.Errorf("library not initialised")
 	}
-	result, err := userconfig.ImportFile(s.db, path)
+	// Explicit file import: upsert so a chosen backup can restore metadata and pin state.
+	result, err := userconfig.ImportFile(s.db, path, userconfig.ReplaceOptions)
 	if err != nil {
 		return importResultToJSON(result), err
 	}

--- a/libraryservice_userconfig.go
+++ b/libraryservice_userconfig.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/willfish/forte/internal/logx"
+	"github.com/willfish/forte/internal/userconfig"
+)
+
+// UserConfigImportResultJSON reports the outcome of a config import.
+type UserConfigImportResultJSON struct {
+	Path            string   `json:"path"`
+	SectionsApplied []string `json:"sectionsApplied"`
+	SectionsSkipped []string `json:"sectionsSkipped"`
+	Warnings        []string `json:"warnings"`
+}
+
+func importResultToJSON(r userconfig.ImportResult) UserConfigImportResultJSON {
+	return UserConfigImportResultJSON{
+		Path:            r.Path,
+		SectionsApplied: r.SectionsApplied,
+		SectionsSkipped: r.SectionsSkipped,
+		Warnings:        r.Warnings,
+	}
+}
+
+// GetUserConfigPath returns the canonical config file path (~/.config/forte/config.toml).
+func (s *LibraryService) GetUserConfigPath() (string, error) {
+	return userconfig.DefaultPath()
+}
+
+// ExportUserConfig writes the canonical config file from current database state.
+func (s *LibraryService) ExportUserConfig() (string, error) {
+	if s.db == nil {
+		return "", fmt.Errorf("library not initialised")
+	}
+	return userconfig.ExportToDBPath(s.db)
+}
+
+// ExportUserConfigToPath writes user configuration to the given path.
+func (s *LibraryService) ExportUserConfigToPath(path string) error {
+	if s.db == nil {
+		return fmt.Errorf("library not initialised")
+	}
+	cfg, err := userconfig.BuildFromDB(s.db)
+	if err != nil {
+		return err
+	}
+	return userconfig.WriteFile(path, cfg)
+}
+
+// ImportUserConfig loads and applies the canonical config file.
+func (s *LibraryService) ImportUserConfig() (UserConfigImportResultJSON, error) {
+	if s.db == nil {
+		return UserConfigImportResultJSON{}, fmt.Errorf("library not initialised")
+	}
+	path, err := userconfig.DefaultPath()
+	if err != nil {
+		return UserConfigImportResultJSON{}, err
+	}
+	return s.ImportUserConfigFromPath(path)
+}
+
+// ImportUserConfigFromPath loads and applies a config file from path.
+func (s *LibraryService) ImportUserConfigFromPath(path string) (UserConfigImportResultJSON, error) {
+	if s.db == nil {
+		return UserConfigImportResultJSON{}, fmt.Errorf("library not initialised")
+	}
+	result, err := userconfig.ImportFile(s.db, path)
+	if err != nil {
+		return importResultToJSON(result), err
+	}
+	jsonResult := importResultToJSON(result)
+	if err := s.applyImportedAppPreferences(); err != nil {
+		return jsonResult, err
+	}
+	return jsonResult, nil
+}
+
+func (s *LibraryService) applyImportedAppPreferences() error {
+	prefs, err := s.db.GetAppPreferences()
+	if err != nil {
+		return err
+	}
+	return s.SaveAppPreferences(AppPreferencesJSON{
+		LibraryEnabled:   prefs.LibraryEnabled,
+		StartLastStation: prefs.StartLastStation,
+		AutoReconnect:    prefs.AutoReconnect,
+		ShowTitlebar:     prefs.ShowTitlebar,
+		LogLevel:         prefs.LogLevel,
+		LogFilePath:      logx.Path(),
+	})
+}


### PR DESCRIPTION
Closes #195

### GitHub issue

[#195 — Export and import sectioned user configuration](https://github.com/willfish/forte/issues/195)

```mermaid
flowchart LR
  DB[(library.db)] -->|Save to config directory| TOML[config.toml]
  TOML -->|Startup merge| DB
  TOML -->|Import from file upsert| DB
```

### What?

- [x] TOML config at `~/.config/forte/config.toml` with `schemaVersion`, `[app]`, `[[radio.favourites]]`, `[[radio.customStations]]`
- [x] `internal/userconfig` export/import with round-trip and merge tests
- [x] Startup import merges radio (insert new UUIDs only; existing favourites unchanged)
- [x] Settings: Save to config directory, Export copy, Import from file (upsert)
- [x] Wails bindings and `docs/user-config.md`

### Why?

Radio favourites, pins, and custom stations lived only in SQLite. A portable, hand-editable config file supports dotfiles, machine moves, and backups without copying the whole database.

### Risk

**Risk level:** 🟢

**Reason for rating:** New feature behind explicit export/import and startup merge; existing DB behaviour unchanged when `config.toml` is absent. Covered by Go tests and svelte-check.

### Try it

1. Build/run as usual (`wails3 dev` or your normal flow).
2. Settings → **Save to config directory** → check `~/.config/forte/config.toml`.
3. Add a favourite in the app, restart — existing favourites should stay; new stations from the file are added.
4. **Import from file…** — upserts from a chosen backup.