### PR TITLE
Preserve per-run crash diagnostics

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"embed"
+	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"strings"
+	"time"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/wailsapp/wails/v3/pkg/events"
@@ -65,6 +69,64 @@ var trayIconMacPlaying []byte
 
 const appID = "io.github.willfish.forte"
 
+type crashLogHeader struct {
+	StartedAt time.Time
+	PID       int
+	Exe       string
+	Args      []string
+}
+
+func openCrashLog(logDir string, now time.Time, pid int) (*os.File, string, error) {
+	crashDir := filepath.Join(logDir, "crashes")
+	if err := os.MkdirAll(crashDir, 0o755); err != nil {
+		return nil, "", err
+	}
+
+	path := filepath.Join(crashDir, fmt.Sprintf("forte-%s-%d.log", now.Format("20060102-150405"), pid))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, "", err
+	}
+
+	pointer := fmt.Sprintf("Latest Forte crash capture: %s\n", path)
+	if err := os.WriteFile(filepath.Join(logDir, "crash.log"), []byte(pointer), 0o644); err != nil {
+		_ = f.Close()
+		return nil, "", err
+	}
+
+	return f, path, nil
+}
+
+func writeCrashLogHeader(w io.Writer, h crashLogHeader) error {
+	buildMain := "(unknown)"
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Path != "" {
+		buildMain = info.Main.Path
+	}
+
+	_, err := fmt.Fprintf(w, `=== Forte crash capture startup ===
+started_at=%s
+pid=%d
+exe=%s
+args=%s
+go_version=%s
+go_os=%s
+go_arch=%s
+build_main=%s
+=== end startup ===
+
+`,
+		h.StartedAt.UTC().Format(time.RFC3339),
+		h.PID,
+		h.Exe,
+		strings.Join(h.Args, " "),
+		runtime.Version(),
+		runtime.GOOS,
+		runtime.GOARCH,
+		buildMain,
+	)
+	return err
+}
+
 // setupCrashLog directs Go runtime crash output (SIGSEGV, etc.) to a file
 // so crashes from the installed program can be diagnosed. It also writes
 // /proc/self/maps at startup so library addresses can be resolved from the
@@ -78,7 +140,7 @@ func setupCrashLog() *os.File {
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		return nil
 	}
-	f, err := os.Create(filepath.Join(logDir, "crash.log"))
+	f, _, err := openCrashLog(logDir, time.Now(), os.Getpid())
 	if err != nil {
 		return nil
 	}
@@ -86,6 +148,14 @@ func setupCrashLog() *os.File {
 		_ = f.Close()
 		return nil
 	}
+
+	exe, _ := os.Executable()
+	_ = writeCrashLogHeader(f, crashLogHeader{
+		StartedAt: time.Now(),
+		PID:       os.Getpid(),
+		Exe:       exe,
+		Args:      os.Args,
+	})
 
 	// Write process memory maps so we can resolve library addresses on crash.
 	// Linux only (/proc not present or different on darwin).

--- a/main_crash_test.go
+++ b/main_crash_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOpenCrashLogCreatesPerRunLogAndLatestPointer(t *testing.T) {
+	logDir := t.TempDir()
+	oldPath := filepath.Join(logDir, "crashes", "forte-20260613-140000-111.log")
+	if err := os.MkdirAll(filepath.Dir(oldPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldPath, []byte("old fatal trace\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 6, 13, 15, 51, 12, 0, time.UTC)
+	f, path, err := openCrashLog(logDir, now, 2257898)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString("new run\n")
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	wantSuffix := filepath.Join("crashes", "forte-20260613-155112-2257898.log")
+	if !strings.HasSuffix(path, wantSuffix) {
+		t.Fatalf("crash log path = %q, want suffix %q", path, wantSuffix)
+	}
+
+	latest, err := os.ReadFile(filepath.Join(logDir, "crash.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(latest), path) {
+		t.Fatalf("latest pointer %q does not mention %q", string(latest), path)
+	}
+
+	old, err := os.ReadFile(oldPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(old) != "old fatal trace\n" {
+		t.Fatalf("old crash log was changed to %q", string(old))
+	}
+}
+
+func TestWriteCrashLogHeaderIncludesRuntimeContext(t *testing.T) {
+	now := time.Date(2026, 6, 13, 15, 51, 12, 0, time.UTC)
+	var out bytes.Buffer
+
+	if err := writeCrashLogHeader(&out, crashLogHeader{
+		StartedAt: now,
+		PID:       2257898,
+		Exe:       "/nix/store/example/bin/forte",
+		Args:      []string{"forte", "--debug"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"=== Forte crash capture startup ===",
+		"started_at=2026-06-13T15:51:12Z",
+		"pid=2257898",
+		"exe=/nix/store/example/bin/forte",
+		"args=forte --debug",
+		"go_version=",
+		"go_os=",
+		"go_arch=",
+		"build_main=github.com/willfish/forte",
+		"=== end startup ===",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("header missing %q:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- write crash captures to per-run files under `~/.config/forte/crashes/`
- keep `~/.config/forte/crash.log` as a latest-capture pointer instead of truncating crash evidence
- include startup metadata before memory maps so the next native crash is easier to map to the exact process and binary

## Why

The last crash was relaunched before inspection, and the old `os.Create` crash logger overwrote the fatal trace with the new process' startup maps. Per-run crash captures preserve that evidence across restarts.

## Validation

- `go test ./...`
- pre-push hooks: `golangci-lint`, `gotest`, `nix build .#forte .#frontend`, trailing whitespace checks
