### PR TITLE
refactor: extract scrobbling coordinator

### DIFF
--- a/internal/scrobbling/scrobbler.go
+++ b/internal/scrobbling/scrobbler.go
@@ -1,0 +1,371 @@
+// Package scrobbling coordinates playback events with configured scrobble services.
+package scrobbling
+
+import (
+	"encoding/json"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/willfish/forte/internal/library"
+	"github.com/willfish/forte/internal/scrobbling/lastfm"
+	"github.com/willfish/forte/internal/scrobbling/listenbrainz"
+)
+
+// Track is the playback metadata needed for scrobbling.
+type Track struct {
+	ID         int64
+	Artist     string
+	Title      string
+	Album      string
+	DurationMs int
+}
+
+// QueuedTrack is a failed scrobble ready to retry.
+type QueuedTrack struct {
+	Track
+	Timestamp int64
+}
+
+// Store is the persistence interface used by Coordinator.
+type Store interface {
+	LoadScrobbleConfig() (library.ScrobbleConfig, error)
+	LoadListenBrainzConfig() (library.ListenBrainzConfig, error)
+	RecordPlay(trackID int64, durationPlayedMs int) error
+	EnqueueScrobble(service, trackJSON string, timestamp int64) error
+	PruneScrobbleQueue() error
+	PendingScrobbles(service string, limit int) ([]library.ScrobbleQueueEntry, error)
+	RemoveScrobble(id int64) error
+	MarkScrobbleAttempt(id int64) error
+}
+
+// LastFM submits Last.fm now-playing and scrobble requests.
+type LastFM interface {
+	NowPlaying(library.ScrobbleConfig, Track) error
+	Scrobble(library.ScrobbleConfig, Track, int64) error
+	ScrobbleBatch(library.ScrobbleConfig, []QueuedTrack) error
+}
+
+// ListenBrainz submits ListenBrainz now-playing and scrobble requests.
+type ListenBrainz interface {
+	NowPlaying(library.ListenBrainzConfig, Track) error
+	Scrobble(library.ListenBrainzConfig, Track, int64) error
+	ScrobbleBatch(library.ListenBrainzConfig, []QueuedTrack) error
+}
+
+// Coordinator tracks playback progress and submits scrobbles.
+type Coordinator struct {
+	store        Store
+	lastfm       LastFM
+	listenbrainz ListenBrainz
+	now          func() time.Time
+	async        func(func())
+
+	mu        sync.Mutex
+	current   Track
+	elapsed   time.Duration
+	scrobbled bool
+}
+
+// Option configures a Coordinator.
+type Option func(*Coordinator)
+
+// WithLastFM replaces the Last.fm adapter.
+func WithLastFM(client LastFM) Option {
+	return func(c *Coordinator) {
+		c.lastfm = client
+	}
+}
+
+// WithListenBrainz replaces the ListenBrainz adapter.
+func WithListenBrainz(client ListenBrainz) Option {
+	return func(c *Coordinator) {
+		c.listenbrainz = client
+	}
+}
+
+// WithNow replaces the clock used for scrobble timestamps.
+func WithNow(now func() time.Time) Option {
+	return func(c *Coordinator) {
+		c.now = now
+	}
+}
+
+// WithAsync replaces asynchronous execution. Tests can run functions inline.
+func WithAsync(async func(func())) Option {
+	return func(c *Coordinator) {
+		c.async = async
+	}
+}
+
+// NewCoordinator creates a scrobbling coordinator backed by store.
+func NewCoordinator(store Store, opts ...Option) *Coordinator {
+	c := &Coordinator{
+		store:        store,
+		lastfm:       lastFMAdapter{},
+		listenbrainz: listenBrainzAdapter{},
+		now:          time.Now,
+		async: func(fn func()) {
+			go fn()
+		},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// TrackStarted resets progress and sends now-playing notifications.
+func (c *Coordinator) TrackStarted(track Track) {
+	c.mu.Lock()
+	c.current = track
+	c.elapsed = 0
+	c.scrobbled = false
+	c.mu.Unlock()
+
+	if c.store == nil {
+		return
+	}
+
+	if cfg, err := c.store.LoadScrobbleConfig(); err == nil && cfg.Enabled && cfg.SessionKey != "" {
+		c.async(func() {
+			if err := c.lastfm.NowPlaying(cfg, track); err != nil {
+				log.Printf("lastfm now-playing: %v", err)
+			}
+		})
+	}
+	if cfg, err := c.store.LoadListenBrainzConfig(); err == nil && cfg.Enabled && cfg.UserToken != "" {
+		c.async(func() {
+			if err := c.listenbrainz.NowPlaying(cfg, track); err != nil {
+				log.Printf("listenbrainz now-playing: %v", err)
+			}
+		})
+	}
+}
+
+// Tick advances scrobble progress by one second when playback is active.
+func (c *Coordinator) Tick(playbackState string) {
+	c.mu.Lock()
+	if playbackState != "playing" || c.scrobbled || c.current.ID == 0 {
+		c.mu.Unlock()
+		return
+	}
+	c.elapsed += time.Second
+	track := c.current
+	threshold := time.Duration(lastfm.ScrobbleThreshold(track.DurationMs)) * time.Millisecond
+	if threshold <= 0 || c.elapsed < threshold {
+		c.mu.Unlock()
+		return
+	}
+
+	c.scrobbled = true
+	elapsedMs := int(c.elapsed.Milliseconds())
+	c.mu.Unlock()
+	if c.store == nil {
+		return
+	}
+	_ = c.store.RecordPlay(track.ID, elapsedMs)
+
+	ts := c.now().Unix()
+	if cfg, err := c.store.LoadScrobbleConfig(); err == nil && cfg.Enabled && cfg.SessionKey != "" {
+		c.async(func() {
+			if err := c.lastfm.Scrobble(cfg, track, ts); err != nil {
+				log.Printf("lastfm scrobble: %v (queued for retry)", err)
+				c.enqueueFailed("lastfm", track, ts)
+			}
+		})
+	}
+	if cfg, err := c.store.LoadListenBrainzConfig(); err == nil && cfg.Enabled && cfg.UserToken != "" {
+		c.async(func() {
+			if err := c.listenbrainz.Scrobble(cfg, track, ts); err != nil {
+				log.Printf("listenbrainz scrobble: %v (queued for retry)", err)
+				c.enqueueFailed("listenbrainz", track, ts)
+			}
+		})
+	}
+}
+
+// FlushQueue retries pending scrobbles for all configured services.
+func (c *Coordinator) FlushQueue() {
+	if c.store == nil {
+		return
+	}
+	if err := c.store.PruneScrobbleQueue(); err != nil {
+		log.Printf("scrobble queue: prune: %v", err)
+	}
+	c.flushLastFMQueue()
+	c.flushListenBrainzQueue()
+}
+
+func (c *Coordinator) flushLastFMQueue() {
+	cfg, err := c.store.LoadScrobbleConfig()
+	if err != nil || !cfg.Enabled || cfg.SessionKey == "" {
+		return
+	}
+	entries, err := c.store.PendingScrobbles("lastfm", 50)
+	if err != nil || len(entries) == 0 {
+		return
+	}
+
+	tracks, ok := c.queuedTracks(entries, "lastfm")
+	if !ok {
+		return
+	}
+	if err := c.lastfm.ScrobbleBatch(cfg, tracks); err != nil {
+		log.Printf("scrobble queue: lastfm batch: %v", err)
+		c.markAttempts(entries)
+		return
+	}
+	c.removeEntries(entries)
+	log.Printf("scrobble queue: flushed %d lastfm scrobbles", len(entries))
+}
+
+func (c *Coordinator) flushListenBrainzQueue() {
+	cfg, err := c.store.LoadListenBrainzConfig()
+	if err != nil || !cfg.Enabled || cfg.UserToken == "" {
+		return
+	}
+	entries, err := c.store.PendingScrobbles("listenbrainz", 100)
+	if err != nil || len(entries) == 0 {
+		return
+	}
+
+	tracks, ok := c.queuedTracks(entries, "listenbrainz")
+	if !ok {
+		return
+	}
+	if err := c.listenbrainz.ScrobbleBatch(cfg, tracks); err != nil {
+		log.Printf("scrobble queue: listenbrainz batch: %v", err)
+		c.markAttempts(entries)
+		return
+	}
+	c.removeEntries(entries)
+	log.Printf("scrobble queue: flushed %d listenbrainz scrobbles", len(entries))
+}
+
+func (c *Coordinator) queuedTracks(entries []library.ScrobbleQueueEntry, service string) ([]QueuedTrack, bool) {
+	tracks := make([]QueuedTrack, len(entries))
+	for i, entry := range entries {
+		var track scrobbleTrackJSON
+		if err := json.Unmarshal([]byte(entry.TrackJSON), &track); err != nil {
+			log.Printf("scrobble queue: unmarshal %s entry %d: %v", service, entry.ID, err)
+			_ = c.store.RemoveScrobble(entry.ID)
+			return nil, false
+		}
+		tracks[i] = QueuedTrack{
+			Track: Track{
+				Artist:     track.Artist,
+				Title:      track.Track,
+				Album:      track.Album,
+				DurationMs: track.DurationMs,
+			},
+			Timestamp: entry.Timestamp,
+		}
+	}
+	return tracks, true
+}
+
+func (c *Coordinator) markAttempts(entries []library.ScrobbleQueueEntry) {
+	for _, entry := range entries {
+		_ = c.store.MarkScrobbleAttempt(entry.ID)
+	}
+}
+
+func (c *Coordinator) removeEntries(entries []library.ScrobbleQueueEntry) {
+	for _, entry := range entries {
+		_ = c.store.RemoveScrobble(entry.ID)
+	}
+}
+
+func (c *Coordinator) enqueueFailed(service string, track Track, ts int64) {
+	data, err := json.Marshal(scrobbleTrackJSON{
+		Artist:     track.Artist,
+		Track:      track.Title,
+		Album:      track.Album,
+		DurationMs: track.DurationMs,
+	})
+	if err != nil {
+		log.Printf("scrobble queue: marshal: %v", err)
+		return
+	}
+	if err := c.store.EnqueueScrobble(service, string(data), ts); err != nil {
+		log.Printf("scrobble queue: enqueue: %v", err)
+	}
+}
+
+type scrobbleTrackJSON struct {
+	Artist     string `json:"artist"`
+	Track      string `json:"track"`
+	Album      string `json:"album"`
+	DurationMs int    `json:"duration_ms"`
+}
+
+type lastFMAdapter struct{}
+
+func (lastFMAdapter) NowPlaying(cfg library.ScrobbleConfig, track Track) error {
+	return lastfm.NowPlaying(cfg.APIKey, cfg.APISecret, cfg.SessionKey, lastfm.TrackInfo{
+		Artist:   track.Artist,
+		Track:    track.Title,
+		Album:    track.Album,
+		Duration: track.DurationMs / 1000,
+	})
+}
+
+func (lastFMAdapter) Scrobble(cfg library.ScrobbleConfig, track Track, ts int64) error {
+	return lastfm.Scrobble(cfg.APIKey, cfg.APISecret, cfg.SessionKey, lastfm.TrackInfo{
+		Artist:   track.Artist,
+		Track:    track.Title,
+		Album:    track.Album,
+		Duration: track.DurationMs / 1000,
+	}, ts)
+}
+
+func (lastFMAdapter) ScrobbleBatch(cfg library.ScrobbleConfig, tracks []QueuedTrack) error {
+	infos := make([]lastfm.TrackInfo, len(tracks))
+	timestamps := make([]int64, len(tracks))
+	for i, track := range tracks {
+		infos[i] = lastfm.TrackInfo{
+			Artist:   track.Artist,
+			Track:    track.Title,
+			Album:    track.Album,
+			Duration: track.DurationMs / 1000,
+		}
+		timestamps[i] = track.Timestamp
+	}
+	return lastfm.ScrobbleBatch(cfg.APIKey, cfg.APISecret, cfg.SessionKey, infos, timestamps)
+}
+
+type listenBrainzAdapter struct{}
+
+func (listenBrainzAdapter) NowPlaying(cfg library.ListenBrainzConfig, track Track) error {
+	return listenbrainz.NowPlaying(cfg.UserToken, listenbrainz.TrackInfo{
+		Artist:     track.Artist,
+		Track:      track.Title,
+		Album:      track.Album,
+		DurationMs: track.DurationMs,
+	})
+}
+
+func (listenBrainzAdapter) Scrobble(cfg library.ListenBrainzConfig, track Track, ts int64) error {
+	return listenbrainz.Scrobble(cfg.UserToken, listenbrainz.TrackInfo{
+		Artist:     track.Artist,
+		Track:      track.Title,
+		Album:      track.Album,
+		DurationMs: track.DurationMs,
+	}, ts)
+}
+
+func (listenBrainzAdapter) ScrobbleBatch(cfg library.ListenBrainzConfig, tracks []QueuedTrack) error {
+	infos := make([]listenbrainz.TrackInfo, len(tracks))
+	timestamps := make([]int64, len(tracks))
+	for i, track := range tracks {
+		infos[i] = listenbrainz.TrackInfo{
+			Artist:     track.Artist,
+			Track:      track.Title,
+			Album:      track.Album,
+			DurationMs: track.DurationMs,
+		}
+		timestamps[i] = track.Timestamp
+	}
+	return listenbrainz.ScrobbleBatch(cfg.UserToken, infos, timestamps)
+}

--- a/internal/scrobbling/scrobbler_test.go
+++ b/internal/scrobbling/scrobbler_test.go
@@ -1,0 +1,195 @@
+package scrobbling
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/willfish/forte/internal/library"
+)
+
+type fakeStore struct {
+	lastfmCfg       library.ScrobbleConfig
+	listenbrainzCfg library.ListenBrainzConfig
+	recordedTrackID int64
+	recordedMs      int
+	enqueuedService string
+	enqueuedJSON    string
+	enqueuedTS      int64
+	pending         map[string][]library.ScrobbleQueueEntry
+	removed         []int64
+	marked          []int64
+	pruned          bool
+}
+
+func (s *fakeStore) LoadScrobbleConfig() (library.ScrobbleConfig, error) {
+	return s.lastfmCfg, nil
+}
+
+func (s *fakeStore) LoadListenBrainzConfig() (library.ListenBrainzConfig, error) {
+	return s.listenbrainzCfg, nil
+}
+
+func (s *fakeStore) RecordPlay(trackID int64, durationPlayedMs int) error {
+	s.recordedTrackID = trackID
+	s.recordedMs = durationPlayedMs
+	return nil
+}
+
+func (s *fakeStore) EnqueueScrobble(service, trackJSON string, timestamp int64) error {
+	s.enqueuedService = service
+	s.enqueuedJSON = trackJSON
+	s.enqueuedTS = timestamp
+	return nil
+}
+
+func (s *fakeStore) PruneScrobbleQueue() error {
+	s.pruned = true
+	return nil
+}
+
+func (s *fakeStore) PendingScrobbles(service string, limit int) ([]library.ScrobbleQueueEntry, error) {
+	entries := s.pending[service]
+	if len(entries) > limit {
+		entries = entries[:limit]
+	}
+	return entries, nil
+}
+
+func (s *fakeStore) RemoveScrobble(id int64) error {
+	s.removed = append(s.removed, id)
+	return nil
+}
+
+func (s *fakeStore) MarkScrobbleAttempt(id int64) error {
+	s.marked = append(s.marked, id)
+	return nil
+}
+
+type fakeLastFM struct {
+	scrobbleErr      error
+	scrobbleBatchErr error
+	scrobbles        int
+	batches          [][]QueuedTrack
+}
+
+func (f *fakeLastFM) NowPlaying(library.ScrobbleConfig, Track) error { return nil }
+
+func (f *fakeLastFM) Scrobble(library.ScrobbleConfig, Track, int64) error {
+	f.scrobbles++
+	return f.scrobbleErr
+}
+
+func (f *fakeLastFM) ScrobbleBatch(_ library.ScrobbleConfig, tracks []QueuedTrack) error {
+	f.batches = append(f.batches, tracks)
+	return f.scrobbleBatchErr
+}
+
+type fakeListenBrainz struct{}
+
+func (fakeListenBrainz) NowPlaying(library.ListenBrainzConfig, Track) error { return nil }
+
+func (fakeListenBrainz) Scrobble(library.ListenBrainzConfig, Track, int64) error { return nil }
+
+func (fakeListenBrainz) ScrobbleBatch(library.ListenBrainzConfig, []QueuedTrack) error {
+	return nil
+}
+
+func TestCoordinatorQueuesFailedLastFMScrobbleAfterThresholdOnce(t *testing.T) {
+	store := &fakeStore{
+		lastfmCfg: library.ScrobbleConfig{
+			APIKey:     "key",
+			APISecret:  "secret",
+			SessionKey: "session",
+			Enabled:    true,
+		},
+	}
+	lastfm := &fakeLastFM{scrobbleErr: errors.New("offline")}
+	now := time.Unix(1_700_000_000, 0)
+	c := NewCoordinator(store, WithLastFM(lastfm), WithListenBrainz(fakeListenBrainz{}), WithNow(func() time.Time {
+		return now
+	}), WithAsync(func(fn func()) { fn() }))
+
+	c.TrackStarted(Track{
+		ID:         42,
+		Artist:     "Nina Simone",
+		Title:      "Feeling Good",
+		Album:      "I Put a Spell on You",
+		DurationMs: 4_000,
+	})
+
+	c.Tick("playing")
+	c.Tick("playing")
+	c.Tick("playing")
+
+	if store.recordedTrackID != 42 {
+		t.Fatalf("recorded track ID = %d, want 42", store.recordedTrackID)
+	}
+	if store.recordedMs != 2_000 {
+		t.Fatalf("recorded duration = %d, want 2000", store.recordedMs)
+	}
+	if lastfm.scrobbles != 1 {
+		t.Fatalf("Last.fm scrobbles = %d, want 1", lastfm.scrobbles)
+	}
+	if store.enqueuedService != "lastfm" {
+		t.Fatalf("enqueued service = %q, want lastfm", store.enqueuedService)
+	}
+	if store.enqueuedTS != now.Unix() {
+		t.Fatalf("enqueued timestamp = %d, want %d", store.enqueuedTS, now.Unix())
+	}
+
+	var queued struct {
+		Artist     string `json:"artist"`
+		Track      string `json:"track"`
+		Album      string `json:"album"`
+		DurationMs int    `json:"duration_ms"`
+	}
+	if err := json.Unmarshal([]byte(store.enqueuedJSON), &queued); err != nil {
+		t.Fatalf("queued JSON: %v", err)
+	}
+	if queued.Artist != "Nina Simone" || queued.Track != "Feeling Good" || queued.Album != "I Put a Spell on You" || queued.DurationMs != 4_000 {
+		t.Fatalf("queued track = %#v", queued)
+	}
+}
+
+func TestCoordinatorFlushQueueRemovesSuccessfulLastFMEntries(t *testing.T) {
+	store := &fakeStore{
+		lastfmCfg: library.ScrobbleConfig{
+			APIKey:     "key",
+			APISecret:  "secret",
+			SessionKey: "session",
+			Enabled:    true,
+		},
+		pending: map[string][]library.ScrobbleQueueEntry{
+			"lastfm": {
+				{
+					ID:        10,
+					TrackJSON: `{"artist":"Bessie Smith","track":"Backwater Blues","album":"The Collection","duration_ms":180000}`,
+					Timestamp: 1_700_000_010,
+				},
+			},
+		},
+	}
+	lastfm := &fakeLastFM{}
+	c := NewCoordinator(store, WithLastFM(lastfm), WithListenBrainz(fakeListenBrainz{}), WithAsync(func(fn func()) { fn() }))
+
+	c.FlushQueue()
+
+	if !store.pruned {
+		t.Fatal("expected scrobble queue to be pruned")
+	}
+	if len(lastfm.batches) != 1 {
+		t.Fatalf("Last.fm batches = %d, want 1", len(lastfm.batches))
+	}
+	got := lastfm.batches[0][0]
+	if got.ID != 0 || got.Artist != "Bessie Smith" || got.Title != "Backwater Blues" || got.Album != "The Collection" || got.DurationMs != 180_000 || got.Timestamp != 1_700_000_010 {
+		t.Fatalf("batched track = %#v", got)
+	}
+	if len(store.removed) != 1 || store.removed[0] != 10 {
+		t.Fatalf("removed entries = %#v, want [10]", store.removed)
+	}
+	if len(store.marked) != 0 {
+		t.Fatalf("marked entries = %#v, want none", store.marked)
+	}
+}

--- a/playerservice.go
+++ b/playerservice.go
@@ -21,8 +21,7 @@ import (
 	"github.com/willfish/forte/internal/library"
 	"github.com/willfish/forte/internal/metadata"
 	"github.com/willfish/forte/internal/player"
-	"github.com/willfish/forte/internal/scrobbling/lastfm"
-	"github.com/willfish/forte/internal/scrobbling/listenbrainz"
+	"github.com/willfish/forte/internal/scrobbling"
 	"github.com/willfish/forte/internal/system"
 )
 
@@ -32,6 +31,7 @@ type PlayerService struct {
 	queue          *player.Queue
 	db             *library.DB
 	resolver       *library.PathResolver
+	scrobbler      *scrobbling.Coordinator
 	mpris          *system.MPRIS
 	notifier       *system.Notifier
 	toasts         *player.Notifications
@@ -42,12 +42,6 @@ type PlayerService struct {
 	tickerDone     chan struct{} // closed when the ticker goroutine exits
 	shutdownOnce   sync.Once
 	shutdownErr    error
-
-	// Scrobble tracking state (protected by scrobbleMu).
-	scrobbleMu      sync.Mutex
-	scrobbleTrackID int64
-	scrobbleElapsed time.Duration
-	scrobbled       bool
 
 	// Radio mode state (protected by radioMu).
 	radioMu               sync.RWMutex
@@ -89,6 +83,7 @@ func (p *PlayerService) ServiceStartup(_ context.Context, _ application.ServiceO
 	}
 	p.db = db
 	p.resolver = library.NewPathResolver(db)
+	p.scrobbler = scrobbling.NewCoordinator(db)
 
 	// When mpv auto-advances to the next track (gapless), advance the queue.
 	e.SetOnTrackChange(func() {
@@ -857,127 +852,29 @@ func (p *PlayerService) skipToNextPlayable() {
 }
 
 // startScrobbleTracking resets scrobble state for the current track and
-// sends a "now playing" notification to Last.fm if configured.
+// sends now-playing notifications if configured.
 func (p *PlayerService) startScrobbleTracking() {
+	if p.scrobbler == nil {
+		return
+	}
 	cur := p.queue.Current()
 	if cur == nil {
 		return
 	}
-	p.scrobbleMu.Lock()
-	p.scrobbleTrackID = cur.TrackID
-	p.scrobbleElapsed = 0
-	p.scrobbled = false
-	p.scrobbleMu.Unlock()
-
-	if p.db == nil {
-		return
-	}
-
-	// Last.fm now-playing.
-	cfg, err := p.db.LoadScrobbleConfig()
-	if err == nil && cfg.Enabled && cfg.SessionKey != "" {
-		track := lastfm.TrackInfo{
-			Artist:   cur.Artist,
-			Track:    cur.Title,
-			Album:    cur.Album,
-			Duration: cur.DurationMs / 1000,
-		}
-		go func() {
-			if err := lastfm.NowPlaying(cfg.APIKey, cfg.APISecret, cfg.SessionKey, track); err != nil {
-				log.Printf("lastfm now-playing: %v", err)
-			}
-		}()
-	}
-
-	// ListenBrainz now-playing.
-	lbCfg, err := p.db.LoadListenBrainzConfig()
-	if err == nil && lbCfg.Enabled && lbCfg.UserToken != "" {
-		lbTrack := listenbrainz.TrackInfo{
-			Artist:     cur.Artist,
-			Track:      cur.Title,
-			Album:      cur.Album,
-			DurationMs: cur.DurationMs,
-		}
-		go func() {
-			if err := listenbrainz.NowPlaying(lbCfg.UserToken, lbTrack); err != nil {
-				log.Printf("listenbrainz now-playing: %v", err)
-			}
-		}()
-	}
+	p.scrobbler.TrackStarted(scrobbling.Track{
+		ID:         cur.TrackID,
+		Artist:     cur.Artist,
+		Title:      cur.Title,
+		Album:      cur.Album,
+		DurationMs: cur.DurationMs,
+	})
 }
 
 // checkScrobble accumulates play time and submits a scrobble when the
 // threshold is reached (50% of duration or 4 minutes, whichever is first).
 func (p *PlayerService) checkScrobble() {
-	if p.engine == nil {
-		return
-	}
-	if p.engine.State().String() != "playing" {
-		return
-	}
-
-	cur := p.queue.Current()
-
-	p.scrobbleMu.Lock()
-	if p.scrobbled {
-		p.scrobbleMu.Unlock()
-		return
-	}
-	p.scrobbleElapsed += time.Second
-	if cur == nil || cur.TrackID != p.scrobbleTrackID {
-		p.scrobbleMu.Unlock()
-		return
-	}
-	threshold := time.Duration(lastfm.ScrobbleThreshold(cur.DurationMs)) * time.Millisecond
-	if threshold <= 0 || p.scrobbleElapsed < threshold {
-		p.scrobbleMu.Unlock()
-		return
-	}
-	p.scrobbled = true
-	elapsedMs := int(p.scrobbleElapsed.Milliseconds())
-	p.scrobbleMu.Unlock()
-
-	if p.db == nil {
-		return
-	}
-
-	// Record play in local listening history.
-	_ = p.db.RecordPlay(cur.TrackID, elapsedMs)
-
-	ts := time.Now().Unix()
-
-	// Last.fm scrobble.
-	cfg, err := p.db.LoadScrobbleConfig()
-	if err == nil && cfg.Enabled && cfg.SessionKey != "" {
-		track := lastfm.TrackInfo{
-			Artist:   cur.Artist,
-			Track:    cur.Title,
-			Album:    cur.Album,
-			Duration: cur.DurationMs / 1000,
-		}
-		go func() {
-			if err := lastfm.Scrobble(cfg.APIKey, cfg.APISecret, cfg.SessionKey, track, ts); err != nil {
-				log.Printf("lastfm scrobble: %v (queued for retry)", err)
-				p.enqueueFailedScrobble("lastfm", track.Artist, track.Track, track.Album, cur.DurationMs, ts)
-			}
-		}()
-	}
-
-	// ListenBrainz scrobble.
-	lbCfg, err := p.db.LoadListenBrainzConfig()
-	if err == nil && lbCfg.Enabled && lbCfg.UserToken != "" {
-		lbTrack := listenbrainz.TrackInfo{
-			Artist:     cur.Artist,
-			Track:      cur.Title,
-			Album:      cur.Album,
-			DurationMs: cur.DurationMs,
-		}
-		go func() {
-			if err := listenbrainz.Scrobble(lbCfg.UserToken, lbTrack, ts); err != nil {
-				log.Printf("listenbrainz scrobble: %v (queued for retry)", err)
-				p.enqueueFailedScrobble("listenbrainz", lbTrack.Artist, lbTrack.Track, lbTrack.Album, cur.DurationMs, ts)
-			}
-		}()
+	if p.scrobbler != nil {
+		p.scrobbler.Tick(p.State())
 	}
 }
 
@@ -999,134 +896,11 @@ func (p *PlayerService) resolvePaths(paths []string) []string {
 	return resolved
 }
 
-// scrobbleTrackJSON is the JSON format stored in the queue for retry.
-type scrobbleTrackJSON struct {
-	Artist     string `json:"artist"`
-	Track      string `json:"track"`
-	Album      string `json:"album"`
-	DurationMs int    `json:"duration_ms"`
-}
-
-// enqueueFailedScrobble saves a failed scrobble to the retry queue.
-func (p *PlayerService) enqueueFailedScrobble(service, artist, track, album string, durationMs int, ts int64) {
-	if p.db == nil {
-		return
-	}
-	data, err := json.Marshal(scrobbleTrackJSON{
-		Artist:     artist,
-		Track:      track,
-		Album:      album,
-		DurationMs: durationMs,
-	})
-	if err != nil {
-		log.Printf("scrobble queue: marshal: %v", err)
-		return
-	}
-	if err := p.db.EnqueueScrobble(service, string(data), ts); err != nil {
-		log.Printf("scrobble queue: enqueue: %v", err)
-	}
-}
-
 // flushScrobbleQueue retries pending scrobbles for all services.
 func (p *PlayerService) flushScrobbleQueue() {
-	if p.db == nil {
-		return
+	if p.scrobbler != nil {
+		p.scrobbler.FlushQueue()
 	}
-
-	if err := p.db.PruneScrobbleQueue(); err != nil {
-		log.Printf("scrobble queue: prune: %v", err)
-	}
-
-	p.flushLastFmQueue()
-	p.flushListenBrainzQueue()
-}
-
-// flushLastFmQueue retries pending Last.fm scrobbles in batches of up to 50.
-func (p *PlayerService) flushLastFmQueue() {
-	cfg, err := p.db.LoadScrobbleConfig()
-	if err != nil || !cfg.Enabled || cfg.SessionKey == "" {
-		return
-	}
-
-	entries, err := p.db.PendingScrobbles("lastfm", 50)
-	if err != nil || len(entries) == 0 {
-		return
-	}
-
-	tracks := make([]lastfm.TrackInfo, len(entries))
-	timestamps := make([]int64, len(entries))
-	for i, e := range entries {
-		var t scrobbleTrackJSON
-		if err := json.Unmarshal([]byte(e.TrackJSON), &t); err != nil {
-			log.Printf("scrobble queue: unmarshal lastfm entry %d: %v", e.ID, err)
-			_ = p.db.RemoveScrobble(e.ID) // corrupted entry
-			return
-		}
-		tracks[i] = lastfm.TrackInfo{
-			Artist:   t.Artist,
-			Track:    t.Track,
-			Album:    t.Album,
-			Duration: t.DurationMs / 1000,
-		}
-		timestamps[i] = e.Timestamp
-	}
-
-	if err := lastfm.ScrobbleBatch(cfg.APIKey, cfg.APISecret, cfg.SessionKey, tracks, timestamps); err != nil {
-		log.Printf("scrobble queue: lastfm batch: %v", err)
-		for _, e := range entries {
-			_ = p.db.MarkScrobbleAttempt(e.ID)
-		}
-		return
-	}
-
-	for _, e := range entries {
-		_ = p.db.RemoveScrobble(e.ID)
-	}
-	log.Printf("scrobble queue: flushed %d lastfm scrobbles", len(entries))
-}
-
-// flushListenBrainzQueue retries pending ListenBrainz scrobbles in batches of up to 100.
-func (p *PlayerService) flushListenBrainzQueue() {
-	lbCfg, err := p.db.LoadListenBrainzConfig()
-	if err != nil || !lbCfg.Enabled || lbCfg.UserToken == "" {
-		return
-	}
-
-	entries, err := p.db.PendingScrobbles("listenbrainz", 100)
-	if err != nil || len(entries) == 0 {
-		return
-	}
-
-	tracks := make([]listenbrainz.TrackInfo, len(entries))
-	timestamps := make([]int64, len(entries))
-	for i, e := range entries {
-		var t scrobbleTrackJSON
-		if err := json.Unmarshal([]byte(e.TrackJSON), &t); err != nil {
-			log.Printf("scrobble queue: unmarshal listenbrainz entry %d: %v", e.ID, err)
-			_ = p.db.RemoveScrobble(e.ID) // corrupted entry
-			return
-		}
-		tracks[i] = listenbrainz.TrackInfo{
-			Artist:     t.Artist,
-			Track:      t.Track,
-			Album:      t.Album,
-			DurationMs: t.DurationMs,
-		}
-		timestamps[i] = e.Timestamp
-	}
-
-	if err := listenbrainz.ScrobbleBatch(lbCfg.UserToken, tracks, timestamps); err != nil {
-		log.Printf("scrobble queue: listenbrainz batch: %v", err)
-		for _, e := range entries {
-			_ = p.db.MarkScrobbleAttempt(e.ID)
-		}
-		return
-	}
-
-	for _, e := range entries {
-		_ = p.db.RemoveScrobble(e.ID)
-	}
-	log.Printf("scrobble queue: flushed %d listenbrainz scrobbles", len(entries))
 }
 
 // PlayRadio starts playback of a radio stream. It saves the current library


### PR DESCRIPTION
## Summary

- Extract scrobble progress tracking, now-playing submission, failed-scrobble queueing, and retry flushing into `internal/scrobbling.Coordinator`.
- Keep `PlayerService` responsible for playback timing and delegate scrobbling work through a small interface.
- Add focused coordinator tests for threshold queueing and retry flush behavior.

Closes #214

## Verification

- `nix develop .#full --command go test -tags nocgo ./...`
- Pre-push hooks inside `nix develop .#full`: `golangci-lint`, `gotest`, `nix build .#forte .#frontend`, `svelte-check`