### PR TITLE
BAU: Fix tray window toggle restore

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,14 +146,6 @@ func main() {
 	tray := app.SystemTray.New()
 	tray.SetLabel("Forte")
 
-	menu := buildForteTrayMenu(app.NewMenu(), trayMenuActions{
-		playback:     ps,
-		toggleWindow: tray.ToggleWindow,
-		quit: func() {
-			app.Quit()
-		},
-	})
-
 	window := app.Window.NewWithOptions(application.WebviewWindowOptions{
 		Title:            "Forte",
 		Width:            1200,
@@ -172,6 +164,14 @@ func main() {
 		e.Cancel()
 	})
 
+	menu := buildForteTrayMenu(app.NewMenu(), trayMenuActions{
+		playback:     ps,
+		toggleWindow: func() { toggleForteWindow(window) },
+		quit: func() {
+			app.Quit()
+		},
+	})
+
 	trayIconState := newTrayIconState("green-dark", trayStateIdle)
 
 	tray.SetMenu(menu).AttachWindow(window)
@@ -186,7 +186,7 @@ func main() {
 		tray.SetIcon(trayIconState.current())
 		// Left-click toggles window (Linux behaviour preserved).
 		tray.OnClick(func() {
-			tray.ToggleWindow()
+			toggleForteWindow(window)
 		})
 	}
 

--- a/tray_menu.go
+++ b/tray_menu.go
@@ -2,6 +2,15 @@ package main
 
 import "github.com/wailsapp/wails/v3/pkg/application"
 
+type trayWindow interface {
+	IsVisible() bool
+	IsMinimised() bool
+	Hide() application.Window
+	Restore()
+	Show() application.Window
+	Focus()
+}
+
 type trayPlaybackController interface {
 	State() string
 	Pause()
@@ -60,4 +69,17 @@ func buildForteTrayMenu(menu *application.Menu, actions trayMenuActions) *applic
 		})
 	}
 	return menu
+}
+
+func toggleForteWindow(window trayWindow) {
+	if window == nil {
+		return
+	}
+	if window.IsVisible() && !window.IsMinimised() {
+		window.Hide()
+		return
+	}
+	window.Restore()
+	window.Show()
+	window.Focus()
 }

--- a/tray_menu_test.go
+++ b/tray_menu_test.go
@@ -12,6 +12,12 @@ type fakeTrayPlayback struct {
 	calls []string
 }
 
+type fakeTrayWindow struct {
+	visible   bool
+	minimised bool
+	calls     []string
+}
+
 func (f *fakeTrayPlayback) State() string {
 	return f.state
 }
@@ -34,6 +40,32 @@ func (f *fakeTrayPlayback) Next() {
 
 func (f *fakeTrayPlayback) Previous() {
 	f.calls = append(f.calls, "previous")
+}
+
+func (f *fakeTrayWindow) IsVisible() bool {
+	return f.visible
+}
+
+func (f *fakeTrayWindow) IsMinimised() bool {
+	return f.minimised
+}
+
+func (f *fakeTrayWindow) Hide() application.Window {
+	f.calls = append(f.calls, "hide")
+	return nil
+}
+
+func (f *fakeTrayWindow) Restore() {
+	f.calls = append(f.calls, "restore")
+}
+
+func (f *fakeTrayWindow) Show() application.Window {
+	f.calls = append(f.calls, "show")
+	return nil
+}
+
+func (f *fakeTrayWindow) Focus() {
+	f.calls = append(f.calls, "focus")
 }
 
 func TestForteTrayMenuShape(t *testing.T) {
@@ -102,6 +134,39 @@ func TestForteTrayMenuActions(t *testing.T) {
 	}
 	if quit != 1 {
 		t.Fatalf("quit called %d times, want 1", quit)
+	}
+}
+
+func TestToggleForteWindow(t *testing.T) {
+	tests := []struct {
+		name      string
+		window    *fakeTrayWindow
+		wantCalls []string
+	}{
+		{
+			name:      "hides visible window",
+			window:    &fakeTrayWindow{visible: true},
+			wantCalls: []string{"hide"},
+		},
+		{
+			name:      "shows hidden window",
+			window:    &fakeTrayWindow{},
+			wantCalls: []string{"restore", "show", "focus"},
+		},
+		{
+			name:      "restores minimised visible window",
+			window:    &fakeTrayWindow{visible: true, minimised: true},
+			wantCalls: []string{"restore", "show", "focus"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			toggleForteWindow(tt.window)
+			if !reflect.DeepEqual(tt.window.calls, tt.wantCalls) {
+				t.Fatalf("calls = %#v, want %#v", tt.window.calls, tt.wantCalls)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What changed

- Replaced direct use of Wails `tray.ToggleWindow()` for Forte's tray actions with an app-owned toggle helper.
- The helper hides only when the window is visible and not minimised; otherwise it restores, shows, and focuses the window.
- Added tests for visible, hidden, and minimised tray-window toggle states.

## Why

Wails' tray toggle decides from `Window.IsVisible()`. On Linux/GTK, a minimised window can still report visible, so selecting `Show/Hide Window` may hide the window instead of restoring it.

## Validation

- `go test ./... -run 'TestForteTrayMenu|TestToggleForteWindow|TestTrayIcon'`
- `go test ./...`
- pre-push hooks: `golangci-lint`, `gotest`, `nix build .#forte .#frontend`, formatting checks
