### PR TITLE
BAU: Fix release tidy with frontend dependencies

### DIFF
--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -48,7 +48,36 @@ tasks:
     summary: Runs `go mod tidy`
     internal: true
     cmds:
-      - go mod tidy
+      - |
+        lock_dir='{{.ROOT_DIR}}/.go/go-mod-tidy.lock'
+        node_modules='{{.ROOT_DIR}}/frontend/node_modules'
+        hidden_node_modules='{{.ROOT_DIR}}/frontend/.node_modules.go-mod-tidy'
+
+        mkdir -p "$(dirname "$lock_dir")"
+        while ! mkdir "$lock_dir" 2>/dev/null; do
+          sleep 0.2
+        done
+
+        restore_node_modules() {
+          if [ -d "$hidden_node_modules" ]; then
+            rm -rf "$node_modules"
+            mv "$hidden_node_modules" "$node_modules"
+          fi
+        }
+
+        cleanup() {
+          restore_node_modules
+          rmdir "$lock_dir"
+        }
+
+        trap cleanup EXIT
+
+        if [ -d "$node_modules" ]; then
+          rm -rf "$hidden_node_modules"
+          mv "$node_modules" "$hidden_node_modules"
+        fi
+
+        go mod tidy
 
   patch:wails:
     summary: Applies Forte's local Wails patches to the module cache
@@ -92,7 +121,16 @@ tasks:
       - sh: npm version
         msg: "Looks like npm isn't installed. Npm is part of the Node installer: https://nodejs.org/en/download/"
     cmds:
-      - npm ci
+      - |
+        lock_dir='{{.ROOT_DIR}}/.go/go-mod-tidy.lock'
+
+        mkdir -p "$(dirname "$lock_dir")"
+        while ! mkdir "$lock_dir" 2>/dev/null; do
+          sleep 0.2
+        done
+        trap 'rmdir "$lock_dir"' EXIT
+
+        npm ci
 
   build:frontend:
     label: build:frontend (DEV={{.DEV}})

--- a/frontend/bindings/github.com/willfish/forte/libraryservice.ts
+++ b/frontend/bindings/github.com/willfish/forte/libraryservice.ts
@@ -366,7 +366,7 @@ export function GetUserConfigPath(): $CancellablePromise<string> {
 }
 
 /**
- * ImportUserConfig loads and applies the canonical config file.
+ * ImportUserConfig loads and merges the canonical config file (same rules as startup).
  */
 export function ImportUserConfig(): $CancellablePromise<$models.UserConfigImportResultJSON> {
     return $Call.ByID(188952206).then(($result: any) => {


### PR DESCRIPTION
## Summary

- hide `frontend/node_modules` while the shared `go mod tidy` task runs, then restore it before subsequent build/package steps
- serialize that temporary move behind a `.go/go-mod-tidy.lock` so concurrent Task deps cannot race
- refresh the generated LibraryService binding comment produced by `wails3 generate bindings`

## Root cause

The release package workflow runs `npm ci` for the frontend, then later package tasks invoke `linux:build` again. That re-enters `common:go:mod:tidy` while `frontend/node_modules` exists. Go walks the module tree, sees scoped npm package directories such as `frontend/node_modules/@napi-rs` and `@tybys`, and fails with `should not have @version` import path errors.

## Verification

- `npm --prefix frontend ci`
- `task common:generate:bindings`
- confirmed `frontend/node_modules` was restored, `.node_modules.go-mod-tidy` was absent, and `.go/go-mod-tidy.lock` was released
- `go test ./...`
- `nix build .#frontend .#forte --no-link`
- `VERSION=1.0.0 task linux:create:rpm`
