### PR TITLE
BAU: Release 1.0.0

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,7 +20,7 @@ tasks:
   package:
     summary: Packages a production build of the application
     env:
-      VERSION: '{{.VERSION | default "0.0.0-dev"}}'
+      VERSION: '{{.VERSION | default "1.0.0"}}'
     cmds:
       - task: "linux:package"
 

--- a/build/config.yml
+++ b/build/config.yml
@@ -5,7 +5,7 @@ info:
   productIdentifier: "io.github.willfish.forte"
   description: "A modern music player"
   copyright: "(c) 2026, William Fish"
-  version: "0.1.0"
+  version: "1.0.0"
 
 dev_mode:
   root_path: .

--- a/flake.nix
+++ b/flake.nix
@@ -105,10 +105,10 @@
 
         frontend = pkgs.buildNpmPackage {
           pname = "forte-frontend";
-          version = "0.1.0";
+          version = "1.0.0";
           src = ./frontend;
           nodejs = pkgs.nodejs_22;
-          npmDepsHash = "sha256-kEprDYBdn3cayhPsS81DOEs+biGUquJZJvO2jD07Lp0=";
+          npmDepsHash = "sha256-MJDctjX8RZl72Vh3L0uPexNjuVHzLfZBMFJE+KzV1Lk=";
           buildPhase = ''
             npm run build
           '';
@@ -120,7 +120,7 @@
 
         forte = pkgs.buildGoModule {
           pname = "forte";
-          version = "0.1.0";
+          version = "1.0.0";
           src = ./.;
           go = pkgs.go_1_25;
           vendorHash =
@@ -271,9 +271,9 @@
               	<key>CFBundlePackageType</key>
               	<string>APPL</string>
               	<key>CFBundleShortVersionString</key>
-              	<string>0.1.0</string>
+                <string>1.0.0</string>
               	<key>CFBundleVersion</key>
-              	<string>0.1.0</string>
+                <string>1.0.0</string>
               	<key>LSMinimumSystemVersion</key>
               	<string>10.13</string>
               	<key>NSHighResolutionCapable</key>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forte-frontend",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "forte-frontend",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@wailsio/runtime": "3.0.0-alpha.79"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "forte-frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "packageManager": "npm@10.9.4",
   "scripts": {

--- a/scripts/prove-distro-install.sh
+++ b/scripts/prove-distro-install.sh
@@ -64,7 +64,7 @@ export PATH="$HOME/go/bin:$PATH"
 go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.95
 go install github.com/go-task/task/v3/cmd/task@v3.51.1
 
-export VERSION=0.1.0-test
+export VERSION=1.0.0-test
 export GIT_COMMITTER_NAME=Forte
 export GIT_COMMITTER_EMAIL=forte@example.invalid
 task linux:create:deb
@@ -162,7 +162,7 @@ export PATH="$HOME/go/bin:$PATH"
 go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.95
 go install github.com/go-task/task/v3/cmd/task@v3.51.1
 
-export VERSION=0.1.0-test
+export VERSION=1.0.0-test
 export GIT_COMMITTER_NAME=Forte
 export GIT_COMMITTER_EMAIL=forte@example.invalid
 task linux:create:aur


### PR DESCRIPTION
## What changed

- Bumped Forte release metadata to `1.0.0` across Wails config, Nix packages, macOS bundle metadata, frontend package metadata, and Linux packaging defaults.
- Updated distro install proof package versions to `1.0.0-test`.
- Updated the Nix frontend dependency hash after the package-lock metadata change.

## Validation

- `go test ./...`
- `npm --prefix frontend run check`
- `nix shell nixpkgs#desktop-file-utils --command desktop-file-validate build/linux/forte.desktop`
- `nix build .#frontend .#forte --no-link`
- pre-push hooks: `golangci-lint`, `nix build .#forte .#frontend`, shell/yaml/nix formatting checks

After this PR merges, tag the merged `master` commit as `v1.0.0`.
