### PR TITLE
BAU: Fix AppImage release icon staging

### DIFF
--- a/build/linux/Taskfile.yml
+++ b/build/linux/Taskfile.yml
@@ -119,12 +119,12 @@ tasks:
       - task: common:ensure:wails3
     cmds:
       - cp "{{.APP_BINARY}}" "{{.APP_NAME}}"
-      - cp ../../appicon.png "{{.APP_NAME}}.png"
+      - cp ../../appicon.png "{{.ICON}}"
       - '{{.ROOT_DIR}}/.go/bin/wails3 generate appimage -binary "{{.APP_NAME}}" -icon {{.ICON}} -desktopfile {{.DESKTOP_FILE}} -outputdir {{.OUTPUT_DIR}} -builddir {{.ROOT_DIR}}/build/linux/appimage/build'
     vars:
       APP_NAME: '{{.APP_NAME}}'
       APP_BINARY: '../../../bin/{{.APP_NAME}}'
-      ICON: '{{.APP_NAME}}.png'
+      ICON: 'io.github.willfish.forte.png'
       DESKTOP_FILE: '../{{.APP_NAME}}.desktop'
       OUTPUT_DIR: '../../../bin'
 


### PR DESCRIPTION
## What changed

- Stage the AppImage icon as `io.github.willfish.forte.png` instead of `forte.png`.
- Pass that same icon filename to `wails3 generate appimage`.

## Why

The release workflow failed during AppImage packaging because the generated desktop file declares `Icon=io.github.willfish.forte`, but the AppImage task only copied `forte.png`. `appimagetool` resolves the desktop icon name and requires `io.github.willfish.forte.png`, `.svg`, or `.xpm` in the AppDir root.

Failing release job: https://github.com/willfish/forte/actions/runs/26972042566/job/79589461349

## Validation

- `go test ./...`
- `nix build .#frontend .#forte --no-link`
- `VERSION=1.0.0 task linux:create:appimage` progressed past the previous icon-missing AppImage failure; local packaging then stopped on local WebKit AppImage discovery that differs from the Ubuntu release runner.
- pre-push hooks: `golangci-lint`, `nix build .#forte .#frontend`, formatting checks
