### PR TITLE
refactor: centralize streaming provider creation

### DIFF
--- a/internal/library/health.go
+++ b/internal/library/health.go
@@ -140,7 +140,7 @@ func (h *HealthMonitor) pingAll() {
 			continue
 		}
 
-		provider, err := newProvider(srv)
+		provider, err := NewServerProvider(srv)
 		if err != nil {
 			slog.Warn("health: create provider", "server", srv.Name, "err", err)
 			continue

--- a/internal/library/provider.go
+++ b/internal/library/provider.go
@@ -1,0 +1,21 @@
+package library
+
+import (
+	"fmt"
+
+	"github.com/willfish/forte/internal/streaming"
+	"github.com/willfish/forte/internal/streaming/jellyfin"
+	"github.com/willfish/forte/internal/streaming/subsonic"
+)
+
+// NewServerProvider creates the streaming provider adapter for a configured server.
+func NewServerProvider(srv Server) (streaming.Provider, error) {
+	switch srv.Type {
+	case "subsonic":
+		return subsonic.New(srv.URL, srv.Username, srv.Password), nil
+	case "jellyfin":
+		return jellyfin.New(srv.URL, srv.Username, srv.Password), nil
+	default:
+		return nil, fmt.Errorf("unknown server type: %s", srv.Type)
+	}
+}

--- a/internal/library/provider_test.go
+++ b/internal/library/provider_test.go
@@ -1,0 +1,52 @@
+package library
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewServerProviderCreatesKnownProviders(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverType string
+		streamURL  string
+	}{
+		{
+			name:       "subsonic",
+			serverType: "subsonic",
+			streamURL:  "https://music.example/rest/stream.view?",
+		},
+		{
+			name:       "jellyfin",
+			serverType: "jellyfin",
+			streamURL:  "https://music.example/Audio/track-1/stream?static=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := NewServerProvider(Server{
+				Type:     tt.serverType,
+				URL:      "https://music.example",
+				Username: "user",
+				Password: "pass",
+			})
+			if err != nil {
+				t.Fatalf("NewServerProvider: %v", err)
+			}
+			if got := provider.StreamURL("track-1"); !strings.HasPrefix(got, tt.streamURL) {
+				t.Fatalf("StreamURL() = %q, want prefix %q", got, tt.streamURL)
+			}
+		})
+	}
+}
+
+func TestNewServerProviderRejectsUnknownProvider(t *testing.T) {
+	_, err := NewServerProvider(Server{Type: "plex"})
+	if err == nil {
+		t.Fatal("NewServerProvider() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "unknown server type: plex") {
+		t.Fatalf("NewServerProvider() error = %q", err)
+	}
+}

--- a/internal/library/resolver.go
+++ b/internal/library/resolver.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 
 	"github.com/willfish/forte/internal/streaming"
-	"github.com/willfish/forte/internal/streaming/jellyfin"
-	"github.com/willfish/forte/internal/streaming/subsonic"
 )
 
 const serverPathPrefix = "server://"
@@ -83,16 +81,10 @@ func (r *PathResolver) getProvider(serverID string) (streaming.Provider, error) 
 		return nil, fmt.Errorf("get server %s: %w", serverID, err)
 	}
 
-	var provider streaming.Provider
-	switch srv.Type {
-	case "subsonic":
-		provider = subsonic.New(srv.URL, srv.Username, srv.Password)
-	case "jellyfin":
-		provider = jellyfin.New(srv.URL, srv.Username, srv.Password)
-	default:
-		return nil, fmt.Errorf("unknown server type: %s", srv.Type)
+	provider, err := NewServerProvider(srv)
+	if err != nil {
+		return nil, err
 	}
-
 	r.providers[serverID] = provider
 	return provider, nil
 }

--- a/internal/library/sync.go
+++ b/internal/library/sync.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/willfish/forte/internal/streaming"
-	"github.com/willfish/forte/internal/streaming/jellyfin"
-	"github.com/willfish/forte/internal/streaming/subsonic"
 )
 
 // artworkClient is used for fetching album artwork with a generous timeout.
@@ -35,7 +33,7 @@ func SyncAllServers(ctx context.Context, db *DB) error {
 
 // SyncServer syncs a single server's catalog into the local database.
 func SyncServer(ctx context.Context, db *DB, srv Server) error {
-	provider, err := newProvider(srv)
+	provider, err := NewServerProvider(srv)
 	if err != nil {
 		return err
 	}
@@ -268,17 +266,6 @@ func reconcile(ctx context.Context, db *DB, serverID string, seenAlbums map[stri
 // serverFilePath returns the synthetic file path for a server track.
 func serverFilePath(serverID, remoteID string) string {
 	return "server://" + serverID + "/" + remoteID
-}
-
-func newProvider(srv Server) (streaming.Provider, error) {
-	switch srv.Type {
-	case "subsonic":
-		return subsonic.New(srv.URL, srv.Username, srv.Password), nil
-	case "jellyfin":
-		return jellyfin.New(srv.URL, srv.Username, srv.Password), nil
-	default:
-		return nil, fmt.Errorf("unknown server type: %s", srv.Type)
-	}
 }
 
 func fetchArtwork(url string) ([]byte, error) {

--- a/internal/library/sync_test.go
+++ b/internal/library/sync_test.go
@@ -17,9 +17,9 @@ func TestServerFilePath(t *testing.T) {
 
 func TestNewProviderSubsonic(t *testing.T) {
 	srv := Server{ID: "1", Name: "Test", Type: "subsonic", URL: "http://localhost", Username: "u", Password: "p"}
-	p, err := newProvider(srv)
+	p, err := NewServerProvider(srv)
 	if err != nil {
-		t.Fatalf("newProvider subsonic: %v", err)
+		t.Fatalf("NewServerProvider subsonic: %v", err)
 	}
 	if p == nil {
 		t.Fatal("expected non-nil provider")
@@ -28,9 +28,9 @@ func TestNewProviderSubsonic(t *testing.T) {
 
 func TestNewProviderJellyfin(t *testing.T) {
 	srv := Server{ID: "1", Name: "Test", Type: "jellyfin", URL: "http://localhost", Username: "u", Password: "p"}
-	p, err := newProvider(srv)
+	p, err := NewServerProvider(srv)
 	if err != nil {
-		t.Fatalf("newProvider jellyfin: %v", err)
+		t.Fatalf("NewServerProvider jellyfin: %v", err)
 	}
 	if p == nil {
 		t.Fatal("expected non-nil provider")
@@ -39,7 +39,7 @@ func TestNewProviderJellyfin(t *testing.T) {
 
 func TestNewProviderUnknown(t *testing.T) {
 	srv := Server{ID: "1", Name: "Test", Type: "unknown", URL: "http://localhost"}
-	_, err := newProvider(srv)
+	_, err := NewServerProvider(srv)
 	if err == nil {
 		t.Error("expected error for unknown server type")
 	}

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -23,8 +23,6 @@ import (
 	"github.com/willfish/forte/internal/radio"
 	"github.com/willfish/forte/internal/scrobbling/lastfm"
 	"github.com/willfish/forte/internal/scrobbling/listenbrainz"
-	"github.com/willfish/forte/internal/streaming/jellyfin"
-	"github.com/willfish/forte/internal/streaming/subsonic"
 	"github.com/willfish/forte/internal/userconfig"
 )
 
@@ -582,14 +580,16 @@ func (s *LibraryService) GetServerStatuses() ([]ServerStatusJSON, error) {
 
 // TestConnection tests connectivity to a streaming server without persisting it.
 func (s *LibraryService) TestConnection(cfg ServerConfig) error {
-	switch cfg.Type {
-	case "subsonic":
-		return subsonic.New(cfg.URL, cfg.Username, cfg.Password).Ping()
-	case "jellyfin":
-		return jellyfin.New(cfg.URL, cfg.Username, cfg.Password).Ping()
-	default:
-		return fmt.Errorf("unknown server type: %s", cfg.Type)
+	provider, err := library.NewServerProvider(library.Server{
+		Type:     cfg.Type,
+		URL:      cfg.URL,
+		Username: cfg.Username,
+		Password: cfg.Password,
+	})
+	if err != nil {
+		return err
 	}
+	return provider.Ping()
 }
 
 // ScrobbleConfigJSON is the JSON-friendly scrobble config exposed to the frontend.


### PR DESCRIPTION
## Summary

- Add `library.NewServerProvider` as the single factory for streaming provider adapters.
- Switch sync, path resolution, health checks, and connection testing to use the shared factory.
- Add direct factory coverage for known and unknown provider types.

Closes #217

## Verification

- `nix develop .#full --command go test -tags nocgo ./...`
- Pre-push hooks inside `nix develop .#full`: `golangci-lint`, `gotest`, `nix build .#forte .#frontend`, `svelte-check`