### PR TITLE
refactor: deepen radio catalog coordination

### DIFF
--- a/internal/radio/catalog.go
+++ b/internal/radio/catalog.go
@@ -1,0 +1,273 @@
+package radio
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/willfish/forte/internal/library"
+)
+
+// StationView is the JSON-friendly station projection exposed to the frontend.
+type StationView struct {
+	UUID      string `json:"uuid"`
+	Name      string `json:"name"`
+	StreamURL string `json:"streamUrl"`
+	Homepage  string `json:"homepage"`
+	Favicon   string `json:"favicon"`
+	Country   string `json:"country"`
+	Tags      string `json:"tags"`
+	Bitrate   int    `json:"bitrate"`
+	Codec     string `json:"codec"`
+	Votes     int    `json:"votes"`
+	Clicks    int    `json:"clicks"`
+}
+
+// StationDirectory is the live station lookup interface backed by RadioBrowser.
+type StationDirectory interface {
+	Search(query string, limit int) ([]Station, error)
+	SearchFiltered(country, codec, tag string, limit int) ([]Station, error)
+	ByTag(tag string, limit int) ([]Station, error)
+	ByCountry(country string, limit int) ([]Station, error)
+	TopVoted(limit int) ([]Station, error)
+	TopClicked(limit int) ([]Station, error)
+	ByUUID(stationUUID string) ([]Station, error)
+}
+
+// SavedStationStore is the persisted station subset needed by Catalog.
+type SavedStationStore interface {
+	GetCustomRadioStations() ([]library.RadioCustomStation, error)
+	GetRadioFavourites() ([]library.RadioFavourite, error)
+	GetRadioHistory(limit int) ([]library.RadioHistoryEntry, error)
+}
+
+// CatalogConfig wires a radio catalog to live and persisted station sources.
+type CatalogConfig struct {
+	Directory      StationDirectory
+	SomaFMStations func() ([]Station, error)
+	SavedStations  SavedStationStore
+	ResolveArtwork func(favicon, homepage string) string
+}
+
+// Catalog coordinates live radio lookup, saved station fallback, and station projection.
+type Catalog struct {
+	directory      StationDirectory
+	somaFMStations func() ([]Station, error)
+	savedStations  SavedStationStore
+	resolveArtwork func(favicon, homepage string) string
+}
+
+// NewCatalog creates a radio catalog from configured station sources.
+func NewCatalog(config CatalogConfig) *Catalog {
+	resolveArtwork := config.ResolveArtwork
+	if resolveArtwork == nil {
+		resolveArtwork = func(favicon, _ string) string { return favicon }
+	}
+	return &Catalog{
+		directory:      config.Directory,
+		somaFMStations: config.SomaFMStations,
+		savedStations:  config.SavedStations,
+		resolveArtwork: resolveArtwork,
+	}
+}
+
+// LookupStation returns full station metadata by UUID. Live metadata wins over saved snapshots.
+func (c *Catalog) LookupStation(stationUUID string) (StationView, error) {
+	stationUUID = strings.TrimSpace(stationUUID)
+	if stationUUID == "" {
+		return StationView{}, fmt.Errorf("station uuid is required")
+	}
+
+	if c.directory != nil {
+		if stations, err := c.directory.ByUUID(stationUUID); err == nil && len(stations) > 0 {
+			return c.ProjectStations(stations)[0], nil
+		}
+	}
+
+	if strings.HasPrefix(stationUUID, "somafm-") && c.somaFMStations != nil {
+		stations, err := c.somaFMStations()
+		if err != nil {
+			return StationView{}, err
+		}
+		for _, station := range stations {
+			if station.UUID == stationUUID {
+				return c.ProjectStations([]Station{station})[0], nil
+			}
+		}
+	}
+
+	if c.savedStations != nil {
+		if station, ok, err := c.lookupSavedStation(stationUUID); err != nil {
+			return StationView{}, err
+		} else if ok {
+			return station, nil
+		}
+	}
+
+	return StationView{}, fmt.Errorf("station not found")
+}
+
+// Search returns projected stations matching a name query.
+func (c *Catalog) Search(query string, limit int) ([]StationView, error) {
+	stations, err := c.directory.Search(query, limit)
+	if err != nil {
+		return nil, err
+	}
+	return c.ProjectStations(stations), nil
+}
+
+// SearchFiltered returns projected stations matching optional filters.
+func (c *Catalog) SearchFiltered(country, codec, tag string, limit int) ([]StationView, error) {
+	stations, err := c.directory.SearchFiltered(country, codec, tag, limit)
+	if err != nil {
+		return nil, err
+	}
+	return c.ProjectStations(stations), nil
+}
+
+// ByTag returns projected stations for a tag.
+func (c *Catalog) ByTag(tag string, limit int) ([]StationView, error) {
+	stations, err := c.directory.ByTag(tag, limit)
+	if err != nil {
+		return nil, err
+	}
+	return c.ProjectStations(stations), nil
+}
+
+// ByCountry returns projected stations for a country.
+func (c *Catalog) ByCountry(country string, limit int) ([]StationView, error) {
+	stations, err := c.directory.ByCountry(country, limit)
+	if err != nil {
+		return nil, err
+	}
+	return c.ProjectStations(stations), nil
+}
+
+// TopVoted returns projected top-voted stations.
+func (c *Catalog) TopVoted(limit int) ([]StationView, error) {
+	stations, err := c.directory.TopVoted(limit)
+	if err != nil {
+		return nil, err
+	}
+	return c.ProjectStations(stations), nil
+}
+
+// TopClicked returns projected top-clicked stations.
+func (c *Catalog) TopClicked(limit int) ([]StationView, error) {
+	stations, err := c.directory.TopClicked(limit)
+	if err != nil {
+		return nil, err
+	}
+	return c.ProjectStations(stations), nil
+}
+
+// SomaFM returns projected SomaFM stations.
+func (c *Catalog) SomaFM() ([]StationView, error) {
+	stations, err := c.somaFMStations()
+	if err != nil {
+		return nil, err
+	}
+	return c.ProjectStations(stations), nil
+}
+
+// ProjectStations normalizes live station metadata for frontend use.
+func (c *Catalog) ProjectStations(stations []Station) []StationView {
+	result := make([]StationView, len(stations))
+	favicons := make([]string, len(stations))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 8)
+	for i, station := range stations {
+		i, station := i, station
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			favicons[i] = c.resolveArtwork(station.Favicon, station.Homepage)
+		}()
+	}
+	wg.Wait()
+	for i, station := range stations {
+		result[i] = StationView{
+			UUID:      station.UUID,
+			Name:      station.Name,
+			StreamURL: NormalizeStreamURL(station.StreamURL),
+			Homepage:  strings.TrimSpace(station.Homepage),
+			Favicon:   favicons[i],
+			Country:   station.Country,
+			Tags:      station.Tags,
+			Bitrate:   station.Bitrate,
+			Codec:     station.Codec,
+			Votes:     station.Votes,
+			Clicks:    station.Clicks,
+		}
+	}
+	return result
+}
+
+func (c *Catalog) lookupSavedStation(stationUUID string) (StationView, bool, error) {
+	custom, err := c.savedStations.GetCustomRadioStations()
+	if err != nil {
+		return StationView{}, false, err
+	}
+	for _, station := range custom {
+		if station.StationUUID == stationUUID {
+			return c.projectSavedStation(stationUUID, station.Name, station.StreamURL, station.FaviconURL, station.Homepage, station.Tags, station.Country, station.Bitrate, station.Codec), true, nil
+		}
+	}
+
+	favourites, err := c.savedStations.GetRadioFavourites()
+	if err != nil {
+		return StationView{}, false, err
+	}
+	for _, favourite := range favourites {
+		if favourite.StationUUID == stationUUID {
+			return c.projectSavedStation(favourite.StationUUID, favourite.Name, favourite.StreamURL, favourite.FaviconURL, favourite.Homepage, favourite.Tags, favourite.Country, favourite.Bitrate, favourite.Codec), true, nil
+		}
+	}
+
+	history, err := c.savedStations.GetRadioHistory(200)
+	if err != nil {
+		return StationView{}, false, err
+	}
+	for _, entry := range history {
+		if entry.StationUUID == stationUUID {
+			return c.projectSavedStation(entry.StationUUID, entry.Name, entry.StreamURL, entry.FaviconURL, entry.Homepage, entry.Tags, entry.Country, entry.Bitrate, entry.Codec), true, nil
+		}
+	}
+
+	return StationView{}, false, nil
+}
+
+func (c *Catalog) projectSavedStation(stationUUID, name, streamURL, faviconURL, homepage, tags, country string, bitrate int, codec string) StationView {
+	favicon := faviconURL
+	if favicon == "" && homepage != "" {
+		favicon = c.resolveArtwork("", homepage)
+	}
+	return StationView{
+		UUID:      stationUUID,
+		Name:      name,
+		StreamURL: NormalizeStreamURL(streamURL),
+		Homepage:  strings.TrimSpace(homepage),
+		Favicon:   favicon,
+		Country:   country,
+		Tags:      tags,
+		Bitrate:   bitrate,
+		Codec:     codec,
+	}
+}
+
+// NormalizeStreamURL applies known station stream URL migrations.
+func NormalizeStreamURL(streamURL string) string {
+	u, err := url.Parse(streamURL)
+	if err != nil {
+		return streamURL
+	}
+	switch strings.ToLower(u.Hostname()) {
+	case "timesradio.wireless.radio":
+		return "https://times.live.stream.broadcasting.news/stream"
+	default:
+		return streamURL
+	}
+}

--- a/internal/radio/catalog_test.go
+++ b/internal/radio/catalog_test.go
@@ -1,0 +1,209 @@
+package radio
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/willfish/forte/internal/library"
+)
+
+type fakeStationDirectory struct {
+	byUUID []Station
+	err    error
+}
+
+func (f fakeStationDirectory) Search(string, int) ([]Station, error) {
+	return nil, errors.New("unexpected search")
+}
+
+func (f fakeStationDirectory) SearchFiltered(string, string, string, int) ([]Station, error) {
+	return nil, errors.New("unexpected filtered search")
+}
+
+func (f fakeStationDirectory) ByTag(string, int) ([]Station, error) {
+	return nil, errors.New("unexpected tag search")
+}
+
+func (f fakeStationDirectory) ByCountry(string, int) ([]Station, error) {
+	return nil, errors.New("unexpected country search")
+}
+
+func (f fakeStationDirectory) TopVoted(int) ([]Station, error) {
+	return nil, errors.New("unexpected top voted")
+}
+
+func (f fakeStationDirectory) TopClicked(int) ([]Station, error) {
+	return nil, errors.New("unexpected top clicked")
+}
+
+func (f fakeStationDirectory) ByUUID(string) ([]Station, error) {
+	return f.byUUID, f.err
+}
+
+type fakeSavedStations struct {
+	custom     []library.RadioCustomStation
+	favourites []library.RadioFavourite
+	history    []library.RadioHistoryEntry
+}
+
+func (f fakeSavedStations) GetCustomRadioStations() ([]library.RadioCustomStation, error) {
+	return f.custom, nil
+}
+
+func (f fakeSavedStations) GetRadioFavourites() ([]library.RadioFavourite, error) {
+	return f.favourites, nil
+}
+
+func (f fakeSavedStations) GetRadioHistory(int) ([]library.RadioHistoryEntry, error) {
+	return f.history, nil
+}
+
+func TestCatalogLookupStationUsesLiveSourcesBeforeSavedFallbacks(t *testing.T) {
+	catalog := NewCatalog(CatalogConfig{
+		Directory: fakeStationDirectory{
+			byUUID: []Station{{
+				UUID:      "station-1",
+				Name:      "Live name",
+				StreamURL: "http://timesradio.wireless.radio/stream",
+				Homepage:  " https://live.example/radio ",
+				Favicon:   "https://live.example/icon.png",
+				Codec:     "MP3",
+			}},
+		},
+		SavedStations: fakeSavedStations{
+			favourites: []library.RadioFavourite{{
+				StationUUID: "station-1",
+				Name:        "Saved name",
+				StreamURL:   "https://saved.example/stream",
+				Codec:       "AAC",
+			}},
+		},
+		ResolveArtwork: func(favicon, homepage string) string {
+			if favicon == "" {
+				t.Fatalf("ResolveArtwork favicon = empty, homepage = %q", homepage)
+			}
+			return favicon
+		},
+	})
+
+	got, err := catalog.LookupStation(" station-1 ")
+	if err != nil {
+		t.Fatalf("LookupStation: %v", err)
+	}
+
+	if got.Name != "Live name" {
+		t.Fatalf("Name = %q, want live station", got.Name)
+	}
+	if got.StreamURL != "https://times.live.stream.broadcasting.news/stream" {
+		t.Fatalf("StreamURL = %q, want normalized Times Radio URL", got.StreamURL)
+	}
+	if got.Homepage != "https://live.example/radio" {
+		t.Fatalf("Homepage = %q, want trimmed homepage", got.Homepage)
+	}
+	if got.Codec != "MP3" {
+		t.Fatalf("Codec = %q, want live codec", got.Codec)
+	}
+}
+
+func TestCatalogLookupStationFallsBackThroughSavedStations(t *testing.T) {
+	tests := []struct {
+		name  string
+		store fakeSavedStations
+		uuid  string
+		want  string
+	}{
+		{
+			name: "custom first",
+			uuid: "saved-custom",
+			store: fakeSavedStations{
+				custom: []library.RadioCustomStation{{
+					StationUUID: "saved-custom",
+					Name:        "Custom station",
+					StreamURL:   "https://custom.example/stream",
+				}},
+			},
+			want: "Custom station",
+		},
+		{
+			name: "favourite second",
+			uuid: "saved-fav",
+			store: fakeSavedStations{
+				favourites: []library.RadioFavourite{{
+					StationUUID: "saved-fav",
+					Name:        "Favourite station",
+					StreamURL:   "https://fav.example/stream",
+				}},
+			},
+			want: "Favourite station",
+		},
+		{
+			name: "history third",
+			uuid: "saved-history",
+			store: fakeSavedStations{
+				history: []library.RadioHistoryEntry{{
+					StationUUID: "saved-history",
+					Name:        "History station",
+					StreamURL:   "https://history.example/stream",
+				}},
+			},
+			want: "History station",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			catalog := NewCatalog(CatalogConfig{
+				Directory:      fakeStationDirectory{},
+				SavedStations:  tt.store,
+				ResolveArtwork: func(favicon, homepage string) string { return favicon },
+			})
+
+			got, err := catalog.LookupStation(tt.uuid)
+			if err != nil {
+				t.Fatalf("LookupStation: %v", err)
+			}
+			if got.Name != tt.want {
+				t.Fatalf("Name = %q, want %q", got.Name, tt.want)
+			}
+		})
+	}
+}
+
+func TestCatalogLookupStationUsesSomaFMForSomaUUIDs(t *testing.T) {
+	catalog := NewCatalog(CatalogConfig{
+		Directory: fakeStationDirectory{},
+		SomaFMStations: func() ([]Station, error) {
+			return []Station{{
+				UUID:      "somafm-groovesalad",
+				Name:      "Groove Salad",
+				StreamURL: "https://somafm.example/groovesalad.mp3",
+				Homepage:  "https://somafm.com/groovesalad/",
+			}}, nil
+		},
+		ResolveArtwork: func(favicon, homepage string) string { return "resolved:" + homepage },
+	})
+
+	got, err := catalog.LookupStation("somafm-groovesalad")
+	if err != nil {
+		t.Fatalf("LookupStation: %v", err)
+	}
+
+	if got.Name != "Groove Salad" {
+		t.Fatalf("Name = %q, want SomaFM station", got.Name)
+	}
+	if got.Favicon != "resolved:https://somafm.com/groovesalad/" {
+		t.Fatalf("Favicon = %q, want resolved artwork", got.Favicon)
+	}
+}
+
+func TestCatalogLookupStationReportsMissingStations(t *testing.T) {
+	catalog := NewCatalog(CatalogConfig{
+		Directory:      fakeStationDirectory{},
+		SavedStations:  fakeSavedStations{},
+		ResolveArtwork: func(favicon, homepage string) string { return favicon },
+	})
+
+	if _, err := catalog.LookupStation("missing"); err == nil {
+		t.Fatal("expected missing station error")
+	}
+}

--- a/libraryservice.go
+++ b/libraryservice.go
@@ -987,19 +987,7 @@ func (s *LibraryService) GetArtistByName(name string) (int64, error) {
 }
 
 // RadioStationJSON is the JSON-friendly radio station type exposed to the frontend.
-type RadioStationJSON struct {
-	UUID      string `json:"uuid"`
-	Name      string `json:"name"`
-	StreamURL string `json:"streamUrl"`
-	Homepage  string `json:"homepage"`
-	Favicon   string `json:"favicon"`
-	Country   string `json:"country"`
-	Tags      string `json:"tags"`
-	Bitrate   int    `json:"bitrate"`
-	Codec     string `json:"codec"`
-	Votes     int    `json:"votes"`
-	Clicks    int    `json:"clicks"`
-}
+type RadioStationJSON = radio.StationView
 
 var somafmClient = radio.NewSomaFMClient()
 
@@ -1013,144 +1001,20 @@ func listSomaFMStations() ([]radio.Station, error) {
 	return somafmClient.Stations()
 }
 
-func stationsToJSON(stations []radio.Station) []RadioStationJSON {
-	result := make([]RadioStationJSON, len(stations))
-	favicons := resolveStationFavicons(stations)
-	for i, s := range stations {
-		result[i] = RadioStationJSON{
-			UUID:      s.UUID,
-			Name:      s.Name,
-			StreamURL: normalizeRadioStreamURL(s.StreamURL),
-			Homepage:  strings.TrimSpace(s.Homepage),
-			Favicon:   favicons[i],
-			Country:   s.Country,
-			Tags:      s.Tags,
-			Bitrate:   s.Bitrate,
-			Codec:     s.Codec,
-			Votes:     s.Votes,
-			Clicks:    s.Clicks,
-		}
-	}
-	return result
-}
-
-func resolveStationFavicons(stations []radio.Station) []string {
-	favicons := make([]string, len(stations))
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, 8)
-	for i, station := range stations {
-		i, station := i, station
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-			favicons[i] = resolveRadioArtwork(station.Favicon, station.Homepage)
-		}()
-	}
-	wg.Wait()
-	return favicons
-}
-
-func normalizeRadioStreamURL(streamURL string) string {
-	u, err := url.Parse(streamURL)
-	if err != nil {
-		return streamURL
-	}
-	switch strings.ToLower(u.Hostname()) {
-	case "timesradio.wireless.radio":
-		return "https://times.live.stream.broadcasting.news/stream"
-	default:
-		return streamURL
-	}
-}
-
 var radioClient = radio.NewClient()
+
+func (s *LibraryService) radioCatalog() *radio.Catalog {
+	return radio.NewCatalog(radio.CatalogConfig{
+		Directory:      radioClient,
+		SomaFMStations: listSomaFMStations,
+		SavedStations:  s.db,
+		ResolveArtwork: resolveRadioArtwork,
+	})
+}
 
 // GetRadioStationByUUID returns full station metadata, fetching from RadioBrowser when possible.
 func (s *LibraryService) GetRadioStationByUUID(stationUUID string) (RadioStationJSON, error) {
-	stationUUID = strings.TrimSpace(stationUUID)
-	if stationUUID == "" {
-		return RadioStationJSON{}, fmt.Errorf("station uuid is required")
-	}
-
-	if stations, err := radioClient.ByUUID(stationUUID); err == nil && len(stations) > 0 {
-		return stationsToJSON(stations)[0], nil
-	}
-
-	if strings.HasPrefix(stationUUID, "somafm-") {
-		stations, err := listSomaFMStations()
-		if err != nil {
-			return RadioStationJSON{}, err
-		}
-		for _, station := range stations {
-			if station.UUID == stationUUID {
-				return stationsToJSON([]radio.Station{station})[0], nil
-			}
-		}
-	}
-
-	if s.db != nil {
-		if station, ok, err := s.lookupSavedRadioStation(stationUUID); err != nil {
-			return RadioStationJSON{}, err
-		} else if ok {
-			return station, nil
-		}
-	}
-
-	return RadioStationJSON{}, fmt.Errorf("station not found")
-}
-
-func (s *LibraryService) lookupSavedRadioStation(stationUUID string) (RadioStationJSON, bool, error) {
-	custom, err := s.db.GetCustomRadioStations()
-	if err != nil {
-		return RadioStationJSON{}, false, err
-	}
-	for _, station := range custom {
-		if station.StationUUID == stationUUID {
-			return savedRadioStationJSON(stationUUID, station.Name, station.StreamURL, station.FaviconURL, station.Homepage, station.Tags, station.Country, station.Bitrate, station.Codec), true, nil
-		}
-	}
-
-	favs, err := s.db.GetRadioFavourites()
-	if err != nil {
-		return RadioStationJSON{}, false, err
-	}
-	for _, fav := range favs {
-		if fav.StationUUID == stationUUID {
-			return savedRadioStationJSON(fav.StationUUID, fav.Name, fav.StreamURL, fav.FaviconURL, fav.Homepage, fav.Tags, fav.Country, fav.Bitrate, fav.Codec), true, nil
-		}
-	}
-
-	history, err := s.db.GetRadioHistory(200)
-	if err != nil {
-		return RadioStationJSON{}, false, err
-	}
-	for _, entry := range history {
-		if entry.StationUUID == stationUUID {
-			return savedRadioStationJSON(entry.StationUUID, entry.Name, entry.StreamURL, entry.FaviconURL, entry.Homepage, entry.Tags, entry.Country, entry.Bitrate, entry.Codec), true, nil
-		}
-	}
-
-	return RadioStationJSON{}, false, nil
-}
-
-func savedRadioStationJSON(stationUUID, name, streamURL, faviconURL, homepage, tags, country string, bitrate int, codec string) RadioStationJSON {
-	favicon := faviconURL
-	if favicon == "" && homepage != "" {
-		favicon = resolveRadioArtwork("", homepage)
-	}
-	return RadioStationJSON{
-		UUID:      stationUUID,
-		Name:      name,
-		StreamURL: normalizeRadioStreamURL(streamURL),
-		Homepage:  strings.TrimSpace(homepage),
-		Favicon:   favicon,
-		Country:   country,
-		Tags:      tags,
-		Bitrate:   bitrate,
-		Codec:     codec,
-	}
+	return s.radioCatalog().LookupStation(stationUUID)
 }
 
 // OpenURL opens an http(s) URL in the system browser.
@@ -1169,65 +1033,37 @@ func (s *LibraryService) OpenURL(rawURL string) error {
 
 // SearchRadioStations searches for radio stations by name.
 func (s *LibraryService) SearchRadioStations(query string, limit int) ([]RadioStationJSON, error) {
-	stations, err := radioClient.Search(query, limit)
-	if err != nil {
-		return nil, err
-	}
-	return stationsToJSON(stations), nil
+	return s.radioCatalog().Search(query, limit)
 }
 
 // SearchRadioStationsFiltered searches with optional country, codec, and tag filters.
 func (s *LibraryService) SearchRadioStationsFiltered(country, codec, tag string, limit int) ([]RadioStationJSON, error) {
-	stations, err := radioClient.SearchFiltered(country, codec, tag, limit)
-	if err != nil {
-		return nil, err
-	}
-	return stationsToJSON(stations), nil
+	return s.radioCatalog().SearchFiltered(country, codec, tag, limit)
 }
 
 // GetRadioStationsByTag returns radio stations matching a tag.
 func (s *LibraryService) GetRadioStationsByTag(tag string, limit int) ([]RadioStationJSON, error) {
-	stations, err := radioClient.ByTag(tag, limit)
-	if err != nil {
-		return nil, err
-	}
-	return stationsToJSON(stations), nil
+	return s.radioCatalog().ByTag(tag, limit)
 }
 
 // GetRadioStationsByCountry returns radio stations matching a country.
 func (s *LibraryService) GetRadioStationsByCountry(country string, limit int) ([]RadioStationJSON, error) {
-	stations, err := radioClient.ByCountry(country, limit)
-	if err != nil {
-		return nil, err
-	}
-	return stationsToJSON(stations), nil
+	return s.radioCatalog().ByCountry(country, limit)
 }
 
 // GetTopVotedRadioStations returns the top voted radio stations.
 func (s *LibraryService) GetTopVotedRadioStations(limit int) ([]RadioStationJSON, error) {
-	stations, err := radioClient.TopVoted(limit)
-	if err != nil {
-		return nil, err
-	}
-	return stationsToJSON(stations), nil
+	return s.radioCatalog().TopVoted(limit)
 }
 
 // GetTopClickedRadioStations returns the most clicked radio stations.
 func (s *LibraryService) GetTopClickedRadioStations(limit int) ([]RadioStationJSON, error) {
-	stations, err := radioClient.TopClicked(limit)
-	if err != nil {
-		return nil, err
-	}
-	return stationsToJSON(stations), nil
+	return s.radioCatalog().TopClicked(limit)
 }
 
 // GetSomaFMStations returns all SomaFM channels.
 func (s *LibraryService) GetSomaFMStations() ([]RadioStationJSON, error) {
-	stations, err := listSomaFMStations()
-	if err != nil {
-		return nil, err
-	}
-	return stationsToJSON(stations), nil
+	return s.radioCatalog().SomaFM()
 }
 
 // RadioFavouriteJSON is the JSON-friendly radio favourite type exposed to the frontend.

--- a/libraryservice_test.go
+++ b/libraryservice_test.go
@@ -41,8 +41,11 @@ func mustExecService(t *testing.T, s *LibraryService, query string, args ...any)
 	}
 }
 
-func TestStationsToJSONNormalizesStaleTimesRadioURL(t *testing.T) {
-	stations := stationsToJSON([]radio.Station{
+func TestRadioCatalogNormalizesStaleTimesRadioURL(t *testing.T) {
+	catalog := radio.NewCatalog(radio.CatalogConfig{
+		ResolveArtwork: func(favicon, homepage string) string { return favicon },
+	})
+	stations := catalog.ProjectStations([]radio.Station{
 		{
 			UUID:      "times-radio-uk",
 			Name:      "Times Radio UK",


### PR DESCRIPTION
## Summary

- Add `internal/radio.Catalog` to own radio station lookup, saved-station fallback, projection, artwork resolution, and stream URL normalization.
- Keep `LibraryService` as the Wails adapter over the catalog while preserving the existing frontend-facing method names and JSON shape.
- Add focused catalog tests for live lookup priority, SomaFM lookup, saved custom/favourite/history fallback, missing stations, and Times Radio URL normalization.

Closes #215

## Verification

- Red test: `go test ./internal/radio -run TestCatalog` failed before `NewCatalog`/`CatalogConfig` existed.
- `go test ./internal/radio -run TestCatalog`
- `nix develop .#full --command go test -tags nocgo ./...`
- `nix develop .#full --command bash -lc 'golangci-lint run ./... && go test -tags nocgo ./... && nix build .#forte .#frontend'`
- `cd frontend && npm ci && npm run check`