### PR TITLE
Reduce idle radio IPC polling

### DIFF
--- a/frontend/src/Toast.svelte
+++ b/frontend/src/Toast.svelte
@@ -11,7 +11,8 @@
 
   let toasts = $state<ToastItem[]>([]);
   let nextId = 0;
-  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let polling = false;
 
   function toastGroup(message: string): string {
     if (message.startsWith('Radio stream ') || message === 'Radio reconnected') {
@@ -21,35 +22,43 @@
   }
 
   function startPolling() {
-    if (pollTimer) return;
-    pollTimer = setInterval(async () => {
-      try {
-        const items = await PlayerService.GetToasts();
-        if (items && items.length > 0) {
-          const now = Date.now();
-          for (const item of items) {
-            const group = toastGroup(item.message);
-            toasts = toasts.filter(t => toastGroup(t.message) !== group);
-            toasts.push({
-              id: nextId++,
-              message: item.message,
-              type: item.type || 'info',
-              expiry: now + 4000,
-            });
-          }
+    if (polling) return;
+    polling = true;
+    poll();
+  }
+
+  async function poll() {
+    try {
+      const items = await PlayerService.GetToasts();
+      if (items && items.length > 0) {
+        const now = Date.now();
+        for (const item of items) {
+          const group = toastGroup(item.message);
+          toasts = toasts.filter(t => toastGroup(t.message) !== group);
+          toasts.push({
+            id: nextId++,
+            message: item.message,
+            type: item.type || 'info',
+            expiry: now + 4000,
+          });
         }
-      } catch {
-        // ignore polling errors
       }
-      // Remove expired toasts.
-      const now = Date.now();
-      toasts = toasts.filter(t => t.expiry > now);
-    }, 500);
+    } catch {
+      // ignore polling errors
+    }
+    // Remove expired toasts.
+    const now = Date.now();
+    toasts = toasts.filter(t => t.expiry > now);
+
+    if (polling) {
+      pollTimer = setTimeout(poll, 2000);
+    }
   }
 
   function stopPolling() {
+    polling = false;
     if (pollTimer) {
-      clearInterval(pollTimer);
+      clearTimeout(pollTimer);
       pollTimer = null;
     }
   }

--- a/frontend/src/lib/playback.ts
+++ b/frontend/src/lib/playback.ts
@@ -20,8 +20,10 @@ const stoppedStatus: PlaybackStatus = {
 };
 
 let current: PlaybackStatus = { ...stoppedStatus };
-let statusTimer: ReturnType<typeof setInterval> | null = null;
+let statusTimer: ReturnType<typeof setTimeout> | null = null;
 let artworkTimer: ReturnType<typeof setInterval> | null = null;
+let statusInFlight = false;
+let pollingActive = false;
 let lastArtworkKey = '';
 const listeners: Array<(status: PlaybackStatus) => void> = [];
 
@@ -41,6 +43,8 @@ export function onPlaybackStatusChange(fn: (status: PlaybackStatus) => void): ()
 }
 
 export async function refreshPlaybackStatus() {
+  if (statusInFlight) return;
+  statusInFlight = true;
   try {
     const next = await PlayerService.GetPlaybackStatus();
     current = {
@@ -63,6 +67,8 @@ export async function refreshPlaybackStatus() {
     notify();
   } catch {
     // Keep the last known state when the backend is briefly unavailable.
+  } finally {
+    statusInFlight = false;
   }
 }
 
@@ -96,15 +102,26 @@ function notify() {
 }
 
 function startPolling() {
-  if (statusTimer) return;
-  void refreshPlaybackStatus();
-  statusTimer = setInterval(refreshPlaybackStatus, 250);
+  if (pollingActive) return;
+  pollingActive = true;
+  pollPlaybackStatus();
   artworkTimer = setInterval(refreshArtwork, 1000);
 }
 
+async function pollPlaybackStatus() {
+  await refreshPlaybackStatus();
+  if (!pollingActive || listeners.length === 0) {
+    statusTimer = null;
+    return;
+  }
+  const delay = current.radioMode ? 2000 : 250;
+  statusTimer = setTimeout(pollPlaybackStatus, delay);
+}
+
 function stopPolling() {
+  pollingActive = false;
   if (statusTimer) {
-    clearInterval(statusTimer);
+    clearTimeout(statusTimer);
     statusTimer = null;
   }
   if (artworkTimer) {

--- a/frontend/tests/mocks/wails-runtime.ts
+++ b/frontend/tests/mocks/wails-runtime.ts
@@ -633,9 +633,11 @@ class MockCancellablePromise<T> extends Promise<T> {
 }
 
 const windowCalls: Array<{ method: string; args: any[] }> = [];
+const callCounts = new Map<number, number>();
 
 export const Call = {
   ByID(id: number, ...args: any[]): MockCancellablePromise<any> {
+    callCounts.set(id, (callCounts.get(id) ?? 0) + 1);
     const handler = fixtures[id];
     if (handler) {
       return MockCancellablePromise.resolve(handler(...args));
@@ -659,6 +661,7 @@ export const Window = {
 
 if (typeof window !== "undefined") {
   (window as any).__wailsWindowCalls = windowCalls;
+  (window as any).__wailsCallCounts = callCounts;
 }
 
 export const Create = {

--- a/frontend/tests/now-playing.spec.ts
+++ b/frontend/tests/now-playing.spec.ts
@@ -37,4 +37,32 @@ test.describe("Now playing view", () => {
     await page.goto("/");
     await expect(page.getByRole("slider", { name: "Volume" })).toBeVisible();
   });
+
+  test("radio playback backs off high-frequency status polling", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Play Jazz FM" }).click();
+    await expect(page.locator("footer")).toContainText("LIVE");
+
+    await page.evaluate(() => {
+      (window as any).__wailsCallCounts.clear();
+    });
+    await page.waitForTimeout(1300);
+
+    const statusCalls = await page.evaluate(() => (window as any).__wailsCallCounts.get(958915679) ?? 0);
+    expect(statusCalls).toBeLessThanOrEqual(2);
+  });
+
+  test("idle toast polling stays low during unattended playback", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Play Jazz FM" }).click();
+    await expect(page.locator("footer")).toContainText("LIVE");
+
+    await page.evaluate(() => {
+      (window as any).__wailsCallCounts.clear();
+    });
+    await page.waitForTimeout(1300);
+
+    const toastCalls = await page.evaluate(() => (window as any).__wailsCallCounts.get(327853480) ?? 0);
+    expect(toastCalls).toBeLessThanOrEqual(1);
+  });
 });


### PR DESCRIPTION
## Summary
- Back off now-playing status polling during radio playback and prevent overlapping status calls.
- Reduce always-on toast polling and make it non-overlapping.
- Add Playwright regressions that count Wails IPC calls during unattended radio playback.

## Root Cause
The captured installed-app crash was a native SIGSEGV inside WebKitGTK while Forte was idle on radio playback. The frontend was continuously driving Wails IPC while unattended: status polling every 250ms and toast polling every 500ms. This reduces that idle IPC pressure on the WebKit/Wails path.

## Validation
- npm run check
- npm run build
- npm run test:e2e
- go test ./...
- nix build .#forte
- push hooks: golangci-lint, gotest hook, nix build .#forte .#frontend, svelte-check